### PR TITLE
fix(core): update import path carbon-components

### DIFF
--- a/packages/core/src/components/component.ts
+++ b/packages/core/src/components/component.ts
@@ -7,7 +7,7 @@ import { Tools } from "../tools";
 import { select } from "d3-selection";
 
 // import the settings for the css prefix
-import settings from "carbon-components/src/globals/js/settings";
+import settings from "carbon-components/es/globals/js/settings";
 
 
 export class Component {

--- a/packages/core/src/components/essentials/legend.spec.ts
+++ b/packages/core/src/components/essentials/legend.spec.ts
@@ -1,7 +1,7 @@
 import { TestEnvironment } from "../../tests/index";
 
 // import the settings for the css prefixes
-import settings from "carbon-components/src/globals/js/settings";
+import settings from "carbon-components/es/globals/js/settings";
 import { options } from "./../../configuration";
 
 import { select } from "d3-selection";

--- a/packages/core/src/components/essentials/title.spec.ts
+++ b/packages/core/src/components/essentials/title.spec.ts
@@ -1,7 +1,7 @@
 import { TestEnvironment } from "../../tests/index";
 
 // import the settings for the css prefixes
-import settings from "carbon-components/src/globals/js/settings";
+import settings from "carbon-components/es/globals/js/settings";
 import { options } from "./../../configuration";
 
 import { select } from "d3-selection";

--- a/packages/core/src/components/essentials/tooltip-bar.ts
+++ b/packages/core/src/components/essentials/tooltip-bar.ts
@@ -4,7 +4,7 @@ import { DOMUtils } from "../../services";
 import { TooltipPosition, TooltipTypes, CartesianOrientations } from "./../../interfaces/enums";
 
 // import the settings for the css prefix
-import settings from "carbon-components/src/globals/js/settings";
+import settings from "carbon-components/es/globals/js/settings";
 
 // D3 Imports
 import { select } from "d3-selection";

--- a/packages/core/src/components/essentials/tooltip.ts
+++ b/packages/core/src/components/essentials/tooltip.ts
@@ -8,7 +8,7 @@ import { ChartModel } from "../../model";
 import Position, { PLACEMENTS } from "@carbon/utils-position";
 
 // import the settings for the css prefix
-import settings from "carbon-components/src/globals/js/settings";
+import settings from "carbon-components/es/globals/js/settings";
 
 // D3 Imports
 import { select, mouse, event } from "d3-selection";

--- a/packages/core/src/services/essentials/dom-utils.ts
+++ b/packages/core/src/services/essentials/dom-utils.ts
@@ -7,7 +7,7 @@ import { select, Selection } from "d3-selection";
 import { Tools } from "../../tools";
 
 // import the settings for the css prefix
-import settings from "carbon-components/src/globals/js/settings";
+import settings from "carbon-components/es/globals/js/settings";
 
 // MISC
 import ResizeObserver from "resize-observer-polyfill";

--- a/packages/core/src/tests/tools.ts
+++ b/packages/core/src/tests/tools.ts
@@ -1,5 +1,5 @@
 // import the settings for the css prefix
-import settings from "carbon-components/src/globals/js/settings";
+import settings from "carbon-components/es/globals/js/settings";
 
 // Functions
 export const makeChartID = chartType => `${chartType}-chart-holder`;


### PR DESCRIPTION
fix #546

### Updates
- update the import path for settings from carbon-components

### Demo screenshot or recording

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/IBM/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
