### PR TITLE
hide invisible axes components

### DIFF
--- a/packages/core/src/styles/components/_axis.scss
+++ b/packages/core/src/styles/components/_axis.scss
@@ -3,6 +3,10 @@
 @import "./../vendor/@carbon/themes/scss/tokens";
 
 .#{$prefix}--#{$charts-prefix}--axes g.axis {
+	g.ticks.invisible {
+		visibility: hidden;
+	}
+
 	g.tick text {
 		fill: $text-02;
 		font-family: carbon--font-family("sans-condensed");


### PR DESCRIPTION
currently they're showing up with an opacity of 0, which would leave pointer-events enabled for them, so I added `visibility: hidden;`