### PR TITLE
Fix hover color logics for Bars hover

### DIFF
--- a/packages/core/src/components/graphs/bar-grouped.ts
+++ b/packages/core/src/components/graphs/bar-grouped.ts
@@ -145,12 +145,15 @@ export class GroupedBar extends Bar {
 
 	addEventListeners() {
 		const self = this;
+		const options = this.model.getOptions();
+		const { groupMapsTo } = options.data;
+
 		this.parent.selectAll("path.bar")
 			.on("mouseover", function(datum) {
 				const hoveredElement = select(this);
 
 				hoveredElement.transition(self.services.transitions.getTransition("graph_element_mouseover_fill_update"))
-					.attr("fill", color(hoveredElement.attr("fill")).darker(0.7).toString());
+					.attr("fill", (d: any) => color(self.model.getFillColor(d[groupMapsTo])).darker(0.7).toString());
 
 				// Dispatch mouse event
 				self.services.events.dispatchEvent(Events.Bar.BAR_MOUSEOVER, {

--- a/packages/core/src/components/graphs/bar-simple.ts
+++ b/packages/core/src/components/graphs/bar-simple.ts
@@ -103,7 +103,7 @@ export class SimpleBar extends Bar {
 				const hoveredElement = select(this);
 				hoveredElement.classed("hovered", true);
 				hoveredElement.transition(self.services.transitions.getTransition("graph_element_mouseover_fill_update"))
-					.attr("fill", color(hoveredElement.attr("fill")).darker(0.7).toString());
+					.attr("fill", (d: any) => color(self.model.getFillColor(d[groupMapsTo])).darker(0.7).toString());
 
 				// Dispatch mouse event
 				self.services.events.dispatchEvent(Events.Bar.BAR_MOUSEOVER, {

--- a/packages/core/src/components/graphs/bar-stacked.ts
+++ b/packages/core/src/components/graphs/bar-stacked.ts
@@ -138,7 +138,7 @@ export class StackedBar extends Bar {
 				const hoveredElement = select(this);
 
 				hoveredElement.transition(self.services.transitions.getTransition("graph_element_mouseover_fill_update"))
-					.attr("fill", color(hoveredElement.attr("fill")).darker(0.7).toString());
+					.attr("fill", (d: any) => color(self.model.getFillColor(d[groupMapsTo])).darker(0.7).toString());
 
 				// Dispatch mouse event
 				self.services.events.dispatchEvent(Events.Bar.BAR_MOUSEOVER, {


### PR DESCRIPTION
This fixes the bars color getting darker and darker until black, that @theiliad found during yesterday's call.
Since we removed the Ruler from the Combo chart the bug is not visible anywhere, but this was the root cause and we feel it's cleaner in this way.


### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/IBM/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
