### PR TITLE
fix(core): Fix interference of thresholds and bar chart elements

### DIFF
--- a/packages/core/src/bar-chart.ts
+++ b/packages/core/src/bar-chart.ts
@@ -250,7 +250,7 @@ export class BarChart extends BaseAxisChart {
 		const self = this;
 		const { accessibility } = this.options;
 
-		this.svg.selectAll("rect")
+		this.svg.selectAll("rect.bar")
 			.on("click", function(d) {
 				self.dispatchEvent("bar-onClick", d);
 			})

--- a/packages/core/src/base-axis-chart.ts
+++ b/packages/core/src/base-axis-chart.ts
@@ -469,7 +469,7 @@ export class BaseAxisChart extends BaseChart {
 		// Applies to thresholds being added
 		thresholdRects.enter()
 			.append("rect")
-			.classed("bar", true)
+			.classed("threshold-bar", true)
 			.attr("x", 0)
 			.attr("y", d => calculateYPosition(d))
 			.attr("width", width)


### PR DESCRIPTION
### Updates
- Rename class for threshold bars
- Only trigger showing of tooltip for `rect`s that have a class of `bar`

Closes #134 