### PR TITLE
Fix Vue wrapper packaging issue

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -2,7 +2,7 @@
   "name": "@carbon/charts-vue",
   "version": "0.11.10",
   "description": "Carbon charting components for Vue",
-  "main": "index.js",
+  "main": "dist/charts-vue.umd.min.js",
   "scripts": {
     "build": "bash build.sh",
     "lint": "vue-cli-service lint ./src/index.js",
@@ -38,6 +38,10 @@
   "publishConfig": {
     "access": "public"
   },
+  "files": [
+    "/dist",
+    "/src"
+  ],
   "lint-staged": {
     "*.{scss,css,js,md,vue}": [
       "yarn format",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -2,7 +2,7 @@
   "name": "@carbon/charts-vue",
   "version": "0.11.10",
   "description": "Carbon charting components for Vue",
-  "main": "dist/charts-vue.umd.min.js",
+  "main": "charts-vue.umd.min.js",
   "scripts": {
     "build": "bash build.sh",
     "lint": "vue-cli-service lint ./src/index.js",
@@ -38,10 +38,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "files": [
-    "/dist",
-    "/src"
-  ],
   "lint-staged": {
     "*.{scss,css,js,md,vue}": [
       "yarn format",

--- a/packages/vue/src/index.js
+++ b/packages/vue/src/index.js
@@ -1,17 +1,22 @@
-const ctx = require.context(
-	'./',
-	true,
-	/^(?!.*(?:\/_|-story\.vue|-test\.vue)).*\.vue$/
-);
-const components = ctx.keys().map(ctx);
+import CcvBarChart from './ccv-bar-chart.vue';
+import CcvDonutChart from './ccv-donut-chart.vue';
+import CcvLineChart from './ccv-line-chart.vue';
+import CcvPieChart from './ccv-pie-chart.vue';
 
+const components = [CcvBarChart, CcvDonutChart, CcvLineChart, CcvPieChart];
+
+/*
+  Allows the module to be used as a Vue plug-in, and has an install()
+  method (which is called when the plug-in loads) that registers all the
+  components.
+*/
 export default {
 	// options is an array of components to be registered
 	// e.g. ['c-button', 'c-modal']
 	install(Vue, options) {
 		if (typeof options === 'undefined') {
 			for (let c of components) {
-				Vue.component(c.default.name, c.default);
+				Vue.component(c.name, c);
 			}
 		} else {
 			if (!(options instanceof Array)) {
@@ -20,10 +25,16 @@ export default {
 
 			for (let c of components) {
 				// register only components specified in the options
-				if (options.includes(c.default.name)) {
-					Vue.component(c.default.name, c.default);
+				if (options.includes(c.name)) {
+					Vue.component(c.name, c);
 				}
 			}
 		}
 	},
 };
+
+/*
+  Allows import of individual components from the module, as an
+  alternative to loading them all via a Vue plug-in.
+*/
+export { CcvBarChart, CcvDonutChart, CcvLineChart, CcvPieChart };


### PR DESCRIPTION
### Fixes #231 
- Set `main` for package correctly
- Export \src and \dist to package, so that individual components can be imported by clients (like the React wrappers do).

Note: the vue-cli library build generates and extraneous dist/demo.html that does not work. There is an issue for this here: https://github.com/vuejs/vue-cli/issues/3291 

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/IBM/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
