### PR TITLE
fix: fix tooltip position with zoom bar enabled

### DIFF
--- a/packages/core/src/components/essentials/tooltip.ts
+++ b/packages/core/src/components/essentials/tooltip.ts
@@ -208,7 +208,7 @@ export class Tooltip extends Component {
 	positionTooltip(e: CustomEvent) {
 		const holder = this.services.domUtils.getHolder();
 		const target = this.tooltip.node();
-		const isZoomBarEnabled = Tools.getProperty(
+		const isTopZoomBarEnabled = Tools.getProperty(
 			this.model.getOptions(),
 			"zoomBar",
 			"top",
@@ -221,7 +221,7 @@ export class Tooltip extends Component {
 		} else {
 			// if the mouse position is from event (ruler)
 			// we need add zoom bar height
-			if (isZoomBarEnabled) {
+			if (isTopZoomBarEnabled) {
 				mouseRelativePos[1] +=
 					Configuration.zoomBar.height +
 					Configuration.zoomBar.spacerHeight;

--- a/packages/core/src/components/essentials/tooltip.ts
+++ b/packages/core/src/components/essentials/tooltip.ts
@@ -12,6 +12,7 @@ import settings from "carbon-components/es/globals/js/settings";
 // D3 Imports
 import { select, mouse } from "d3-selection";
 import { TooltipPosition, Events, TruncationTypes } from "../../interfaces";
+import * as Configuration from "../../configuration";
 
 export class Tooltip extends Component {
 	type = "tooltip";
@@ -207,10 +208,26 @@ export class Tooltip extends Component {
 	positionTooltip(e: CustomEvent) {
 		const holder = this.services.domUtils.getHolder();
 		const target = this.tooltip.node();
+		const isZoomBarEnabled = Tools.getProperty(
+			this.model.getOptions(),
+			"zoomBar",
+			"top",
+			"enabled"
+		);
 
 		let mouseRelativePos = Tools.getProperty(e, "detail", "mousePosition");
 		if (!mouseRelativePos) {
 			mouseRelativePos = mouse(holder);
+		} else {
+			// if the mouse position is from event (ruler)
+			// we need add zoom bar height
+			if (isZoomBarEnabled) {
+				mouseRelativePos[1] +=
+					Configuration.zoomBar.height +
+					Configuration.zoomBar.spacerHeight;
+
+				// TODO - we need to add toolbar height when toolbar is available
+			}
 		}
 
 		let pos;


### PR DESCRIPTION
### Updates
- Fix the wrong ruler tooltip y position with zoom bar enabled
  - Add zoom bar height to tooltip y position if zoom bar is enabled

### Demo screenshot or recording
before:
![image](https://user-images.githubusercontent.com/59426533/89015562-d05c3a80-d349-11ea-9771-8dae0acfa0c1.png)


after:
![image](https://user-images.githubusercontent.com/59426533/89015309-680d5900-d349-11ea-8c5c-ca9a0ae58070.png)


### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
