### PR TITLE
[WIP] Accessibility

### DIFF
--- a/packages/core/src/bar-chart.ts
+++ b/packages/core/src/bar-chart.ts
@@ -106,7 +106,7 @@ export class BarChart extends BaseAxisChart {
 						.attr("fill", d => this.getFillScale()[d.datasetLabel](d.label))
 						.attr("stroke", d => this.options.accessibility ? this.colorScale[d.datasetLabel](d.label) : null)
 						.attr("stroke-width", Configuration.bars.default.strokeWidth)
-						.attr("stroke-opacity", d => this.options.accessibility ? 1 : 0)						
+						.attr("stroke-opacity", d => this.options.accessibility ? 1 : 0)
 						.attr("tabindex", 0);
 
 		// Hide the overlay

--- a/packages/core/src/bar-chart.ts
+++ b/packages/core/src/bar-chart.ts
@@ -106,7 +106,8 @@ export class BarChart extends BaseAxisChart {
 						.attr("fill", d => this.getFillScale()[d.datasetLabel](d.label))
 						.attr("stroke", d => this.options.accessibility ? this.colorScale[d.datasetLabel](d.label) : null)
 						.attr("stroke-width", Configuration.bars.default.strokeWidth)
-						.attr("stroke-opacity", d => this.options.accessibility ? 1 : 0);
+						.attr("stroke-opacity", d => this.options.accessibility ? 1 : 0)						
+						.attr("tabindex", 0);
 
 		// Hide the overlay
 		this.updateOverlay().hide();

--- a/packages/core/src/line-chart.ts
+++ b/packages/core/src/line-chart.ts
@@ -89,7 +89,8 @@ export class LineChart extends BaseAxisChart {
 				.attr("cx", d => this.x(d.label) + margins.left)
 				.attr("cy", d => this.y(d.value))
 				.attr("r", Configuration.charts.pointCircles.radius)
-				.attr("stroke", d => this.colorScale[d.datasetLabel](d.label));
+				.attr("stroke", d => this.colorScale[d.datasetLabel](d.label))
+				.attr("tabindex", 0);
 
 		// Hide the overlay
 		this.updateOverlay().hide();

--- a/packages/core/src/pie-chart.ts
+++ b/packages/core/src/pie-chart.ts
@@ -124,6 +124,7 @@ export class PieChart extends BaseChart {
 			.attr("stroke", d => this.colorScale[this.displayData.datasets[0].label](d.data.label))
 			.attr("stroke-width", Configuration.pie.default.strokeWidth)
 			.attr("stroke-opacity", d => this.options.accessibility ? 1 : 0)
+			.attr("tabindex", 0)
 			.each(function(d) { this._current = d; });
 
 		// Draw the slice labels


### PR DESCRIPTION
### Updates

- createSlider function called on initial draw, attempts to append a slider element to each chart's action bar (see TODO to see how I'm getting the action bar's name - not good)

- Since the only this.options.type is line, 3 sliders are created in the line chart's access bar (there should only be one for each chart), and no sliders created in other charts such as step-line charts

- The sliders look ugly but I'll fix that eventually
![screen shot 2018-11-16 at 1 43 12 pm](https://user-images.githubusercontent.com/12204023/48640799-b926bf00-e9a5-11e8-8fa1-da9e461ad6b7.png)


### Demo screenshot or recording

### Review checklist (for reviewers only)

- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/IBM/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
