### PR TITLE
style(core): outline the chart grid with a border

### DIFF
--- a/packages/core/src/styles/components/_grid.scss
+++ b/packages/core/src/styles/components/_grid.scss
@@ -7,6 +7,7 @@
 		} @else {
 			fill: $ui-background;
 		}
+		stroke: $ui-03;
 	}
 
 	g.x.grid g.tick,


### PR DESCRIPTION
### Updates
- added a border to the backdrop 
- the active axis lines are still on with a darker stroke that the gridlines and border

### Demo screenshot or recording
![image](https://user-images.githubusercontent.com/14351335/71010819-5fb62580-20ba-11ea-8048-71fd5b79e72f.png)

![image](https://user-images.githubusercontent.com/14351335/71010835-680e6080-20ba-11ea-8fd4-ca595260b7bf.png)

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/IBM/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
