### PR TITLE
Fix linting problem about methods order

### DIFF
--- a/packages/core/src/components/graphs/bar-grouped.ts
+++ b/packages/core/src/components/graphs/bar-grouped.ts
@@ -31,69 +31,6 @@ export class GroupedBar extends Bar {
 		eventsFragment.addEventListener(Events.Legend.ITEM_MOUSEOUT, this.handleLegendMouseOut);
 	}
 
-	protected getDataCorrespondingToLabel(label: string) {
-		const displayData = this.model.getDisplayData();
-		const domainIdentifier = this.services.cartesianScales.getDomainIdentifier();
-
-		return displayData.filter(datum => datum[domainIdentifier] === label);
-	}
-
-	protected getGroupWidth() {
-		const numOfActiveDataGroups = this.model.getActiveDataGroupNames().length;
-		const totalGroupPadding = this.getTotalGroupPadding();
-
-		return this.getBarWidth() * numOfActiveDataGroups + totalGroupPadding;
-	}
-
-
-	protected getTotalGroupPadding() {
-		const numOfActiveDataGroups = this.model.getActiveDataGroupNames().length;
-
-		if (numOfActiveDataGroups === 1) {
-			return 0;
-		}
-
-		const domainScale = this.services.cartesianScales.getDomainScale();
-		const padding = Math.min(
-			5,
-			5 * (domainScale.step() / 70)
-		);
-
-		return padding * (numOfActiveDataGroups - 1);
-	}
-
-	// Gets the correct width for bars based on options & configurations
-	protected getBarWidth() {
-		const options = this.model.getOptions();
-		const providedWidth = Tools.getProperty(options, "bars", "width");
-		const providedMaxWidth = Tools.getProperty(options, "bars", "maxWidth");
-
-		// If there's a provided width, compare with maxWidth and
-		// Determine which to return
-		if (providedWidth !== null) {
-			if (providedMaxWidth === null) {
-				return providedWidth;
-			} else if (providedWidth <= providedMaxWidth) {
-				return providedWidth;
-			}
-		}
-
-		const numOfActiveDataGroups = this.model.getActiveDataGroupNames().length;
-		const totalGroupPadding = this.getTotalGroupPadding();
-
-		const domainScale = this.services.cartesianScales.getDomainScale();
-		return Math.min(
-			providedMaxWidth,
-			(domainScale.step() - totalGroupPadding) / numOfActiveDataGroups
-		);
-	}
-
-	protected setGroupScale() {
-		this.groupScale = scaleBand()
-			.domain(this.model.getActiveDataGroupNames())
-			.rangeRound([0, this.getGroupWidth()]);
-	}
-
 	render(animate: boolean) {
 		// Chart options mixed with the internal configurations
 		const displayData = this.model.getDisplayData();
@@ -271,5 +208,68 @@ export class GroupedBar extends Bar {
 		const eventsFragment = this.services.events;
 		eventsFragment.removeEventListener(Events.Legend.ITEM_HOVER, this.handleLegendOnHover);
 		eventsFragment.removeEventListener(Events.Legend.ITEM_MOUSEOUT, this.handleLegendMouseOut);
+	}
+
+	protected getDataCorrespondingToLabel(label: string) {
+		const displayData = this.model.getDisplayData();
+		const domainIdentifier = this.services.cartesianScales.getDomainIdentifier();
+
+		return displayData.filter(datum => datum[domainIdentifier] === label);
+	}
+
+	protected getGroupWidth() {
+		const numOfActiveDataGroups = this.model.getActiveDataGroupNames().length;
+		const totalGroupPadding = this.getTotalGroupPadding();
+
+		return this.getBarWidth() * numOfActiveDataGroups + totalGroupPadding;
+	}
+
+
+	protected getTotalGroupPadding() {
+		const numOfActiveDataGroups = this.model.getActiveDataGroupNames().length;
+
+		if (numOfActiveDataGroups === 1) {
+			return 0;
+		}
+
+		const domainScale = this.services.cartesianScales.getDomainScale();
+		const padding = Math.min(
+			5,
+			5 * (domainScale.step() / 70)
+		);
+
+		return padding * (numOfActiveDataGroups - 1);
+	}
+
+	// Gets the correct width for bars based on options & configurations
+	protected getBarWidth() {
+		const options = this.model.getOptions();
+		const providedWidth = Tools.getProperty(options, "bars", "width");
+		const providedMaxWidth = Tools.getProperty(options, "bars", "maxWidth");
+
+		// If there's a provided width, compare with maxWidth and
+		// Determine which to return
+		if (providedWidth !== null) {
+			if (providedMaxWidth === null) {
+				return providedWidth;
+			} else if (providedWidth <= providedMaxWidth) {
+				return providedWidth;
+			}
+		}
+
+		const numOfActiveDataGroups = this.model.getActiveDataGroupNames().length;
+		const totalGroupPadding = this.getTotalGroupPadding();
+
+		const domainScale = this.services.cartesianScales.getDomainScale();
+		return Math.min(
+			providedMaxWidth,
+			(domainScale.step() - totalGroupPadding) / numOfActiveDataGroups
+		);
+	}
+
+	protected setGroupScale() {
+		this.groupScale = scaleBand()
+			.domain(this.model.getActiveDataGroupNames())
+			.rangeRound([0, this.getGroupWidth()]);
 	}
 }

