### PR TITLE
provide all datapoint info to stacked bar tooltips

### DIFF
--- a/packages/core/src/components/graphs/bar-stacked.ts
+++ b/packages/core/src/components/graphs/bar-stacked.ts
@@ -147,20 +147,31 @@ export class StackedBar extends Bar {
 				});
 			})
 			.on("mousemove", function(datum) {
+				const displayData = self.model.getDisplayData();
 				const hoveredElement = select(this);
 
 				const domainIdentifier = self.services.cartesianScales.getDomainIdentifier();
 				const rangeIdentifier = self.services.cartesianScales.getRangeIdentifier();
 				const { groupMapsTo } = self.model.getOptions().data;
 
-				// Show tooltip
-				self.services.events.dispatchEvent(Events.Tooltip.SHOW, {
-					hoveredElement,
-					data: {
+				let matchingDataPoint = displayData.find(d => {
+					return d[rangeIdentifier] === datum.data[datum.group] &&
+						d[domainIdentifier].toString() === datum.data.sharedStackKey &&
+						d[groupMapsTo] === datum.group;
+				});
+
+				if (matchingDataPoint === undefined) {
+					matchingDataPoint = {
 						[domainIdentifier]: datum.data.sharedStackKey,
 						[rangeIdentifier]: datum.data[datum.group],
 						[groupMapsTo]: datum.group
-					},
+					};
+				}
+
+				// Show tooltip
+				self.services.events.dispatchEvent(Events.Tooltip.SHOW, {
+					hoveredElement,
+					data: matchingDataPoint,
 					type: TooltipTypes.DATAPOINT
 				});
 			})


### PR DESCRIPTION
When stacked bar tooltips are shown, the tooltip doesn't get passed the full datapoint object, rather a minimal version of it (because of how stacked data gets generated in D3).

This PR will find the corresponding data point and pass it in full to tooltips.