### PR TITLE
Support for Horizontal Line and Scatter Chart

### DIFF
--- a/packages/core/demo/data/index.ts
+++ b/packages/core/demo/data/index.ts
@@ -197,6 +197,16 @@ let allDemoGroups = [
 				options: lineDemos.lineTimeSeriesRotatedTicksOptions,
 				data: lineDemos.lineTimeSeriesDataRotatedTicks,
 				chartType: chartTypes.LineChart
+			},
+			{
+				options: lineDemos.lineTimeSeriesHorizontalOptions,
+				data: lineDemos.lineTimeSeriesData,
+				chartType: chartTypes.LineChart
+			},
+			{
+				options: lineDemos.lineHorizontalOptions,
+				data: lineDemos.lineData,
+				chartType: chartTypes.LineChart
 			}
 		]
 	},

--- a/packages/core/demo/data/line.ts
+++ b/packages/core/demo/data/line.ts
@@ -98,3 +98,36 @@ export const lineTimeSeriesRotatedTicksOptions = {
 		}
 	}
 };
+
+export const lineHorizontalOptions = {
+	title: "Line Horizontal (discrete)",
+	axes: {
+		left: {
+			title: "2019 Annual Sales Figures",
+			mapsTo: "key",
+			scaleType: "labels"
+		},
+		bottom: {
+			mapsTo: "value",
+			title: "Conversion rate",
+			scaleType: "linear"
+		}
+	}
+};
+
+export const lineTimeSeriesHorizontalOptions = {
+	title: "Line Horizontal (time series)",
+	axes: {
+		left: {
+			title: "2019 Annual Sales Figures",
+			mapsTo: "date",
+			scaleType: "time"
+		},
+		bottom: {
+			mapsTo: "value",
+			title: "Conversion rate",
+			scaleType: "linear"
+		}
+	},
+	curve: "curveMonotoneY"
+};

--- a/packages/core/src/components/graphs/line.ts
+++ b/packages/core/src/components/graphs/line.ts
@@ -2,6 +2,7 @@
 import { Component } from "../component";
 import * as Configuration from "../../configuration";
 import { Roles, Events } from "../../interfaces";
+import { Tools } from "../../tools";
 
 // D3 Imports
 import { select } from "d3-selection";
