### PR TITLE
feat(svelte): add Gauge chart wrapper

### DIFF
--- a/packages/svelte/src/GaugeChart.svelte
+++ b/packages/svelte/src/GaugeChart.svelte
@@ -1,0 +1,11 @@
+<script>
+  import { GaugeChart } from "@carbon/charts";
+  import BaseChart from "./BaseChart.svelte";
+</script>
+
+<BaseChart
+  {...$$restProps}
+  Chart={GaugeChart}
+  on:load
+  on:update
+  on:destroy />

--- a/packages/svelte/src/index.js
+++ b/packages/svelte/src/index.js
@@ -9,6 +9,7 @@ import LineChart from "./LineChart.svelte";
 import PieChart from "./PieChart.svelte";
 import ScatterChart from "./ScatterChart.svelte";
 import RadarChart from "./RadarChart.svelte";
+import GaugeChart from "./GaugeChart.svelte";
 
 export {
 	AreaChart,
@@ -21,5 +22,6 @@ export {
 	LineChart,
 	PieChart,
 	ScatterChart,
-	RadarChart
+	RadarChart,
+	GaugeChart,
 };


### PR DESCRIPTION
### Updates
- add Gauge chart wrapper for Svelte

### Demo screenshot or recording

<img width="994" alt="Screen Shot 2020-07-01 at 10 02 50 AM" src="https://user-images.githubusercontent.com/10718366/86272022-c694bb00-bb82-11ea-8fed-b65eb40fa7e3.png">

Verify the Gauge charts in the Storybook by running `yarn storybook`.

Verify the Svelte library can build by running `yarn build`.

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
