### PR TITLE
feat(core): Show a different number of vertical axes ticks depending …

### DIFF
--- a/packages/core/src/components/axes/axis.ts
+++ b/packages/core/src/components/axes/axis.ts
@@ -105,13 +105,10 @@ export class Axis extends Component {
 			if (isNumberOfTicksProvided) {
 				numberOfTicks = numberOfTicksProvided;
 			} else {
-				// If number of ticks is not provided:
+				numberOfTicks = Configuration.axis.ticks.number;
 				if (isVerticalAxis) {
-					// Get how many ticks based on height
+					// Set how many ticks based on height
 					numberOfTicks = this.getNumberOfFittingTicks(height, tickHeight, Configuration.tickSpaceRatioVertical);
-				} else {
-					// Set default ticks number
-					numberOfTicks = Configuration.axis.ticks.number;
 				}
 			}
 

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -295,3 +295,6 @@ export const spacers = {
 		size: 24
 	}
 };
+
+export const tickSpaceRatioVertical = 2.5;
+export const tickSpaceRatioHorizontal = 3.5;

--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -6,6 +6,7 @@ import {
 	merge as lodashMerge,
 	cloneDeep as lodashCloneDeep,
 	uniq as lodashUnique,
+	clamp as lodashClamp,
 	// the imports below are needed because of typescript bug (error TS4029)
 	Cancelable,
 	DebounceSettings
@@ -18,6 +19,7 @@ export namespace Tools {
 	export const clone = lodashCloneDeep;
 	export const merge = lodashMerge;
 	export const removeArrayDuplicates = lodashUnique;
+	export const clamp = lodashClamp;
 
 	/**************************************
 	 *  DOM-related operations            *
@@ -52,9 +54,9 @@ export namespace Tools {
 			const transforms = transformStr[0].replace(/translate\(/, "").replace(/\)/, "").split(",");
 
 			return {
-					tx: transforms[0],
-					ty: transforms[1]
-				};
+				tx: transforms[0],
+				ty: transforms[1]
+			};
 		}
 		return null;
 	}


### PR DESCRIPTION
### Updates
Closes #483.
Enhanced vertical axis to calculate how many ticks can be shown depending on the chart height. 
If `Tools.getProperty(axisOptions, "ticks", "number")` is defined, it will be used instead.

Strategy for calculating height:
- Add text element in axis (take the correct font size)
- Get height (tickHeight)
- Remove it 
- Calculate number of ticks as: chartHeight / (tickHeight * 2.5) 
2.5 was chosen with Accurat designers as a font size coefficient to make labels look not-crowded.

### Recording
![ticksnum](https://user-images.githubusercontent.com/5892387/75455339-a4dbbb00-5979-11ea-80b3-70f8e2086f59.gif)

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/IBM/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