--- a/packages/core/src/model.ts
+++ b/packages/core/src/model.ts
@@ -39,65 +39,6 @@ export class ChartModel {
 		this.services = services;
 	}
 
-	/**
-	 * Converts data provided in the older format to tabular
-	 * 
-	 */
-	protected transformToTabularData(data) {
-		console.warn("We've updated the charting data format to be tabular by default. The current format you're using is deprecated and will be removed in v1.0, read more here https://carbon-design-system.github.io/carbon-charts/?path=/story/tutorials--tabular-data-format")
-		const tabularData = [];
-		const { datasets, labels } = data;
-
-		// Loop through all datasets
-		datasets.forEach(dataset => {
-			// Update each data point to the new format
-			dataset.data.forEach((datum, i) => {
-				let group;
-
-				const datasetLabel = Tools.getProperty(dataset, "label");
-				if (datasetLabel === null) {
-					const correspondingLabel = Tools.getProperty(labels, i);
-					if (correspondingLabel) {
-						group = correspondingLabel;
-					} else {
-						group = "Ungrouped";
-					}
-				} else {
-					group = datasetLabel;
-				}
-
-				const updatedDatum = {
-					group,
-					key: labels[i]
-				};
-
-				if (isNaN(datum)) {
-					updatedDatum["value"] = datum.value;
-					updatedDatum["date"] = datum.date;
-				} else {
-					updatedDatum["value"] = datum;
-				}
-
-				tabularData.push(updatedDatum);
-			});
-		});
-
-		return tabularData;
-	}
-
-	protected getTabularData(data) {
-		// if data is not an array
-		if (!Array.isArray(data)) {
-			return this.transformToTabularData(data);
-		}
-
-		return data;
-	}
-
-	protected sanitize(data) {
-		return this.getTabularData(data);
-	}
-
 	getDisplayData() {
 		if (!this.get("data")) {
 			return null;
@@ -135,43 +76,6 @@ export class ChartModel {
 		});
 
 		return sanitizedData;
-	}
-
-	/*
-	 * Data groups
-	*/
-	protected updateAllDataGroups() {
-		// allDataGroups is used to generate a color scale that applies
-		// to all the groups. Now when the data updates, you might remove a group,
-		// and then bring it back in a newer data update, therefore
-		// the order of the groups in allDataGroups matters so that you'd never
-		// have an incorrect color assigned to a group.
-
-		// Also, a new group should only be added to allDataGroups if
-		// it doesn't currently exist
-
-		if (!this.allDataGroups) {
-			this.allDataGroups = this.getDataGroupNames();
-		} else {
-			// Loop through current data groups
-			this.getDataGroupNames().forEach(dataGroupName => {
-				// If group name hasn't been stored yet, store it
-				if (this.allDataGroups.indexOf(dataGroupName) === -1) {
-					this.allDataGroups.push(dataGroupName);
-				}
-			});
-		}
-	}
-
-	protected generateDataGroups(data) {
-		const { groupMapsTo } = this.getOptions().data;
-		const { ACTIVE } = Configuration.legend.items.status;
-
-		const uniqueDataGroups = map(data, datum => datum[groupMapsTo]).keys();
-		return uniqueDataGroups.map(groupName => ({
-			name: groupName,
-			status: ACTIVE
-		}));
 	}
 
 	getDataGroups() {
@@ -353,6 +257,142 @@ export class ChartModel {
 		});
 	}
 
