### PR TITLE
[React] Fix componentDidUpdate to use current props.

### DIFF
--- a/packages/react/src/base-chart.js
+++ b/packages/react/src/base-chart.js
@@ -25,6 +25,6 @@ export default class BaseChart extends React.Component {
 	}
 
 	componentDidUpdate() {
-		this.chart.setData(this.props);
+		this.chart.setData(this.props.data);
 	}
 }

--- a/packages/react/src/base-chart.js
+++ b/packages/react/src/base-chart.js
@@ -24,9 +24,7 @@ export default class BaseChart extends React.Component {
 		Object.assign(this, this.chart);
 	}
 
-	componentDidUpdate(newProps) {
-		const { data } = newProps;
-
-		this.chart.setData(data);
+	componentDidUpdate() {
+		this.chart.setData(this.props);
 	}
 }


### PR DESCRIPTION
### Updates
- Fixes componentDidUpdate method in base chart to use current props instead of previous props. https://reactjs.org/docs/react-component.html#componentdidupdate

### Demo screenshot or recording

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/IBM/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
