### PR TITLE
Tslint: Add rules about trailing comma and space before function parenthesis

### DIFF
--- a/packages/core/tslint.json
+++ b/packages/core/tslint.json
@@ -112,6 +112,17 @@
       "check-separator",
 	  "check-module",
       "check-type"
+    ],
+    "space-before-function-paren": [
+      true,
+      "never"
+    ],
+    "trailing-comma": [
+      true,
+      {
+        "multiline": "never",
+        "singleline": "never"
+      }
     ]
   }
 }

--- a/packages/core/tslint.json
+++ b/packages/core/tslint.json
@@ -110,7 +110,7 @@
       "check-decl",
       "check-operator",
       "check-separator",
-	  "check-module",
+	    "check-module",
       "check-type"
     ],
     "space-before-function-paren": [


### PR DESCRIPTION
Add two simple _tslint_ rules:

- `space-before-function-paren`: disallows a space before function parenthesis
- `trailing-comma`: disallows trailing commas.

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/IBM/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
