### PR TITLE
fix vue type check for charting data

### DIFF
--- a/packages/vue/src/ccv-base-chart.vue
+++ b/packages/vue/src/ccv-base-chart.vue
@@ -7,7 +7,7 @@ export default {
 		};
 	},
 	props: {
-		data: { type: Object, required: true },
+		data: { type: [Object, Array], required: true },
 		options: { type: Object, required: true }
 	},
 	watch: {


### PR DESCRIPTION
Currently we're supporting the new tabular format (array-type) as well as the old object-based structure. We'll need to add this for now for Vue to allow both types, and in the future we'll only allow Arrays