### PR TITLE
optional domain setting

### DIFF
--- a/packages/core/demo/demo-data/bar.ts
+++ b/packages/core/demo/demo-data/bar.ts
@@ -106,6 +106,20 @@ export const simpleBarOptions = {
 	}
 };
 
+export const simpleBarFixedDomainOptions = {
+	title: "Simple bar (fixed domain)",
+	axes: {
+		left: {
+			primary: true,
+			domain: [-100000, 100000]
+		},
+		bottom: {
+			scaleType: "labels",
+			secondary: true
+		}
+	}
+};
+
 // Horizontal Simple
 export const simpleHorizontalBarData = simpleBarData;
 

--- a/packages/core/demo/demo-data/index.ts
+++ b/packages/core/demo/demo-data/index.ts
@@ -79,6 +79,11 @@ let allDemoGroups = [
 				chartType: chartTypes.SimpleBarChart
 			},
 			{
+				options: barDemos.simpleBarFixedDomainOptions,
+				data: barDemos.simpleBarData,
+				chartType: chartTypes.SimpleBarChart
+			},
+			{
 				options: barDemos.groupedBarOptions,
 				data: barDemos.groupedBarData,
 				chartType: chartTypes.GroupedBarChart

--- a/packages/core/src/interfaces/axis-scales.ts
+++ b/packages/core/src/interfaces/axis-scales.ts
@@ -1,4 +1,5 @@
 import { ScaleTypes } from "./enums";
+import { AxisDomain } from "d3";
 
 /**
  * options to configure a scale. not all options are used by all scales
@@ -22,6 +23,7 @@ export interface AxisOptions {
 	 * Range usually follows a linear scale
 	 */
 	useAsRange?: boolean;
+	domain?: AxisDomain[];
 	primary?: boolean;
 	secondary?: boolean;
 	/**

--- a/packages/core/src/interfaces/axis-scales.ts
+++ b/packages/core/src/interfaces/axis-scales.ts
@@ -23,6 +23,13 @@ export interface AxisOptions {
 	 * Range usually follows a linear scale
 	 */
 	useAsGraphRange?: boolean;
+	/**
+	 * Whether the Axis should use the specified domain
+	 * instead of it being dynamically generated based on data extents.
+	 * The type of values should depend on the scale type.
+	 * Example for continuous axis scale: [-100, 100]
+	 * Example for discrete axis scale: ['Qty', 'More', 'Sold']
+	 */
 	domain?: AxisDomain[];
 	primary?: boolean;
 	secondary?: boolean;

--- a/packages/core/src/interfaces/axis-scales.ts
+++ b/packages/core/src/interfaces/axis-scales.ts
@@ -15,14 +15,14 @@ export interface AxisOptions {
 	 * you would expect to only have 1 axis (dimension) being used as domain
 	 * Domain usually represents labels, ordinal values, time intervals etc.
 	 */
-	useAsDomain?: boolean;
+	useAsGraphDomain?: boolean;
 	/**
 	 * Whether the Axis should be used as the range
 	 * axis of the chart. In the case of Cartesian Scales
 	 * you would expect to only have 1 axis (dimension) being used as range
 	 * Range usually follows a linear scale
 	 */
-	useAsRange?: boolean;
+	useAsGraphRange?: boolean;
 	domain?: AxisDomain[];
 	primary?: boolean;
 	secondary?: boolean;

--- a/packages/core/src/services/scales-cartesian.ts
+++ b/packages/core/src/services/scales-cartesian.ts
@@ -232,6 +232,12 @@ export class CartesianScales extends Service {
 
 		// Get the extent of the domain
 		let domain;
+
+		// If domain is specified return that domain
+		if (axisOptions.domain) {
+			return axisOptions.domain;
+		}
+
 		// If the scale is stacked
 		if (axisOptions.stacked) {
 			domain = extent(


### PR DESCRIPTION
### Updates
Partially solves #402 by allowing to specify a fixed domain through each axis configuration.
The keyword `domain` has been added to `AxisOptions` interface. If you prefer, we can change it to something more inline with your naming conventions (maybe something like `extents` would be better?)

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/IBM/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
