### PR TITLE
fix: add missing timescale option in AxisOptions interface

### DIFF
--- a/packages/core/src/interfaces/charts.ts
+++ b/packages/core/src/interfaces/charts.ts
@@ -10,6 +10,7 @@ import {
 	BarOptions,
 	StackedBarOptions,
 } from "./components";
+import { TimeScaleOptions } from "./axis-scales";
 
 /**
  * Base chart options common to any chart
@@ -109,6 +110,7 @@ export interface BaseChartOptions {
 export interface AxisChartOptions extends BaseChartOptions {
 	axes?: AxesOptions;
 	grid?: GridOptions;
+	timeScale?: TimeScaleOptions;
 	tooltip?: AxisTooltipOptions;
 }
 


### PR DESCRIPTION
### Updates
- #668 - add missing `timescale` option in `AxisOptions` interface
