### PR TITLE
remove  titles from the demo

### DIFF
--- a/packages/core/demo/demo-data/bar.ts
+++ b/packages/core/demo/demo-data/bar.ts
@@ -74,7 +74,6 @@ export const groupedBarOptions = {
 	},
 	legendClickable: true,
 	containerResizable: true,
-	title: "Bar Chart",
 	theme: getTheme()
 };
 
@@ -115,7 +114,6 @@ export const simpleBarOptions = {
 	bars: {
 		maxWidth: 50
 	},
-	title: "Simple Bar Chart"
 };
 
 // Stacked bar
@@ -187,6 +185,5 @@ export const stackedBarOptions = {
 	},
 	legendClickable: true,
 	containerResizable: true,
-	title: "Stacked Bar Chart",
 	theme: getTheme()
 };

--- a/packages/core/demo/demo-data/combo.ts
+++ b/packages/core/demo/demo-data/combo.ts
@@ -73,6 +73,5 @@ export const comboOptions = {
 	},
 	legendClickable: true,
 	containerResizable: true,
-	title: "Combo Chart",
 	theme: getTheme()
 };

--- a/packages/core/demo/demo-data/line.ts
+++ b/packages/core/demo/demo-data/line.ts
@@ -64,7 +64,6 @@ export const curvedLineOptions = {
 	},
 	legendClickable: true,
 	containerResizable: true,
-	title: "Line Chart",
 	theme: getTheme()
 };
 
@@ -137,7 +136,6 @@ export const lineOptions = {
 	},
 	legendClickable: true,
 	containerResizable: true,
-	title: "Line Chart",
 	theme: getTheme()
 };
 

--- a/packages/core/demo/demo-data/pie-donut.ts
+++ b/packages/core/demo/demo-data/pie-donut.ts
@@ -6,7 +6,6 @@ export const pieOptions = {
 	legendClickable: true,
 	containerResizable: true,
 	colors,
-	title: "Pie Chart",
 	theme: getTheme()
 };
 
@@ -20,7 +19,6 @@ export const donutOptions = {
 		label: "Products",
 		number: 300000
 	},
-	title: "Donut Chart"
 };
 
 export const pieData = {


### PR DESCRIPTION
### Updates
- remove demo titles until refactor layout
- titles can be used on charts if the chart is a big enough size that it looks good, otherwise chart title can be separate to the chart (until refactor) 
