### PR TITLE
fix(core): Enforce text alignment of legend popup in the styles

### DIFF
--- a/packages/core/src/style.scss
+++ b/packages/core/src/style.scss
@@ -192,6 +192,7 @@ div.chart-holder {
 			right: 10px;
 		}
 		.legend-tooltip-content {
+			text-align: left;
 			padding: 0 7px 15px 7px;
 		}
 	}


### PR DESCRIPTION
Currently `text-align` isn't enforced in the CSS for the legend popup, and in cases where your container does `text-align: center` you'll see this:
![image](https://user-images.githubusercontent.com/14989804/53605640-2392f200-3b86-11e9-8377-836f79ec1dd7.png)

Closes #168