### PR TITLE
fix(core): add tooltip to gauge chart

### DIFF
--- a/packages/core/src/charts/gauge.ts
+++ b/packages/core/src/charts/gauge.ts
@@ -7,8 +7,7 @@ import { Tools } from "../tools";
 // Components
 import {
 	Gauge,
-	// the imports below are needed because of typescript bug (error TS4029)
-	TooltipPie
+	Tooltip
 } from "../components/index";
 
 export class GaugeChart extends Chart {
@@ -33,6 +32,8 @@ export class GaugeChart extends Chart {
 		const graphFrameComponents = [new Gauge(this.model, this.services)];
 
 		const components: any[] = this.getChartComponents(graphFrameComponents);
+		components.push(new Tooltip(this.model, this.services));
+
 		return components;
 	}
 }


### PR DESCRIPTION
I noticed that tooltip was never added in with the gauge chart, it is needed for title truncation



### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
