### PR TITLE
fix(core): Tools.getProperty did return 'null' for falsy values

### DIFF
--- a/packages/core/src/tools.spec.ts
+++ b/packages/core/src/tools.spec.ts
@@ -1,0 +1,39 @@
+import { Tools } from "./tools";
+
+describe("Tools.getProperty", () => {
+	it("works with a simple nested object containing a number > 0", () => {
+		const obj = { a: { b: { c: 5 } } };
+
+		expect(Tools.getProperty(obj, "a", "b", "c")).toEqual(5);
+	});
+
+	it("works with a simple nested object containing a 0", () => {
+		const obj = { a: { b: { c: 0 } } };
+
+		expect(Tools.getProperty(obj, "a", "b", "c")).toEqual(0);
+	});
+
+	it("works with a simple nested object containing `false`", () => {
+		const obj = { a: { b: { c: false } } };
+
+		expect(Tools.getProperty(obj, "a", "b", "c")).toEqual(false);
+	});
+
+	it("works with a simple nested object containing `true`", () => {
+		const obj = { a: { b: { c: true } } };
+
+		expect(Tools.getProperty(obj, "a", "b", "c")).toEqual(true);
+	});
+
+	it("works with a simple nested object containing a string", () => {
+		const obj = { a: { b: { c: "qwerty" } } };
+
+		expect(Tools.getProperty(obj, "a", "b", "c")).toEqual("qwerty");
+	});
+
+	it("works with a simple nested object containing an empty string", () => {
+		const obj = { a: { b: { c: "" } } };
+
+		expect(Tools.getProperty(obj, "a", "b", "c")).toEqual("");
+	});
+});

--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -183,7 +183,7 @@ export namespace Tools {
 		let position = object;
 		if (position) {
 			for (const prop of propPath) {
-				if (position[prop]) {
+				if (position[prop] !== null && position[prop] !== undefined) {
 					position = position[prop];
 				} else {
 					return null;


### PR DESCRIPTION
Hi, this is Accurat :)

While making an unrelated PR (#299), we found out that `Tools.getProperty()` did return `null` for falsy values.
We are proposing this fix to make it return the actual value in the object – even when `false` or `0` or `""`.

In practice, we haven't found an existing example of this bug in the current codebase, but this is an obstacle in creating any `true`-defaulted property.

We are creating this mini-PR to be extra sure this pretty global change does not break anything. The problem could arise if some code relies on the bug, being the function used ~60 times across the codebase.

Some simple tests were added to make the problem appear.

Feel free to close this directly if we made a wrong assumption, or if it's by design.

### Updates
- Added tests which are failing when the bug is not fixed
- The fix, which is using `!== null && !== undefined`
	- An alternative could be to rely on `lodash.get`




### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/IBM/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
