### PR TITLE
refactor(core): update the data handling 

### DIFF
--- a/packages/core/src/components/graphs/bar-grouped.ts
+++ b/packages/core/src/components/graphs/bar-grouped.ts
@@ -111,7 +111,7 @@ export class GroupedBar extends Bar {
 		return datasets.map(dataset => ({
 			label: d,
 			datasetLabel: dataset.label,
-			value: dataset.data[index]
+			value: dataset.data[index].value ? dataset.data[index].value : dataset.data[index]
 		}));
 	}
 

--- a/packages/core/src/components/graphs/pie.ts
+++ b/packages/core/src/components/graphs/pie.ts
@@ -43,7 +43,7 @@ export class Pie extends Component {
 		const dataset = displayData.datasets[0];
 		return dataset.data.map((datum, i) => ({
 			label: displayData.labels[i],
-			value: datum
+			value: datum.value ? datum.value : datum
 		}));
 	}
 


### PR DESCRIPTION
Updated grouped bar and donut/pie to handle objects passed in as data instead of just an array of data as numbers. This helps the data layer to be more universal across the different charts

before it had to **only** be of the type : 

```
data: [
		32432,
		21312,
		56456,
		21312,
		34234
	]
```

but now it can handle this as well: 
			
```
data: [
		{
			date: new Date(2019, 0, 1),
			value: 65000,
		},
		{
			date: new Date(2019, 0, 2),
			value: 29123
		},
		{
			date: new Date(2019, 0, 3),
			value: 35213
		}
	]

```
