### PR TITLE
fix(stacked-bar-charts): Allow null values in multiple data sets

### DIFF
--- a/packages/core/src/components/graphs/bar-stacked.ts
+++ b/packages/core/src/components/graphs/bar-stacked.ts
@@ -62,7 +62,7 @@ export class StackedBar extends Bar {
 		// Update data on all bars
 		const bars = svg.selectAll("g.bars").selectAll("path.bar")
 			// Remove bars with a start and end value of 0
-			.data(data => data.filter(d => !(d[0] === 0 && d[1] === 0)));
+			.data(data => data);
 
 		// Remove bars that need to be removed
 		bars.exit()
@@ -153,7 +153,7 @@ export class StackedBar extends Bar {
 
 				const rangeIdentifier = self.services.cartesianScales.getRangeIdentifier();
 				const { groupMapsTo } = self.model.getOptions().data;
-		
+
 				// Show tooltip
 				self.services.events.dispatchEvent("show-tooltip", {
 					hoveredElement,


### PR DESCRIPTION
### Updates
- Updates StackedBarChart to handle a null data value
- Updates MutliTooltip to not load an li for null values
- Fixes https://github.com/carbon-design-system/carbon-charts/issues/494

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/IBM/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
