### PR TITLE
optimize axis tick formatting

### DIFF
--- a/packages/core/src/components/axes/axis.ts
+++ b/packages/core/src/components/axes/axis.ts
@@ -152,7 +152,7 @@ export class Axis extends Component {
 			} else {
 				formatter = (t: number, i: number) => {
 					const defaultFormattedValue = formatTick(t, i, timeInterval, timeScaleOptions);
-					return userProvidedFormatter(defaultFormattedValue, i);
+					return userProvidedFormatter(t, i, defaultFormattedValue);
 				};
 			}
 		} else {


### PR DESCRIPTION
Currently axis tick formatters are only being called for linear scales.

This PR adds support for all scale types as long as a formatter is provided by the user.