### PR TITLE
Scatter transition upward

### DIFF
--- a/packages/core/src/components/graphs/scatter.ts
+++ b/packages/core/src/components/graphs/scatter.ts
@@ -58,6 +58,7 @@ export class Scatter extends Component {
 			.classed("filled", filled)
 			.classed("unfilled", !filled)
 			.attr("cx", (d, i) => this.services.cartesianScales.getDomainValue(d, i))
+			.attr("cy", 311)
 			.transition(this.services.transitions.getTransition("scatter-update-enter", animate))
 			.attr("cy", (d, i) => this.services.cartesianScales.getRangeValue(d, i))
 			.attr("r", options.points.radius)


### PR DESCRIPTION
Solve #431: 
- [x] Scatter & bubble: animate the nodes starting from the x-axis and transitioning upward, instead of top-down.