### PR TITLE
fix(core): export patterns as strings of svgs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ node_js:
 before_install: .travis/before_install.sh
 install:
   - npm install
-after_success: "npm run build-all"
 script: lerna run lint
 sudo: false
 deploy:

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
 		"contributors:add": "all-contributors add",
 		"contributors:generate": "all-contributors generate",
 		"build-all": "bash scripts/build-packages-and-demos.sh",
-		"build-all-demos": "bash scripts/build-demos.sh"
+		"build-all-demos": "bash scripts/build-demos.sh",
+		"deploy": "bash scripts/deploy.sh"
 	},
 	"husky": {
 		"hooks": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,8 @@
   "author": "IBM",
   "license": "Apache-2.0",
   "dependencies": {
-    "resize-observer-polyfill": "1.5.0"
+	"resize-observer-polyfill": "1.5.0",
+	"d3": "4.13.0"
   },
   "peerDependencies": {
     "d3": ">=4.11.0 <=5.7.0"

--- a/packages/core/src/assets/patterns/index.ts
+++ b/packages/core/src/assets/patterns/index.ts
@@ -1,14 +1,14 @@
-const PATTERN_1 = require("./pattern-1.svg");
-const PATTERN_2 = require("./pattern-2.svg");
-const PATTERN_3 = require("./pattern-3.svg");
-const PATTERN_4 = require("./pattern-4.svg");
-const PATTERN_5 = require("./pattern-5.svg");
-const PATTERN_6 = require("./pattern-6.svg");
-const PATTERN_7 = require("./pattern-7.svg");
-const PATTERN_8 = require("./pattern-8.svg");
-const PATTERN_9 = require("./pattern-9.svg");
-const PATTERN_10 = require("./pattern-10.svg");
-const PATTERN_11 = require("./pattern-11.svg");
+const PATTERN_1 = require("./pattern-1.ts");
+const PATTERN_2 = require("./pattern-2.ts");
+const PATTERN_3 = require("./pattern-3.ts");
+const PATTERN_4 = require("./pattern-4.ts");
+const PATTERN_5 = require("./pattern-5.ts");
+const PATTERN_6 = require("./pattern-6.ts");
+const PATTERN_7 = require("./pattern-7.ts");
+const PATTERN_8 = require("./pattern-8.ts");
+const PATTERN_9 = require("./pattern-9.ts");
+const PATTERN_10 = require("./pattern-10.ts");
+const PATTERN_11 = require("./pattern-11.ts");
 
 export default [
 	PATTERN_1,

--- a/packages/core/src/assets/patterns/pattern-1.ts
+++ b/packages/core/src/assets/patterns/pattern-1.ts
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+export default `<?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 100 100" style="enable-background:new 0 0 100 100;" xml:space="preserve">
@@ -7,7 +7,8 @@
 	.st1{fill:#231F20;}
 	.st2{fill:url(#lines_-_right_to_left);}
 </style>
-<pattern  width="50" height="50" patternUnits="userSpaceOnUse" id="lines_-_right_to_left" viewBox="97.78 -148.535 50 50" style="overflow:visible;">
+<pattern  width="50" height="50"
+patternUnits="userSpaceOnUse" id="lines_-_right_to_left" viewBox="97.78 -148.535 50 50" style="overflow:visible;">
 	<g id="XMLID_16_">
 		<polygon id="XMLID_26_" class="st0" points="97.78,-148.535 147.78,-148.535 147.78,-98.535 97.78,-98.535 		"/>
 		<polygon id="XMLID_25_" class="st1" points="110.606,0 100,-10.607 214.117,-124.724 224.723,-114.117 		"/>
@@ -22,4 +23,4 @@
 	</g>
 </pattern>
 <rect id="XMLID_1_" class="st2" width="100" height="100"/>
-</svg>
+</svg>`;

--- a/packages/core/src/assets/patterns/pattern-10.ts
+++ b/packages/core/src/assets/patterns/pattern-10.ts
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+export default `<?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 100 100" style="enable-background:new 0 0 100 100;" xml:space="preserve">
@@ -20,4 +20,4 @@
 	</g>
 </pattern>
 <rect id="XMLID_1_" class="st2" width="100" height="100"/>
-</svg>
+</svg>`;

--- a/packages/core/src/assets/patterns/pattern-11.ts
+++ b/packages/core/src/assets/patterns/pattern-11.ts
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+export default `<?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 100 100" style="enable-background:new 0 0 100 100;" xml:space="preserve">
@@ -18,4 +18,4 @@
 	</g>
 </pattern>
 <rect id="XMLID_1_" class="st2" width="100" height="100"/>
-</svg>
+</svg>`;

--- a/packages/core/src/assets/patterns/pattern-2.ts
+++ b/packages/core/src/assets/patterns/pattern-2.ts
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+export default `<?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 100 100" style="enable-background:new 0 0 100 100;" xml:space="preserve">
@@ -20,4 +20,4 @@
 	</g>
 </pattern>
 <rect id="XMLID_1_" class="st2" width="100" height="100"/>
-</svg>
+</svg>`;

--- a/packages/core/src/assets/patterns/pattern-3.ts
+++ b/packages/core/src/assets/patterns/pattern-3.ts
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+export default `<?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 100 100" style="enable-background:new 0 0 100 100;" xml:space="preserve">
@@ -14,4 +14,4 @@
 	</g>
 </pattern>
 <rect id="XMLID_1_" class="st2" width="100" height="100"/>
-</svg>
+</svg>`;

--- a/packages/core/src/assets/patterns/pattern-4.ts
+++ b/packages/core/src/assets/patterns/pattern-4.ts
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+export default `<?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 100 100" style="enable-background:new 0 0 100 100;" xml:space="preserve">
@@ -20,4 +20,4 @@
 	</g>
 </pattern>
 <rect id="XMLID_1_" class="st2" width="100" height="100"/>
-</svg>
+</svg>`;

--- a/packages/core/src/assets/patterns/pattern-5.ts
+++ b/packages/core/src/assets/patterns/pattern-5.ts
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+export default `<?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 100 100" style="enable-background:new 0 0 100 100;" xml:space="preserve">
@@ -26,4 +26,4 @@
 	</g>
 </pattern>
 <rect id="XMLID_1_" class="st1" width="100" height="100"/>
-</svg>
+</svg>`;

--- a/packages/core/src/assets/patterns/pattern-6.ts
+++ b/packages/core/src/assets/patterns/pattern-6.ts
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+export default `<?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 100 100" style="enable-background:new 0 0 100 100;" xml:space="preserve">
@@ -20,4 +20,4 @@
 	</g>
 </pattern>
 <rect id="XMLID_1_" class="st2" width="100" height="100"/>
-</svg>
+</svg>`;

--- a/packages/core/src/assets/patterns/pattern-7.ts
+++ b/packages/core/src/assets/patterns/pattern-7.ts
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+export default `<?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 100 100" style="enable-background:new 0 0 100 100;" xml:space="preserve">
@@ -7,7 +7,8 @@
 	.st1{fill:#231F20;}
 	.st2{fill:url(#lines_-_left_to_right);}
 </style>
-<pattern  width="50" height="50" patternUnits="userSpaceOnUse" id="lines_-_left_to_right" viewBox="101.277 -147.008 50 50" style="overflow:visible;">
+<pattern  width="50" height="50"
+patternUnits="userSpaceOnUse" id="lines_-_left_to_right" viewBox="101.277 -147.008 50 50" style="overflow:visible;">
 	<g id="XMLID_8_">
 		<polygon id="XMLID_32_" class="st0" points="101.277,-147.008 151.277,-147.008 151.277,-97.008 101.277,-97.008 		"/>
 		<polygon id="XMLID_31_" class="st1" points="264.058,0 150,-114.058 160.606,-124.665 274.665,-10.607 		"/>
@@ -25,4 +26,4 @@
 	</g>
 </pattern>
 <rect id="XMLID_1_" class="st2" width="100" height="100"/>
-</svg>
+</svg>`;

--- a/packages/core/src/assets/patterns/pattern-8.ts
+++ b/packages/core/src/assets/patterns/pattern-8.ts
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+export default `<?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 100 100" style="enable-background:new 0 0 100 100;" xml:space="preserve">
@@ -7,7 +7,8 @@
 	.st1{fill:#231F20;}
 	.st2{fill:url(#hex_pattern);}
 </style>
-<pattern  width="100" height="100" patternUnits="userSpaceOnUse" id="hex_pattern" viewBox="20 -117.32 100 100" style="overflow:visible;">
+<pattern  width="100" height="100"
+patternUnits="userSpaceOnUse" id="hex_pattern" viewBox="20 -117.32 100 100" style="overflow:visible;">
 	<g id="XMLID_10_">
 		<polygon id="XMLID_23_" class="st0" points="20,-117.32 120,-117.32 120,-17.32 20,-17.32 		"/>
 		<polygon id="XMLID_21_" class="st1" points="110,-25 100,-42.32 110,-59.641 130,-59.641 140,-42.32 130,-25 		"/>
@@ -20,4 +21,4 @@
 	</g>
 </pattern>
 <rect id="XMLID_1_" class="st2" width="100" height="100"/>
-</svg>
+</svg>`;

--- a/packages/core/src/assets/patterns/pattern-9.ts
+++ b/packages/core/src/assets/patterns/pattern-9.ts
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+export default `<?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 100 100" style="enable-background:new 0 0 100 100;" xml:space="preserve">
@@ -41,4 +41,4 @@
 	</g>
 </pattern>
 <rect id="XMLID_1_" class="st2" width="100" height="100"/>
-</svg>
+</svg>`;

--- a/packages/core/src/services/patterns.ts
+++ b/packages/core/src/services/patterns.ts
@@ -10,7 +10,6 @@ const selectors = {
 
 // Helper functions
 const trimSVG = (htmlString: string) => {
-	console.log(htmlString);
 	// Remove the CSS style block
 	const htmlBeforeStyleBlock = htmlString.substring(0, htmlString.indexOf("<style type=\"text/css\">"));
 	const htmlAfterStyleBlock = htmlString.substring(htmlString.indexOf("</style>") + "</style>".length);

--- a/packages/core/src/services/patterns.ts
+++ b/packages/core/src/services/patterns.ts
@@ -10,6 +10,7 @@ const selectors = {
 
 // Helper functions
 const trimSVG = (htmlString: string) => {
+	console.log(htmlString);
 	// Remove the CSS style block
 	const htmlBeforeStyleBlock = htmlString.substring(0, htmlString.indexOf("<style type=\"text/css\">"));
 	const htmlAfterStyleBlock = htmlString.substring(htmlString.indexOf("</style>") + "</style>".length);
@@ -67,7 +68,7 @@ export default class PatternsService {
 				const id = ++this.idAccum;
 
 				if (!datasetPattern || legendType === Configuration.legend.basedOn.LABELS) {
-					datasetPattern = PATTERN_SVGS[this.patternAccum++];
+					datasetPattern = PATTERN_SVGS[this.patternAccum++].default;
 				}
 
 				// Create SVG container div

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -35,6 +35,9 @@
     "prettier": "1.16.4",
     "vue-template-compiler": "2.5.21"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "lint-staged": {
     "*.{scss,css,js,md,vue}": [
       "yarn format",


### PR DESCRIPTION
- export patterns as strings in ts files (simplifies distribution, potentially simplifies adding patterns in the future)
- add d3@4 as a hard dep
- remove `after_success` from travis.yml ... it's not needed at this point