### PR TITLE
style(core): restyle chart backdrop colors (theming)

### DIFF
--- a/packages/core/src/styles/components/_grid.scss
+++ b/packages/core/src/styles/components/_grid.scss
@@ -1,11 +1,11 @@
 .#{$prefix}--#{$charts-prefix}--grid {
 	rect.chart-grid-backdrop {
-		@if $carbon--theme == $carbon--theme--g90 {
-			fill: $carbon--gray-100;
-		} @else if $carbon--theme == $carbon--theme--g100 {
-			fill: $carbon--black-100;
-		} @else {
+		@if $carbon--theme == $carbon--theme--g10 {
 			fill: $ui-01;
+		} @else if $carbon--theme == $carbon--theme--g90 {
+			fill: $carbon--gray-100;
+		} @else {
+			fill: $ui-background;
 		}
 	}
 


### PR DESCRIPTION
Closes #432

### Updates
- updated white/g10 to use same color as backdrop (white)
- updated the color used on g100 backdrops to being gray100 (same as g90)

### Demo screenshot or recording

#### g100 theme
![image](https://user-images.githubusercontent.com/14351335/70937192-e4009e00-2011-11ea-9254-fdc98c21d221.png)

#### white theme
![image](https://user-images.githubusercontent.com/14351335/70937226-ee229c80-2011-11ea-9359-d1bd2fa8fb66.png)


### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/IBM/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
