### PR TITLE
Avoid extra space between graphs and chart edge

### DIFF
--- a/packages/core/src/components/axes/axis.ts
+++ b/packages/core/src/components/axes/axis.ts
@@ -220,11 +220,11 @@ export class Axis extends Component {
 					let tickValues;
 					// scale.nice() will change scale domain which causes extra space near chart edge
 					// so use another scale instance to avoid impacts to original scale
-					const tmpScale = scale.copy();
+					const tempScale = scale.copy();
 					if (addSpaceOnEdges && !customDomain) {
-						tmpScale.nice(numberOfTicks);
+						tempScale.nice(numberOfTicks);
 					}
-					tickValues = tmpScale.ticks(numberOfTicks);
+					tickValues = tempScale.ticks(numberOfTicks);
 
 					// Remove labels on the edges
 					// If there are more than 2 labels to show

--- a/packages/core/src/components/axes/axis.ts
+++ b/packages/core/src/components/axes/axis.ts
@@ -209,7 +209,7 @@ export class Axis extends Component {
 						"timeScale",
 						"addSpaceOnEdges"
 					);
-					
+
 					const customDomain = Tools.getProperty(
 						options,
 						"axes",
@@ -218,14 +218,21 @@ export class Axis extends Component {
 					);
 
 					let tickValues;
+					// scale.nice() will change scale domain which causes extra space near chart edge
+					// so use another scale instance to avoid impacts to original scale
+					const tmpScale = scale.copy();
 					if (addSpaceOnEdges && !customDomain) {
-						tickValues = scale.nice(numberOfTicks);
+						tmpScale.nice(numberOfTicks);
 					}
-					tickValues = scale.ticks(numberOfTicks);
+					tickValues = tmpScale.ticks(numberOfTicks);
 
 					// Remove labels on the edges
 					// If there are more than 2 labels to show
-					if (addSpaceOnEdges && tickValues.length > 2 && !customDomain) {
+					if (
+						addSpaceOnEdges &&
+						tickValues.length > 2 &&
+						!customDomain
+					) {
 						tickValues.splice(tickValues.length - 1, 1);
 						tickValues.splice(0, 1);
 					}


### PR DESCRIPTION
### Updates
The d3 scale.nice() function changes the scale domain.
In some cases, this domain change will cause obvious extra space in addition to the space created by `addSpaceOnEdges` option.

Example data:
```
[
  {
    "group": "dataset 1",
    "date": "2020-07-14T02:07:00.000Z",
    "value": 3
  },
  {
    "group": "dataset 1",
    "date": "2020-07-14T18:07:01.538Z",
    "value": 7
  },
  {
    "group": "dataset 1",
    "date": "2020-07-15T10:07:03.076Z",
    "value": 14
  },
  {
    "group": "dataset 1",
    "date": "2020-07-16T02:07:04.614Z",
    "value": 0
  },
  {
    "group": "dataset 1",
    "date": "2020-07-16T18:07:06.152Z",
    "value": 3
  },
  {
    "group": "dataset 1",
    "date": "2020-07-17T10:07:07.690Z",
    "value": 3
  },
  {
    "group": "dataset 1",
    "date": "2020-07-18T02:07:09.228Z",
    "value": 0
  },
  {
    "group": "dataset 1",
    "date": "2020-07-18T18:07:10.766Z",
    "value": 8
  },
  {
    "group": "dataset 1",
    "date": "2020-07-19T10:07:12.304Z",
    "value": 6
  },
  {
    "group": "dataset 1",
    "date": "2020-07-20T02:07:13.842Z",
    "value": 0
  },
  {
    "group": "dataset 1",
    "date": "2020-07-20T18:07:15.380Z",
    "value": 7
  },
  {
    "group": "dataset 1",
    "date": "2020-07-21T10:07:16.918Z",
    "value": 6
  },
  {
    "group": "dataset 1",
    "date": "2020-07-22T02:07:18.456Z",
    "value": 0
  },
  {
    "group": "dataset 1",
    "date": "2020-07-22T18:07:19.994Z",
    "value": 9
  },
  {
    "group": "dataset 1",
    "date": "2020-07-23T10:07:21.532Z",
    "value": 6
  },
  {
    "group": "dataset 1",
    "date": "2020-07-24T02:07:23.070Z",
    "value": 0
  },
  {
    "group": "dataset 1",
    "date": "2020-07-24T18:07:24.608Z",
    "value": 9
  },
  {
    "group": "dataset 1",
    "date": "2020-07-25T10:07:26.146Z",
    "value": 6
  },
  {
    "group": "dataset 1",
    "date": "2020-07-26T02:07:27.684Z",
    "value": 0
  },
  {
    "group": "dataset 1",
    "date": "2020-07-26T18:07:29.222Z",
    "value": 3
  },
  {
    "group": "dataset 1",
    "date": "2020-07-27T10:07:30.760Z",
    "value": 6
  },
  {
    "group": "dataset 1",
    "date": "2020-07-28T02:07:32.298Z",
    "value": 0
  },
  {
    "group": "dataset 1",
    "date": "2020-07-28T18:07:33.836Z",
    "value": 9
  },
  {
    "group": "dataset 1",
    "date": "2020-07-29T10:07:35.374Z",
    "value": 8
  },
  {
    "group": "dataset 1",
    "date": "2020-07-30T02:07:36.912Z",
    "value": 0
  },
  {
    "group": "dataset 1",
    "date": "2020-07-30T18:07:38.450Z",
    "value": 8
  },
  {
    "group": "dataset 1",
    "date": "2020-07-31T10:07:39.988Z",
    "value": 0
  },
  {
    "group": "dataset 1",
    "date": "2020-08-01T02:07:41.526Z",
    "value": 9
  },
  {
    "group": "dataset 1",
    "date": "2020-08-01T18:07:43.064Z",
    "value": 9
  },
  {
    "group": "dataset 1",
    "date": "2020-08-02T10:07:44.602Z",
    "value": 0
  },
  {
    "group": "dataset 1",
    "date": "2020-08-03T02:07:46.140Z",
    "value": 9
  },
  {
    "group": "dataset 1",
    "date": "2020-08-03T18:07:47.678Z",
    "value": 11
  },
  {
    "group": "dataset 1",
    "date": "2020-08-04T10:07:49.216Z",
    "value": 0
  },
  {
    "group": "dataset 1",
    "date": "2020-08-05T02:07:50.754Z",
    "value": 7
  },
  {
    "group": "dataset 1",
    "date": "2020-08-05T18:07:52.292Z",
    "value": 5
  },
  {
    "group": "dataset 1",
    "date": "2020-08-06T10:07:53.830Z",
    "value": 0
  },
  {
    "group": "dataset 1",
    "date": "2020-08-07T02:07:55.368Z",
    "value": 10
  },
  {
    "group": "dataset 1",
    "date": "2020-08-07T18:07:56.906Z",
    "value": 12
  },
  {
    "group": "dataset 1",
    "date": "2020-08-08T10:07:58.444Z",
    "value": 0
  },
  {
    "group": "dataset 1",
    "date": "2020-08-09T02:07:59.982Z",
    "value": 7
  }
]
```


### Demo screenshot or recording
Before fix:
![image](https://user-images.githubusercontent.com/59426533/88520282-f15d1c80-d025-11ea-8192-f68aa35418c4.png)

After fix:
![image](https://user-images.githubusercontent.com/59426533/88519542-df2eae80-d024-11ea-9b12-f5751b7da3ea.png)

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