+	/**
+	 * Should the data point be filled?
+	 * @param group
+	 * @param key
+	 * @param value
+	 * @param defaultFilled the default for this chart
+	 */
+	getIsFilled(group: any, key?: any, data?: any, defaultFilled?: boolean) {
+		const options = this.getOptions();
+		if (options.getIsFilled) {
+			return options.getIsFilled(group, key, data, defaultFilled);
+		} else {
+			return defaultFilled;
+		}
+	}
+
+	getFillColor(group: any, key?: any, data?: any) {
+		const options = this.getOptions();
+		const defaultFillColor = this.getFillScale()(group);
+		if (options.getFillColor) {
+			return options.getFillColor(group, key, data, defaultFillColor);
+		} else {
+			return defaultFillColor;
+		}
+	}
+
+	getStrokeColor(group: any, key?: any, data?: any) {
+		const options = this.getOptions();
+		const defaultStrokeColor = this.colorScale(group);
+		if (options.getStrokeColor) {
+			return options.getStrokeColor(group, key, data, defaultStrokeColor);
+		} else {
+			return defaultStrokeColor;
+		}
+	}
+
+	getFillScale() {
+		return this.colorScale;
+	}
+
+	/**
+	 * Converts data provided in the older format to tabular
+	 *
+	 */
+	protected transformToTabularData(data) {
+		console.warn("We've updated the charting data format to be tabular by default. The current format you're using is deprecated and will be removed in v1.0, read more here https://carbon-design-system.github.io/carbon-charts/?path=/story/tutorials--tabular-data-format")
+		const tabularData = [];
+		const { datasets, labels } = data;
+
+		// Loop through all datasets
+		datasets.forEach(dataset => {
+			// Update each data point to the new format
+			dataset.data.forEach((datum, i) => {
+				let group;
+
+				const datasetLabel = Tools.getProperty(dataset, "label");
+				if (datasetLabel === null) {
+					const correspondingLabel = Tools.getProperty(labels, i);
+					if (correspondingLabel) {
+						group = correspondingLabel;
+					} else {
+						group = "Ungrouped";
+					}
+				} else {
+					group = datasetLabel;
+				}
+
+				const updatedDatum = {
+					group,
+					key: labels[i]
+				};
+
+				if (isNaN(datum)) {
+					updatedDatum["value"] = datum.value;
+					updatedDatum["date"] = datum.date;
+				} else {
+					updatedDatum["value"] = datum;
+				}
+
+				tabularData.push(updatedDatum);
+			});
+		});
+
+		return tabularData;
+	}
+
+	protected getTabularData(data) {
+		// if data is not an array
+		if (!Array.isArray(data)) {
+			return this.transformToTabularData(data);
+		}
+
+		return data;
+	}
+
+	protected sanitize(data) {
+		return this.getTabularData(data);
+	}
+
+	/*
+	 * Data groups
+	*/
+	protected updateAllDataGroups() {
+		// allDataGroups is used to generate a color scale that applies
+		// to all the groups. Now when the data updates, you might remove a group,
+		// and then bring it back in a newer data update, therefore
+		// the order of the groups in allDataGroups matters so that you'd never
+		// have an incorrect color assigned to a group.
+
+		// Also, a new group should only be added to allDataGroups if
+		// it doesn't currently exist
+
+		if (!this.allDataGroups) {
+			this.allDataGroups = this.getDataGroupNames();
+		} else {
+			// Loop through current data groups
+			this.getDataGroupNames().forEach(dataGroupName => {
+				// If group name hasn't been stored yet, store it
+				if (this.allDataGroups.indexOf(dataGroupName) === -1) {
+					this.allDataGroups.push(dataGroupName);
+				}
+			});
+		}
+	}
+
+	protected generateDataGroups(data) {
+		const { groupMapsTo } = this.getOptions().data;
+		const { ACTIVE } = Configuration.legend.items.status;
+
+		const uniqueDataGroups = map(data, datum => datum[groupMapsTo]).keys();
+		return uniqueDataGroups.map(groupName => ({
+			name: groupName,
+			status: ACTIVE
+		}));
+	}
+
 	/*
 	 * Fill scales
 	*/
