### PR TITLE
feat(core): Add configuration option to not include 0 on axes

### DIFF
--- a/packages/core/src/charts/bar-grouped.ts
+++ b/packages/core/src/charts/bar-grouped.ts
@@ -27,8 +27,8 @@ export class GroupedBarChart extends AxisChart {
 		// Merge the default options for this chart
 		// With the user provided options
 		this.model.setOptions(
-			Tools.merge(
-				Tools.clone(Configuration.options.groupedBarChart),
+			Tools.mergeDefaultChartOptions(
+				Configuration.options.groupedBarChart,
 				chartConfigs.options
 			)
 		);

--- a/packages/core/src/charts/bar-simple.ts
+++ b/packages/core/src/charts/bar-simple.ts
@@ -30,8 +30,8 @@ export class SimpleBarChart extends AxisChart {
 		// Merge the default options for this chart
 		// With the user provided options
 		this.model.setOptions(
-			Tools.merge(
-				Tools.clone(Configuration.options.simpleBarChart),
+			Tools.mergeDefaultChartOptions(
+				Configuration.options.simpleBarChart,
 				chartConfigs.options
 			)
 		);

--- a/packages/core/src/charts/bar-stacked.ts
+++ b/packages/core/src/charts/bar-stacked.ts
@@ -26,8 +26,8 @@ export class StackedBarChart extends AxisChart {
 		// Merge the default options for this chart
 		// With the user provided options
 		this.model.setOptions(
-			Tools.merge(
-				Tools.clone(Configuration.options.stackedBarChart),
+			Tools.mergeDefaultChartOptions(
+				Configuration.options.stackedBarChart,
 				chartConfigs.options
 			)
 		);

--- a/packages/core/src/charts/bubble.ts
+++ b/packages/core/src/charts/bubble.ts
@@ -27,8 +27,8 @@ export class BubbleChart extends AxisChart {
 		// Merge the default options for this chart
 		// With the user provided options
 		this.model.setOptions(
-			Tools.merge(
-				Tools.clone(Configuration.options.bubbleChart),
+			Tools.mergeDefaultChartOptions(
+				Configuration.options.bubbleChart,
 				chartConfigs.options
 			)
 		);

--- a/packages/core/src/charts/donut.ts
+++ b/packages/core/src/charts/donut.ts
@@ -23,8 +23,8 @@ export class DonutChart extends PieChart {
 		// Merge the default options for this chart
 		// With the user provided options
 		this.model.setOptions(
-			Tools.merge(
-				Tools.clone(Configuration.options.donutChart),
+			Tools.mergeDefaultChartOptions(
+				Configuration.options.donutChart,
 				chartConfigs.options
 			)
 		);

--- a/packages/core/src/charts/line.ts
+++ b/packages/core/src/charts/line.ts
@@ -27,8 +27,8 @@ export class LineChart extends AxisChart {
 		// Merge the default options for this chart
 		// With the user provided options
 		this.model.setOptions(
-			Tools.merge(
-				Tools.clone(Configuration.options.lineChart),
+			Tools.mergeDefaultChartOptions(
+				Configuration.options.lineChart,
 				chartConfigs.options
 			)
 		);

--- a/packages/core/src/charts/pie.ts
+++ b/packages/core/src/charts/pie.ts
@@ -32,8 +32,8 @@ export class PieChart extends Chart {
 		// Merge the default options for this chart
 		// With the user provided options
 		this.model.setOptions(
-			Tools.merge(
-				Tools.clone(Configuration.options.pieChart),
+			Tools.mergeDefaultChartOptions(
+				Configuration.options.pieChart,
 				chartConfigs.options
 			)
 		);

--- a/packages/core/src/charts/scatter.ts
+++ b/packages/core/src/charts/scatter.ts
@@ -27,8 +27,8 @@ export class ScatterChart extends AxisChart {
 		// Merge the default options for this chart
 		// With the user provided options
 		this.model.setOptions(
-			Tools.merge(
-				Tools.clone(Configuration.options.scatterChart),
+			Tools.mergeDefaultChartOptions(
+				Configuration.options.scatterChart,
 				chartConfigs.options
 			)
 		);

--- a/packages/core/src/components/axes/two-dimensional-axes.ts
+++ b/packages/core/src/components/axes/two-dimensional-axes.ts
@@ -1,6 +1,6 @@
 // Internal Imports
 import { Component } from "../component";
-import { AxisPositions, ScaleTypes } from "../../interfaces";
+import { AxisPositions, ScaleTypes, AxesOptions } from "../../interfaces";
 import { Axis } from "./axis";
 import { Tools } from "../../tools";
 import { DOMUtils } from "../../services";
@@ -19,40 +19,15 @@ export class TwoDimensionalAxes extends Component {
 
 	render(animate = false) {
 		const axes = {};
-
 		const axisPositions = Object.keys(AxisPositions);
 		const axesOptions = Tools.getProperty(this.model.getOptions(), "axes");
 
-		if (axesOptions) {
-			let primaryAxisOptions, secondaryAxisOptions;
-			axisPositions.forEach(axisPosition => {
-				const axisOptions = axesOptions[AxisPositions[axisPosition]];
-				if (axisOptions) {
-					axes[AxisPositions[axisPosition]] = true;
-
-					if (axisOptions.primary === true) {
-						primaryAxisOptions = axisOptions;
-					} else if (axisOptions.secondary === true) {
-						secondaryAxisOptions = axisOptions;
-					}
-				}
-			});
-		} else {
-			this.model.getOptions().axes = {
-				left: {
-					primary: true,
-					includeZero: true
-				},
-				bottom: {
-					secondary: true,
-					type: this.model.getDisplayData().labels ? ScaleTypes.LABELS : undefined,
-					includeZero: true
-				}
-			};
-
-			axes[AxisPositions.LEFT] = true;
-			axes[AxisPositions.BOTTOM] = true;
-		}
+		axisPositions.forEach(axisPosition => {
+			const axisOptions = axesOptions[AxisPositions[axisPosition]];
+			if (axisOptions) {
+				axes[AxisPositions[axisPosition]] = true;
+			}
+		});
 
 		this.configs.axes = axes;
 

--- a/packages/core/src/components/axes/two-dimensional-axes.ts
+++ b/packages/core/src/components/axes/two-dimensional-axes.ts
@@ -40,11 +40,13 @@ export class TwoDimensionalAxes extends Component {
 		} else {
 			this.model.getOptions().axes = {
 				left: {
-					primary: true
+					primary: true,
+					includeZero: true
 				},
 				bottom: {
 					secondary: true,
-					type: this.model.getDisplayData().labels ? ScaleTypes.LABELS : undefined
+					type: this.model.getDisplayData().labels ? ScaleTypes.LABELS : undefined,
+					includeZero: true
 				}
 			};
 

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -82,7 +82,7 @@ export const axisChartTooltip: AxisTooltipOptions = Tools.merge({}, baseTooltip,
 	}
 } as AxisTooltipOptions);
 
-export const barChartTooltip: BarTooltipOptions = Tools.merge({}, axisChartTooltip , {
+export const barChartTooltip: BarTooltipOptions = Tools.merge({}, axisChartTooltip, {
 	datapoint: {
 		verticalOffset: 4
 	},
@@ -287,7 +287,8 @@ export const axis = {
 	ticks: {
 		number: 7,
 		rotateIfSmallerThan: 30
-	}
+	},
+	paddingRatio: 0.1
 };
 
 export const spacers = {

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -91,9 +91,23 @@ export const barChartTooltip: BarTooltipOptions = Tools.merge({}, axisChartToolt
 	}
 } as BarTooltipOptions);
 
-// We setup no axes by default, the TwoDimensionalAxes component
-// Will setup axes options based on what user provides
-const axes: AxesOptions = { };
+// These options will be managed by Tools.mergeDefaultChartOptions
+// by removing the ones the user is not providing,
+// and by TwoDimensionalAxes.
+const axes: AxesOptions = {
+	top: {
+		includeZero: true
+	},
+	bottom: {
+		includeZero: true
+	},
+	left: {
+		includeZero: true
+	},
+	right: {
+		includeZero: true
+	}
+};
 
 const timeScale: TimeScaleOptions = {
 	addSpaceOnEdges: 1,

--- a/packages/core/src/interfaces/axis-scales.ts
+++ b/packages/core/src/interfaces/axis-scales.ts
@@ -25,6 +25,12 @@ export interface AxisOptions {
 	primary?: boolean;
 	secondary?: boolean;
 	/**
+	* Whether the Axis should be forced to include 0 as a starting point
+	* (or ending point, in case of all negative axis).
+	* Default: true
+	*/
+	includeZero?: boolean;
+	/**
 	 * optional title for the scales
 	 */
 	title?: string;

--- a/packages/core/src/services/scales-cartesian.ts
+++ b/packages/core/src/services/scales-cartesian.ts
@@ -232,7 +232,7 @@ export class CartesianScales extends Service {
 	protected getScaleDomain(axisPosition: AxisPositions) {
 		const options = this.model.getOptions();
 		const axisOptions = Tools.getProperty(options, "axes", axisPosition);
-		const includeZero = axisOptions.includeZero === undefined || axisOptions.includeZero;
+		const { includeZero } = axisOptions;
 		const { datasets, labels } = this.model.getDisplayData();
 
 		// If scale is a LABELS scale, return some labels as the domain

--- a/packages/core/src/services/scales-cartesian.ts
+++ b/packages/core/src/services/scales-cartesian.ts
@@ -1,7 +1,7 @@
 // Internal Imports
 import * as Configuration from "../configuration";
 import { Service } from "./service";
-import { AxisPositions, CartesianOrientations, ScaleTypes } from "../interfaces";
+import { AxisPositions, CartesianOrientations, ScaleTypes, AxesOptions } from "../interfaces";
 import { Tools } from "../tools";
 
 // D3 Imports
@@ -74,7 +74,25 @@ export class CartesianScales extends Service {
 		return this.rangeAxisPosition;
 	}
 
+	setDefaultAxes() {
+		const axesOptions = Tools.getProperty(this.model.getOptions(), "axes");
+		if (!axesOptions) {
+			(this.model.getOptions().axes as AxesOptions) = {
+				left: {
+					primary: true,
+					includeZero: true,
+				},
+				bottom: {
+					secondary: true,
+					includeZero: true,
+					scaleType: this.model.getDisplayData().labels ? ScaleTypes.LABELS : undefined
+				}
+			};
+		}
+	}
+
 	update(animate = true) {
+		this.setDefaultAxes();
 		this.determineOrientation();
 		const axisPositions = Object.keys(AxisPositions).map(axisPositionKey => AxisPositions[axisPositionKey]);
 		axisPositions.forEach(axisPosition => {

--- a/packages/core/src/tools.spec.ts
+++ b/packages/core/src/tools.spec.ts
@@ -37,3 +37,61 @@ describe("Tools.getProperty", () => {
 		expect(Tools.getProperty(obj, "a", "b", "c")).toEqual("");
 	});
 });
+
+
+describe("Tools.mergeDefaultChartOptions", () => {
+	it("it merges default chart configuration with provided ones, with special cases for axes", () => {
+		const providedOptions = {
+			title: "Title",
+			axes: {
+				bottom: {
+					title: "Title",
+					secondary: true
+				},
+				left: {
+					primary: true
+				}
+			}
+		};
+
+		const defaultOptions = {
+			axes: {
+				top: {
+					includeZero: true
+				},
+				bottom: {
+					includeZero: true
+				},
+				left: {
+					includeZero: true
+				},
+				right: {
+					includeZero: true
+				}
+			},
+			timeScale: {
+				addSpaceOnEdges: 1
+			}
+		};
+
+		const expectedMerge = {
+			title: "Title",
+			axes: {
+				bottom: {
+					includeZero: true,
+					title: "Title",
+					secondary: true
+				},
+				left: {
+					includeZero: true,
+					primary: true
+				}
+			},
+			timeScale: {
+				addSpaceOnEdges: 1
+			}
+		};
+
+		expect(Tools.mergeDefaultChartOptions(defaultOptions, providedOptions)).toEqual(expectedMerge);
+	});
+});

--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -1,5 +1,5 @@
 // Internal imports
-import { CartesianOrientations } from "./interfaces";
+import { CartesianOrientations, AxisChartOptions } from "./interfaces";
 
 import {
 	debounce as lodashDebounce,
@@ -18,6 +18,37 @@ export namespace Tools {
 	export const clone = lodashCloneDeep;
 	export const merge = lodashMerge;
 	export const removeArrayDuplicates = lodashUnique;
+
+
+	/**
+	 * Returns default chart options merged with provided options,
+	 * with special cases for axes.
+	 * Axes object will not merge the not provided axes.
+	 *
+	 * @export
+	 * @param {AxisChartOptions} defaultOptions Configuration.options[chartType]
+	 * @param {AxisChartOptions} providedOptions user provided options
+	 * @returns merged options
+	 */
+	export function mergeDefaultChartOptions(defaultOptions: AxisChartOptions, providedOptions: AxisChartOptions) {
+		defaultOptions = Tools.clone(defaultOptions);
+		const providedAxesNames = Object.keys(providedOptions.axes || {});
+
+		if (providedAxesNames.length === 0) {
+			delete defaultOptions.axes;
+		}
+
+		for (const axisName in defaultOptions.axes) {
+			if (!providedAxesNames.includes(axisName)) {
+				delete defaultOptions.axes[axisName];
+			}
+		}
+
+		return Tools.merge(
+			defaultOptions,
+			providedOptions
+		);
+	}
 
 	/**************************************
 	 *  DOM-related operations            *
@@ -52,9 +83,9 @@ export namespace Tools {
 			const transforms = transformStr[0].replace(/translate\(/, "").replace(/\)/, "").split(",");
 
 			return {
-					tx: transforms[0],
-					ty: transforms[1]
-				};
+				tx: transforms[0],
+				ty: transforms[1]
+			};
 		}
 		return null;
 	}


### PR DESCRIPTION
### Updates
Closes #402.
Add configuration option `includeZero?: boolean` (default true) to let users exclude 0 from the axis. 

### Screenshots
`includeZero: true` (default behaviour)
<img width="494" alt="include" src="https://user-images.githubusercontent.com/5892387/75260601-27357500-57ea-11ea-9df0-3840e7b413d5.png">

`includeZero: false`
<img width="489" alt="not include" src="https://user-images.githubusercontent.com/5892387/75260638-34526400-57ea-11ea-87a5-1a34311a3de3.png">

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/IBM/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
