### PR TITLE
fix(core demo): Fix experimental link issue

### DIFF
--- a/packages/core/demo/index.ts
+++ b/packages/core/demo/index.ts
@@ -32,7 +32,7 @@ if (location) {
 			// It's not necessary to process the location pathname
 			// Since we're using the location origin
 			// And since we don't use any other query params
-			location.href = `${location.origin}?experimental=${experimentalMode}`;
+			location.href = `${location.origin}${location.pathname}?experimental=${experimentalMode}`;
 		});
 	});
 } else {


### PR DESCRIPTION
Minor bugfix.

Essentially the URL the experimental switch redirects to is incorrect, and this fixes it by factoring in `location.pathname`.