### PR TITLE
Pie zero labels

### DIFF
--- a/packages/core/demo/data/pie.ts
+++ b/packages/core/demo/data/pie.ts
@@ -1,5 +1,5 @@
 export const pieData = [
-	{ group: "2V2N 9KYPM version 1", value: 21000 },
+	{ group: "2V2N 9KYPM version 1", value: 20000 },
 	{ group: "L22I P66EP L22I P66EP L22I P66EP", value: 65000 },
 	{ group: "JQAI 2M4L1", value: 75000 },
 	{ group: "J9DZ F37AP", value: 1200 },

--- a/packages/core/demo/data/pie.ts
+++ b/packages/core/demo/data/pie.ts
@@ -1,5 +1,5 @@
 export const pieData = [
-	{ group: "2V2N 9KYPM version 1", value: 20000 },
+	{ group: "2V2N 9KYPM version 1", value: 21000 },
 	{ group: "L22I P66EP L22I P66EP L22I P66EP", value: 65000 },
 	{ group: "JQAI 2M4L1", value: 75000 },
 	{ group: "J9DZ F37AP", value: 1200 },

--- a/packages/core/src/components/graphs/pie.ts
+++ b/packages/core/src/components/graphs/pie.ts
@@ -106,14 +106,15 @@ export class Pie extends Component {
 			.attr("aria-roledescription", "slice")
 			.attr("aria-label", d => `${d.value}, ${Tools.convertValueToPercentage(d.data.value, displayData) + "%"}`)
 			// Tween
-			.attrTween("d", function (a) {
+			.attrTween("d", function(a) {
 				return arcTween.bind(this)(a, self.arc);
 			});
 
 		// Draw the slice labels
+		const labelData = pieLayoutData.filter(x => x.value > 0);
 		const labelsGroup = DOMUtils.appendOrSelect(svg, "g.labels").attr("role", Roles.GROUP);
 		const labels = labelsGroup.selectAll("text.pie-label")
-			.data(pieLayoutData, (d: any) => d.data[groupMapsTo]);
+			.data(labelData, (d: any) =>  d.data[groupMapsTo]);
 
 		// Remove labels that are existing
 		labels.exit()
@@ -151,8 +152,8 @@ export class Pie extends Component {
 
 				return d;
 			})
-			.attr("transform", function (d, i) {
-				const totalSlices = displayData.length;
+			.attr("transform", function(d, i) {
+				const totalSlices = labelData.length;
 				const sliceAngleDeg = (d.endAngle - d.startAngle) * (180 / Math.PI);
 
 				// check if last 2 slices (or just last) are < the threshold

--- a/packages/core/src/components/graphs/pie.ts
+++ b/packages/core/src/components/graphs/pie.ts
@@ -141,7 +141,7 @@ export class Pie extends Component {
 			.datum(function(d) {
 				const textLength = this.getComputedTextLength();
 				d.textOffsetX = textLength / 2;
-				d.textOffsetY = parseFloat(getComputedStyle(this).fontSize) / 2;
+				d.textOffsetY = Math.ceil(select(this).node().getBBox().height / 2);
 
 				const marginedRadius = radius + 7;
 
@@ -275,7 +275,7 @@ export class Pie extends Component {
 		const enteringHorizontalLines = enteringCallouts.append("line")
 			.classed("horizontal-line", true);
 
-		enteringHorizontalLines.merge(callouts.selectAll("line.horizontal-line"))
+		enteringHorizontalLines.merge(svg.selectAll("line.horizontal-line"))
 			.datum(function(d: any) {
 				return select(this.parentNode).datum();
 			})

--- a/packages/core/src/components/graphs/pie.ts
+++ b/packages/core/src/components/graphs/pie.ts
@@ -114,7 +114,7 @@ export class Pie extends Component {
 		const labelData = pieLayoutData.filter(x => x.value > 0);
 		const labelsGroup = DOMUtils.appendOrSelect(svg, "g.labels").attr("role", Roles.GROUP);
 		const labels = labelsGroup.selectAll("text.pie-label")
-			.data(labelData, (d: any) =>  d.data[groupMapsTo]);
+			.data(labelData, (d: any) => d.data[groupMapsTo]);
 
 		// Remove labels that are existing
 		labels.exit()


### PR DESCRIPTION
### Updates
- updated to remove label data for slices that are 0, label `text` and callouts won't get rendered to the DOM

closes #500 
closes #552 

### Demo screenshot or recording


##### example 1
![image](https://user-images.githubusercontent.com/14351335/78728403-3806f980-7905-11ea-9e0c-e773a2862837.png)
last dataset value is set to 0, it does not render the label and the next smallest slice (under the threshold) will become the "right" callout. 


##### example 2
![image](https://user-images.githubusercontent.com/14351335/78728472-6c7ab580-7905-11ea-9e48-b4a998320ae6.png)
with last dataset value set to 0 **and** there are 2 other dataset values that are within the threshold (they become left/right callout). 


### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/IBM/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
