### PR TITLE
Timeseries axis: Fix rotating tick when is not necessary

### DIFF
--- a/packages/core/demo/demo-data/index.ts
+++ b/packages/core/demo/demo-data/index.ts
@@ -162,6 +162,11 @@ let allDemoGroups = [
 				options: lineDemos.lineOptions,
 				data: lineDemos.lineData,
 				chartType: chartTypes.LineChart
+			},
+			{
+				options: lineDemos.lineTimeSeriesRotatedTicksOptions,
+				data: lineDemos.lineTimeSeriesDataRotatedTicks,
+				chartType: chartTypes.LineChart
 			}
 		]
 	},

--- a/packages/core/demo/demo-data/line.ts
+++ b/packages/core/demo/demo-data/line.ts
@@ -220,7 +220,7 @@ export const lineTimeSeriesRotatedTicksOptions = {
 		left: { secondary: true },
 		bottom: {
 			scaleType: "time",
-			primary: true,
-		},
-	},
+			primary: true
+		}
+	}
 };

--- a/packages/core/demo/demo-data/line.ts
+++ b/packages/core/demo/demo-data/line.ts
@@ -197,3 +197,30 @@ export const lineTimeSeriesOptions = {
 	},
 	curve: "curveMonotoneX"
 };
+
+export const lineTimeSeriesDataRotatedTicks = {
+	labels: ["Qty"],
+	datasets: [
+		{
+			label: "Dataset 1",
+			data: [
+				{ date: new Date(2019, 11, 30), value: 10 },
+				{ date: new Date(2019, 11, 31), value: 10 },
+				{ date: new Date(2020, 0, 1), value: 10 },
+				{ date: new Date(2020, 0, 2), value: 10 },
+				{ date: new Date(2020, 0, 3), value: 10 },
+			]
+		}
+	]
+};
+
+export const lineTimeSeriesRotatedTicksOptions = {
+	title: "Line (time series) - Rotated ticks labels",
+	axes: {
+		left: { secondary: true },
+		bottom: {
+			scaleType: "time",
+			primary: true,
+		},
+	},
+};

--- a/packages/core/demo/demo-data/line.ts
+++ b/packages/core/demo/demo-data/line.ts
@@ -208,7 +208,7 @@ export const lineTimeSeriesDataRotatedTicks = {
 				{ date: new Date(2019, 11, 31), value: 10 },
 				{ date: new Date(2020, 0, 1), value: 10 },
 				{ date: new Date(2020, 0, 2), value: 10 },
-				{ date: new Date(2020, 0, 3), value: 10 },
+				{ date: new Date(2020, 0, 3), value: 10 }
 			]
 		}
 	]

--- a/packages/core/src/components/axes/axis.ts
+++ b/packages/core/src/components/axes/axis.ts
@@ -99,6 +99,8 @@ export class Axis extends Component {
 			.tickSizeOuter(0)
 			.tickFormat(Tools.getProperty(axisOptions, "ticks", "formatter"));
 
+		const isTimeScaleType = this.scaleType === ScaleTypes.TIME || axisOptions.scaleType === ScaleTypes.TIME;
+
 		if (scale.ticks) {
 			let numberOfTicks;
 
@@ -114,7 +116,7 @@ export class Axis extends Component {
 
 			axis.ticks(numberOfTicks);
 
-			if (this.scaleType === ScaleTypes.TIME) {
+			if (isTimeScaleType) {
 				let tickValues = scale.ticks(numberOfTicks).concat(scale.domain())
 					.map(date => +date).sort();
 				tickValues = Tools.removeArrayDuplicates(tickValues);
@@ -202,7 +204,8 @@ export class Axis extends Component {
 				// When dealing with a continuous scale
 				// We need to calculate an estimated size of the ticks
 				const minTickSize = Tools.getProperty(axisOptions, "ticks", "rotateIfSmallerThan") || Configuration.axis.ticks.rotateIfSmallerThan;
-				const estimatedTickSize = width / scale.ticks().length / 2;
+				const ticksNumber = isTimeScaleType ? axis.tickValues().length : scale.ticks().length;
+				const estimatedTickSize = width / ticksNumber / 2;
 
 				rotateTicks = estimatedTickSize < minTickSize;
 			}


### PR DESCRIPTION
Closes: #519.

### Demo screenshot

As is:
![As is](https://user-images.githubusercontent.com/44204353/76397012-9bd7ea00-637a-11ea-8f89-febdd975b358.png)

After this PR: 
![After this PR](https://user-images.githubusercontent.com/44204353/76397043-ac886000-637a-11ea-9f5f-e561bdf18a82.png)

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/IBM/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)