### PR TITLE
Remove <title> element

### DIFF
--- a/packages/core/src/services/essentials/dom-utils.ts
+++ b/packages/core/src/services/essentials/dom-utils.ts
@@ -233,10 +233,6 @@ export class DOMUtils extends Service {
 			.attr("height", "100%")
 			.attr("width", "100%");
 
-		svg.append("title").text(
-			Tools.getProperty(options, "title") || "Chart"
-		);
-
 		this.svg = svg.node();
 	}
 


### PR DESCRIPTION
We need to temporarily take out this element and think of a better solution for having text alternatives for charts. When we add the `<title>` element we end up seeing a browser tooltip constantly when hovering on the chart