### PR TITLE
feat(bar): bar chart should support a max bar width

### DIFF
--- a/packages/core/demo/demo-data/bar.ts
+++ b/packages/core/demo/demo-data/bar.ts
@@ -108,7 +108,9 @@ export const simpleBarOptions = {
 	},
 	legendClickable: true,
 	containerResizable: true,
-	maxWidth: 50
+	bars: {
+		maxWidth: 50
+	}
 };
 
 // Stacked bar

--- a/packages/core/demo/demo-data/bar.ts
+++ b/packages/core/demo/demo-data/bar.ts
@@ -107,7 +107,8 @@ export const simpleBarOptions = {
 		}
 	},
 	legendClickable: true,
-	containerResizable: true
+	containerResizable: true,
+	maxWidth: 50
 };
 
 // Stacked bar

--- a/packages/core/src/bar-chart.ts
+++ b/packages/core/src/bar-chart.ts
@@ -25,6 +25,31 @@ const getYMin = configs => {
 	return yMin;
 };
 
+// returns the configured max width or the calculated bandwidth
+// whichever is lower
+// defaults to the calculated bandwidth if no maxWidth is defined
+const getMaxBarWidth = (maxWidth, currentBandWidth) => {
+	if (!maxWidth) {
+		return currentBandWidth;
+	}
+	if (currentBandWidth <= maxWidth) {
+		return currentBandWidth;
+	}
+	return maxWidth;
+};
+
+// returns true if the calculated bandwidth is greater than the maxWidth (if deinfed)
+// i.e. if we should be constraining ourselves to a specific bar width
+const isWidthConstrained = (maxWidth, currentBandWidth) => {
+	if (!maxWidth) {
+		return false;
+	}
+	if (currentBandWidth <= maxWidth) {
+		return false;
+	}
+	return true;
+};
+
 export class BarChart extends BaseAxisChart {
 	x: any;
 	x1?: any;
@@ -51,7 +76,8 @@ export class BarChart extends BaseAxisChart {
 			const width = chartSize.width - margins.left - margins.right;
 
 			this.x1 = scaleBand().rangeRound([0, width]).padding(Configuration.bars.spacing.bars);
-			this.x1.domain(configs.data.datasets.map(dataset => dataset.label)).rangeRound([0, this.x.bandwidth()]);
+			this.x1.domain(configs.data.datasets.map(dataset => dataset.label))
+				.rangeRound([0, getMaxBarWidth(this.options.maxWidth, this.x.bandwidth())]);
 		}
 
 		this.options.type = "bar";
@@ -69,8 +95,21 @@ export class BarChart extends BaseAxisChart {
 			this.x.domain(this.displayData.labels);
 		}
 
-		this.x1 = scaleBand().rangeRound([0, width]).padding(Configuration.bars.spacing.bars);
-		this.x1.domain(this.displayData.datasets.map(dataset => dataset.label)).rangeRound([0, this.x.bandwidth()]);
+		if (!isWidthConstrained(this.options.maxWidth, this.x.bandwidth())) {
+			this.x1 = scaleBand().rangeRound([0, width]).padding(Configuration.bars.spacing.bars);
+		} else {
+			this.x1 = scaleBand().rangeRound([0, width]);
+		}
+		this.x1.domain(this.displayData.datasets.map(dataset => dataset.label))
+			.rangeRound([0, getMaxBarWidth(this.options.maxWidth, this.x.bandwidth())]);
+	}
+
+	getBarX(d) {
+		if (!isWidthConstrained(this.options.maxWidth, this.x.bandwidth())) {
+			return this.x1(d.datasetLabel);
+		}
+
+		return (this.x.bandwidth() / 2) - (this.options.maxWidth / 2);
 	}
 
 	draw() {
@@ -99,7 +138,7 @@ export class BarChart extends BaseAxisChart {
 					.enter()
 						.append("rect")
 						.classed("bar", true)
-						.attr("x", d => this.x1(d.datasetLabel))
+						.attr("x", this.getBarX.bind(this))
 						.attr("y", d => this.y(Math.max(0, d.value)))
 						.attr("width", this.x1.bandwidth())
 						.attr("height", d => Math.abs(this.y(d.value) - this.y(0)))
@@ -144,7 +183,7 @@ export class BarChart extends BaseAxisChart {
 			.enter()
 			.append("rect")
 			.attr("class", "bar")
-			.attr("x", d => this.x1(d.datasetLabel))
+			.attr("x", this.getBarX.bind(this))
 			.attr("y", d => this.y(Math.max(0, d.value)))
 			.attr("width", this.x1.bandwidth())
 			.attr("height", d => Math.abs(this.y(d.value) - this.y(0)))
@@ -160,7 +199,7 @@ export class BarChart extends BaseAxisChart {
 			.enter()
 			.append("rect")
 			.attr("class", "bar")
-			.attr("x", d => this.x1(d.datasetLabel))
+			.attr("x", this.getBarX.bind(this))
 			.attr("y", d => this.y(Math.max(0, d.value)))
 			.attr("width", this.x1.bandwidth())
 			.attr("height", d => Math.abs(this.y(d.value) - this.y(0)))
@@ -215,7 +254,7 @@ export class BarChart extends BaseAxisChart {
 			// TODO
 			// .ease(d3.easeCircle)
 			.style("opacity", 1)
-			.attr("x", d => this.x1(d.datasetLabel))
+			.attr("x", this.getBarX.bind(this))
 			.attr("y", d => this.y(Math.max(0, d.value)))
 			.attr("width", this.x1.bandwidth())
 			.attr("height", d => Math.abs(this.y(d.value) - this.y(0)))

--- a/packages/core/src/bar-chart.ts
+++ b/packages/core/src/bar-chart.ts
@@ -7,6 +7,8 @@ import { BaseAxisChart } from "./base-axis-chart";
 import { StackedBarChart } from "./stacked-bar-chart";
 import * as Configuration from "./configuration";
 
+import { Tools } from "./tools";
+
 const getYMin = configs => {
 	const { datasets } = configs.data;
 	const { scales } = configs.options;
@@ -77,7 +79,7 @@ export class BarChart extends BaseAxisChart {
 
 			this.x1 = scaleBand().rangeRound([0, width]).padding(Configuration.bars.spacing.bars);
 			this.x1.domain(configs.data.datasets.map(dataset => dataset.label))
-				.rangeRound([0, getMaxBarWidth(this.options.maxWidth, this.x.bandwidth())]);
+				.rangeRound([0, getMaxBarWidth(Tools.getProperty(this.options, "bars", "maxWidth"), this.x.bandwidth())]);
 		}
 
 		this.options.type = "bar";
@@ -103,15 +105,15 @@ export class BarChart extends BaseAxisChart {
 		}
 
 		this.x1.domain(this.displayData.datasets.map(dataset => dataset.label))
-			.rangeRound([0, getMaxBarWidth(this.options.maxWidth, this.x.bandwidth())]);
+			.rangeRound([0, getMaxBarWidth(Tools.getProperty(this.options, "bars", "maxWidth"), this.x.bandwidth())]);
 	}
 
 	getBarX(d) {
-		if (!isWidthConstrained(this.options.maxWidth, this.x.bandwidth())) {
+		if (!isWidthConstrained(Tools.getProperty(this.options, "bars", "maxWidth"), this.x.bandwidth())) {
 			return this.x1(d.datasetLabel);
 		}
 
-		return (this.x.bandwidth() / 2) - (this.options.maxWidth / 2);
+		return (this.x.bandwidth() / 2) - (Tools.getProperty(this.options, "bars", "maxWidth") / 2);
 	}
 
 	draw() {

--- a/packages/core/src/bar-chart.ts
+++ b/packages/core/src/bar-chart.ts
@@ -95,11 +95,13 @@ export class BarChart extends BaseAxisChart {
 			this.x.domain(this.displayData.labels);
 		}
 
-		if (!isWidthConstrained(this.options.maxWidth, this.x.bandwidth())) {
+		// if it's a grouped bar, use additoinal padding so the bars don't group up
+		if (this.displayData.datasets.length > 1) {
 			this.x1 = scaleBand().rangeRound([0, width]).padding(Configuration.bars.spacing.bars);
 		} else {
 			this.x1 = scaleBand().rangeRound([0, width]);
 		}
+
 		this.x1.domain(this.displayData.datasets.map(dataset => dataset.label))
 			.rangeRound([0, getMaxBarWidth(this.options.maxWidth, this.x.bandwidth())]);
 	}

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -167,7 +167,9 @@ export const bars = {
 		bars: 0.2,
 		datasets: 0.25
 	},
-	maxWidth: -1
+	bars: {
+		maxWidth: null
+	}
 };
 
 export const lines = {

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -166,7 +166,8 @@ export const bars = {
 	spacing: {
 		bars: 0.2,
 		datasets: 0.25
-	}
+	},
+	maxWidth: -1
 };
 
 export const lines = {

--- a/packages/core/src/stacked-bar-chart.ts
+++ b/packages/core/src/stacked-bar-chart.ts
@@ -68,6 +68,9 @@ export class StackedBarChart extends BaseAxisChart {
 		return stackDataArray;
 	}
 
+	// currently unused, but required to match the BarChart class
+	getBarX(d) {}
+
 	draw() {
 		this.innerWrap.style("width", "100%")
 			.style("height", "100%");

--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -210,4 +210,16 @@ export namespace Tools {
 
 		return transformMatrixArray[4];
 	}
+
+	export const getProperty = (object, ...propPath) => {
+		let position = object;
+		for (const prop of propPath) {
+			if (position[prop]) {
+				position = position[prop];
+			} else {
+				return null;
+			}
+		}
+		return position;
+	};
 }


### PR DESCRIPTION
closes #139 
closes #140 

Right now it's just applied to normal bars, but the process should be the same for stacked bars.

Grouped bars will be a bit of a different beast - I'm not sure this entirely applies to them anyway.