@@ -392,46 +432,6 @@ export class ChartModel {
 		});
 
 		this.colorScale = scaleOrdinal().range(colorRange)
-				.domain(this.allDataGroups);
-	}
-
-	/**
-	 * Should the data point be filled?
-	 * @param group
-	 * @param key
-	 * @param value
-	 * @param defaultFilled the default for this chart
-	 */
-	getIsFilled(group: any, key?: any, data?: any, defaultFilled?: boolean) {
-		const options = this.getOptions();
-		if (options.getIsFilled) {
-			return options.getIsFilled(group, key, data, defaultFilled);
-		} else {
-			return defaultFilled;
-		}
-	}
-
-	getFillColor(group: any, key?: any, data?: any) {
-		const options = this.getOptions();
-		const defaultFillColor = this.getFillScale()(group);
-		if (options.getFillColor) {
-			return options.getFillColor(group, key, data, defaultFillColor);
-		} else {
-			return defaultFillColor;
-		}
-	}
-
-	getStrokeColor(group: any, key?: any, data?: any) {
-		const options = this.getOptions();
-		const defaultStrokeColor = this.colorScale(group);
-		if (options.getStrokeColor) {
-			return options.getStrokeColor(group, key, data, defaultStrokeColor);
-		} else {
-			return defaultStrokeColor;
-		}
-	}
-
-	getFillScale() {
-		return this.colorScale;
+			.domain(this.allDataGroups);
 	}
 }

--- a/packages/core/src/services/scales-cartesian.ts
+++ b/packages/core/src/services/scales-cartesian.ts
@@ -85,57 +85,6 @@ export class CartesianScales extends Service {
 		});
 	}
 
