### PR TITLE
fix(svelte): support Svelte CodeSandbox demos

### DIFF
--- a/packages/core/src/components/essentials/threshold.ts
+++ b/packages/core/src/components/essentials/threshold.ts
@@ -79,8 +79,8 @@ export class Threshold extends Component {
 
 		const { cartesianScales } = this.services;
 		const orientation = cartesianScales.getOrientation();
-		const getDomainValue = d => cartesianScales.getDomainValue(d);
-		const getRangeValue = d => cartesianScales.getRangeValue(d);
+		const getDomainValue = (d) => cartesianScales.getDomainValue(d);
+		const getRangeValue = (d) => cartesianScales.getRangeValue(d);
 		const [
 			getXValue,
 			getYValue,

--- a/packages/svelte/build.sh
+++ b/packages/svelte/build.sh
@@ -13,7 +13,7 @@ echo "bundling..."
 rollup -c
 
 # copy src directory for Svelte entry
-cp -r src/ dist/
+cp -r src/ dist/src
 
 echo "copying metadata"
 cp *.md dist/

--- a/packages/svelte/rollup.config.js
+++ b/packages/svelte/rollup.config.js
@@ -18,7 +18,7 @@ export default [
 			resolve(),
 			terser()
 		],
-		external: ["@carbon/charts"]
+		external: ["svelte", "@carbon/charts"]
 	},
 	{
 		input: "./src/index.js",
@@ -28,9 +28,8 @@ export default [
 		},
 		plugins: [
 			svelte(),
-			resolve(),
-			terser()
+			resolve()
 		],
-		external: ["@carbon/charts"]
+		external: ["svelte", "@carbon/charts"]
 	}
 ];

--- a/packages/svelte/src/BaseChart.svelte
+++ b/packages/svelte/src/BaseChart.svelte
@@ -6,17 +6,33 @@
   import { onMount, createEventDispatcher } from "svelte";
 
   const dispatch = createEventDispatcher();
+  const id = "chart-" + Math.random().toString(36);
 
   let ref = undefined;
   let chart = undefined;
 
   onMount(() => {
-    chart = new Chart(ref, { data, options });
-    dispatch("load", chart);
+    /**
+     * CodeSandbox does not resolve Svelte components from the `svelte` package.json entry.
+     * This causes `bind:ref` to be `undefined`; the chart can't mount to the element.
+     * 
+     * We fallback to manually querying the DOM for the chart holder element because
+     * CodeSandbox does not use uncompiled Svelte source code.
+     * 
+     * See https://github.com/sveltejs/svelte/issues/2937
+     */
+    const element = ref || document.getElementById(id);
+
+    if (element) {
+      chart = new Chart(element, { data, options });
+      dispatch("load", chart);
+    }
 
     return () => {
-      chart.destroy();
-      dispatch("destroy");
+      if (chart) {
+        chart.destroy();
+        dispatch("destroy");
+      }
     };
   });
 
@@ -27,4 +43,4 @@
   }
 </script>
 
-<div {...$$restProps} bind:this={ref} on:load on:update on:destroy />
+<div {...$$restProps} bind:this={ref} {id} />


### PR DESCRIPTION
**Description**

Currently, Svelte demos do not work in CodeSandbox.

This is caused because the `bind:this` directive used in [BaseChart.svelte](https://github.com/carbon-design-system/carbon-charts/blob/master/packages/svelte/src/BaseChart.svelte#L30) component is never defined. As a result, the chart does not mount to the DOM. This issue is [well documented](https://github.com/sveltejs/svelte/issues/2937).

However, this problem only occurs in the UMD and ESM build formats and if `svelte` cannot be de-duplicated in a Rollup/webpack set-up. Uncompiled Svelte source code works properly; the `bind:` directive works properly and `ref` grabs a reference to the div element.

CodeSandbox likely uses either the UMD (`main`) or ESM (`module`) package entries. For a typical Rollup or webpack set-up run locally, this bug does not occur because the uncompiled Svelte components are resolved from the `svelte` package.json field.

After a discussion with @theiliad , we desire a strategy that will fix the CodeSandbox demos while supporting the various build formats. This PR introduces a fix to the `svelte` wrappers so that demos can work in CodeSandbox.

**The solution is to manually query the DOM for the chart holder element.** If `bind:this` fails, we can still grab a reference to the underlying div element as a fallback.

This is a graceful solution because we still attempt to first use the `bind:this` directive.

**Testing**

I've tested the bundled UMD/ESM code locally; as expected, the manual DOM reference is used (`ref` is undefined).

In the Svelte Storybook, `bind:this` is executed properly and `ref` is defined (as expected).

### Updates
- feat: manually query chart holder element as a fallback
- build(svelte): copy svelte source folder to `dist/src`

### Demo screenshot or recording

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/IBM/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
