### PR TITLE
add mouse events for axis labels

### DIFF
--- a/packages/core/src/interfaces/events.ts
+++ b/packages/core/src/interfaces/events.ts
@@ -1,4 +1,14 @@
 /**
+ * enum of all axis-related events
+ */
+export enum Axis {
+	LABEL_MOUSEOVER = "axis-label-mouseover",
+	LABEL_MOUSEMOVE = "axis-label-mousemove",
+	LABEL_CLICK = "axis-label-click",
+	LABEL_MOUSEOUT = "axis-label-mouseout"
+}
+
+/**
  * enum of all pie graph events
  */
 export enum Pie {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14989804/76247916-b2fdc700-6216-11ea-9d8a-1ccebbed159a.png)

Closes #487

I'm wondering if we should distinguish axis events based on axis position (e.g. `left`, `right` etc.)