-	protected findMainVerticalAxisPosition() {
-		const options = this.model.getOptions();
-		const axisOptions = Tools.getProperty(options, "axes");
-
-		// If right axis has been specified as `main`
-		if (Tools.getProperty(axisOptions, AxisPositions.RIGHT, "main") === true) {
-			return AxisPositions.RIGHT;
-		}
-
-		return AxisPositions.LEFT;
-	}
-
-	protected findMainHorizontalAxisPosition() {
-		const options = this.model.getOptions();
-		const axisOptions = Tools.getProperty(options, "axes");
-
-		// If top axis has been specified as `main`
-		if (Tools.getProperty(axisOptions, AxisPositions.TOP, "main") === true) {
-			return AxisPositions.TOP;
-		}
-
-		return AxisPositions.BOTTOM;
-	}
-
-	protected findDomainAndRangeAxesPositions(mainVerticalAxisPosition: AxisPositions, mainHorizontalAxisPosition: AxisPositions) {
-		const options = this.model.getOptions();
-
-		const mainVerticalAxisOptions = Tools.getProperty(options, "axes", mainVerticalAxisPosition);
-		const mainHorizontalAxisOptions = Tools.getProperty(options, "axes", mainHorizontalAxisPosition);
-
-		const mainVerticalScaleType = mainVerticalAxisOptions.scaleType || ScaleTypes.LINEAR;
-		const mainHorizontalScaleType = mainHorizontalAxisOptions.scaleType || ScaleTypes.LINEAR;
-
-		const result = {
-			domainAxisPosition: null,
-			rangeAxisPosition: null
-		};
-		if (mainHorizontalScaleType === ScaleTypes.LABELS || mainHorizontalScaleType === ScaleTypes.TIME) {
-			result.domainAxisPosition = mainHorizontalAxisPosition;
-			result.rangeAxisPosition = mainVerticalAxisPosition;
-		} else if (mainVerticalScaleType === ScaleTypes.LABELS || mainVerticalScaleType === ScaleTypes.TIME) {
-			result.domainAxisPosition = mainVerticalAxisPosition;
-			result.rangeAxisPosition = mainHorizontalAxisPosition;
-		} else {
-			result.domainAxisPosition = mainHorizontalAxisPosition;
-			result.rangeAxisPosition = mainVerticalAxisPosition;
-		}
-
-		return result;
-	}
-
 	findDomainAndRangeAxes() {
 		// find main axes between (left & right) && (bottom & top)
 		const mainVerticalAxisPosition = this.findMainVerticalAxisPosition();
@@ -262,6 +211,57 @@ export class CartesianScales extends Service {
 		return displayData.filter(datum => {
 			return datum[domainIdentifier] === domainValue;
 		});
+	}
+
+	protected findMainVerticalAxisPosition() {
+		const options = this.model.getOptions();
+		const axisOptions = Tools.getProperty(options, "axes");
+
+		// If right axis has been specified as `main`
+		if (Tools.getProperty(axisOptions, AxisPositions.RIGHT, "main") === true) {
+			return AxisPositions.RIGHT;
+		}
+
+		return AxisPositions.LEFT;
+	}
+
+	protected findMainHorizontalAxisPosition() {
+		const options = this.model.getOptions();
+		const axisOptions = Tools.getProperty(options, "axes");
+
+		// If top axis has been specified as `main`
+		if (Tools.getProperty(axisOptions, AxisPositions.TOP, "main") === true) {
+			return AxisPositions.TOP;
+		}
+
+		return AxisPositions.BOTTOM;
+	}
+
+	protected findDomainAndRangeAxesPositions(mainVerticalAxisPosition: AxisPositions, mainHorizontalAxisPosition: AxisPositions) {
+		const options = this.model.getOptions();
+
+		const mainVerticalAxisOptions = Tools.getProperty(options, "axes", mainVerticalAxisPosition);
+		const mainHorizontalAxisOptions = Tools.getProperty(options, "axes", mainHorizontalAxisPosition);
+
+		const mainVerticalScaleType = mainVerticalAxisOptions.scaleType || ScaleTypes.LINEAR;
+		const mainHorizontalScaleType = mainHorizontalAxisOptions.scaleType || ScaleTypes.LINEAR;
+
+		const result = {
+			domainAxisPosition: null,
+			rangeAxisPosition: null
+		};
+		if (mainHorizontalScaleType === ScaleTypes.LABELS || mainHorizontalScaleType === ScaleTypes.TIME) {
+			result.domainAxisPosition = mainHorizontalAxisPosition;
+			result.rangeAxisPosition = mainVerticalAxisPosition;
+		} else if (mainVerticalScaleType === ScaleTypes.LABELS || mainVerticalScaleType === ScaleTypes.TIME) {
+			result.domainAxisPosition = mainVerticalAxisPosition;
+			result.rangeAxisPosition = mainHorizontalAxisPosition;
+		} else {
+			result.domainAxisPosition = mainHorizontalAxisPosition;
+			result.rangeAxisPosition = mainVerticalAxisPosition;
+		}
+
+		return result;
 	}
 
 	protected getScaleDomain(axisPosition: AxisPositions) {


### PR DESCRIPTION
This PR solves some linting problems due to the arrangement of methods that did not respect with the following TSlint rule:

```json
"member-ordering": [
  true,
  {
  "order": [
    "public-static-field",
    "protected-static-field",
    "private-static-field",
    "public-static-method",
    "protected-static-method",
    "private-static-method",
    "public-instance-field",
    "protected-instance-field",
    "private-instance-field",
    "public-constructor",
    "protected-constructor",
    "private-constructor",
    "public-instance-method",
    "protected-instance-method",
    "private-instance-method"
    ]
  }
]
```

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/IBM/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)

@caesarsol 