### PR TITLE
fix(core): update tooltip value formatter

### DIFF
--- a/packages/core/src/interfaces/components.ts
+++ b/packages/core/src/interfaces/components.ts
@@ -52,7 +52,7 @@ export interface TooltipOptions {
 	/**
 	 * a function to format the tooltip values
 	 */
-	formatter?: Function;
+	valueFormatter?: Function;
 	/**
 	 * custom function for returning tooltip HTML
 	 * passed an array or object with the data, and then the default tooltip markup


### PR DESCRIPTION
Tooltip interface was updated to reflect the naming change within tooltip (tooltip looks for a
valueFormatter, instead of formatter). Name was updated to be more clear with the addition of
supporting completely custom tooltips as well as allowing users to intercept and modify just the
value (appending %, $, localizing, etc).

### Updates
- fixed a missed occurance of the name change for the tooltip valueFormatter

### Demo screenshot or recording
the demo code for testing/using a value formatter:
```
export const lineTimeSeriesOptions = {
	title: "Line (time series)",
	axes: {
		left: {
			secondary: true
		},
		bottom: {
			scaleType: "time",
			primary: true
		}
	},
	curve: "curveMonotoneX",
	tooltip: {
		valueFormatter: (d) => { return `${d}%`;}
	}
};
```
![image](https://user-images.githubusercontent.com/14351335/70930522-63d33c00-2003-11ea-805d-caae25b0f9b7.png)

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/IBM/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
