### PR TITLE
style(core): line chart node styles

### DIFF
--- a/packages/core/src/styles/graphs/_line.scss
+++ b/packages/core/src/styles/graphs/_line.scss
@@ -1,5 +1,5 @@
 .#{$prefix}--#{$charts-prefix}--line path.line {
 	pointer-events: none;
 	fill: none;
-	stroke-width: 1.75;
+	stroke-width: 1.5;
 }

--- a/packages/core/src/styles/graphs/_scatter.scss
+++ b/packages/core/src/styles/graphs/_scatter.scss
@@ -9,6 +9,7 @@ g.#{$prefix}--#{$charts-prefix}--scatter {
 
 	circle.dot.unfilled {
 		fill: $ui-01;
+		stroke-width: 1.5;
 	}
 
 	g.lines path.line {


### PR DESCRIPTION
Closes #433

### Updates
change the line weights to be 1.5 and node outlines to match.

### Demo screenshot or recording
![image](https://user-images.githubusercontent.com/14351335/70929651-8cf2cd00-2001-11ea-8881-185f37b74fde.png)

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/IBM/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