@@ -20,14 +21,19 @@ export class Line extends Component {
 
 	render(animate = true) {
 		const svg = this.getContainerSVG();
+		const { cartesianScales, curves } = this.services;
+
+		const getDomainValue = (d, i) => cartesianScales.getDomainValue(d, i);
+		const getRangeValue = (d, i) => cartesianScales.getRangeValue(d, i);
+		const [getXValue, getYValue] = Tools.flipBasedOnOrientation(getDomainValue, getRangeValue, cartesianScales.getOrientation());
 
 		// D3 line generator function
 		const lineGenerator = line()
-			.x((d, i) => this.services.cartesianScales.getDomainValue(d, i))
-			.y((d, i) => this.services.cartesianScales.getRangeValue(d, i))
-			.curve(this.services.curves.getD3Curve())
+			.x(getXValue)
+			.y(getYValue)
+			.curve(curves.getD3Curve())
 			.defined((datum: any, i) => {
-				const rangeIdentifier = this.services.cartesianScales.getRangeIdentifier();
+				const rangeIdentifier = cartesianScales.getRangeIdentifier();
 				const value = datum[rangeIdentifier];
 				if (value === null || value === undefined) {
 					return false;

--- a/packages/core/src/components/graphs/line.ts
+++ b/packages/core/src/components/graphs/line.ts
@@ -25,7 +25,11 @@ export class Line extends Component {
 
 		const getDomainValue = (d, i) => cartesianScales.getDomainValue(d, i);
 		const getRangeValue = (d, i) => cartesianScales.getRangeValue(d, i);
-		const [getXValue, getYValue] = Tools.flipBasedOnOrientation(getDomainValue, getRangeValue, cartesianScales.getOrientation());
+		const [getXValue, getYValue] = Tools.flipDomainAndRangeBasedOnOrientation(
+			getDomainValue,
+			getRangeValue,
+			cartesianScales.getOrientation()
+		);
 
 		// D3 line generator function
 		const lineGenerator = line()

--- a/packages/core/src/components/graphs/scatter.ts
+++ b/packages/core/src/components/graphs/scatter.ts
@@ -1,6 +1,7 @@
 // Internal Imports
 import { Component } from "../component";
 import { TooltipTypes, Roles, Events } from "../../interfaces";
+import { Tools } from "../../tools";
 
 // D3 Imports
 import { select, Selection, event as d3Event } from "d3-selection";
@@ -60,18 +61,23 @@ export class Scatter extends Component {
 		// Chart options mixed with the internal configurations
 		const options = this.model.getOptions();
 		const { filled } = options.points;
+		const { cartesianScales, transitions } = this.services;
 
 		const { groupMapsTo } = options.data;
-		const domainIdentifier = this.services.cartesianScales.getDomainIdentifier();
-		const rangeIdentifier = this.services.cartesianScales.getRangeIdentifier();
+		const domainIdentifier = cartesianScales.getDomainIdentifier();
+		const rangeIdentifier = cartesianScales.getRangeIdentifier();
+
+		const getDomainValue = (d, i) => cartesianScales.getDomainValue(d, i);
+		const getRangeValue = (d, i) => cartesianScales.getRangeValue(d, i);
+		const [getXValue, getYValue] = Tools.flipBasedOnOrientation(getDomainValue, getRangeValue, cartesianScales.getOrientation());
 
 		selection.raise()
 			.classed("dot", true)
 			.classed("filled", d => this.model.getIsFilled(d[groupMapsTo], d[domainIdentifier], d, filled))
 			.classed("unfilled", d => !this.model.getIsFilled(d[groupMapsTo], d[domainIdentifier], d, filled))
-			.attr("cx", (d, i) => this.services.cartesianScales.getDomainValue(d, i))
-			.transition(this.services.transitions.getTransition("scatter-update-enter", animate))
-			.attr("cy", (d, i) => this.services.cartesianScales.getRangeValue(d, i))
+			.attr("cx", getXValue)
+			.transition(transitions.getTransition("scatter-update-enter", animate))
+			.attr("cy", getYValue)
 			.attr("r", options.points.radius)
 			.attr("fill", d => {
 				if (this.model.getIsFilled(d[groupMapsTo], d[domainIdentifier], d, filled)) {

--- a/packages/core/src/components/graphs/scatter.ts
+++ b/packages/core/src/components/graphs/scatter.ts
@@ -69,7 +69,11 @@ export class Scatter extends Component {
 
 		const getDomainValue = (d, i) => cartesianScales.getDomainValue(d, i);
 		const getRangeValue = (d, i) => cartesianScales.getRangeValue(d, i);
-		const [getXValue, getYValue] = Tools.flipBasedOnOrientation(getDomainValue, getRangeValue, cartesianScales.getOrientation());
+		const [getXValue, getYValue] = Tools.flipDomainAndRangeBasedOnOrientation(
+			getDomainValue,
+			getRangeValue,
+			cartesianScales.getOrientation()
+		);
 
 		selection.raise()
 			.classed("dot", true)

--- a/packages/core/src/services/scales-cartesian.ts
+++ b/packages/core/src/services/scales-cartesian.ts
@@ -90,7 +90,7 @@ export class CartesianScales extends Service {
 		const axisOptions = Tools.getProperty(options, "axes");
 
 		// If right axis has been specified as `main`
-		if (Tools.getProperty(axisOptions, "axes", AxisPositions.RIGHT, "main") === true) {
+		if (Tools.getProperty(axisOptions, AxisPositions.RIGHT, "main") === true) {
 			return AxisPositions.RIGHT;
 		}
 
@@ -102,7 +102,7 @@ export class CartesianScales extends Service {
 		const axisOptions = Tools.getProperty(options, "axes");
 
 		// If top axis has been specified as `main`
-		if (Tools.getProperty(axisOptions, "axes", AxisPositions.TOP, "main") === true) {
+		if (Tools.getProperty(axisOptions, AxisPositions.TOP, "main") === true) {
 			return AxisPositions.TOP;
 		}
 

--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -279,7 +279,7 @@ export namespace Tools {
 		return `M${x0},${y0}L${x0},${y1}L${x1},${y1}L${x1},${y0}L${x0},${y0}`;
 	};
 
-	export function flipBasedOnOrientation<D, R>(domain: D, range: R, orientation?: CartesianOrientations): [D, R] | [R, D] {
+	export function flipDomainAndRangeBasedOnOrientation<D, R>(domain: D, range: R, orientation?: CartesianOrientations): [D, R] | [R, D] {
 		return orientation === CartesianOrientations.VERTICAL ? [domain, range] : [range, domain];
 	}
 }

--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -278,4 +278,8 @@ export namespace Tools {
 
 		return `M${x0},${y0}L${x0},${y1}L${x1},${y1}L${x1},${y0}L${x0},${y0}`;
 	};
+
+	export function flipBasedOnOrientation<D, R>(domain: D, range: R, orientation?: CartesianOrientations): [D, R] | [R, D] {
+		return orientation === CartesianOrientations.VERTICAL ? [domain, range] : [range, domain];
+	}
 }


### PR DESCRIPTION
### Updates
Support for Horizontal Line and Scatter Chart.

Resolve #583.

### Demo screenshot or recording
<img width="724" alt="Screenshot 2020-04-20 at 14 53 18" src="https://user-images.githubusercontent.com/5892387/79753751-be183c80-8316-11ea-8b92-e574779245bb.png">
<img width="727" alt="Screenshot 2020-04-20 at 14 53 03" src="https://user-images.githubusercontent.com/5892387/79753767-c1abc380-8316-11ea-908e-8359f363df05.png">

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/IBM/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
