### PR TITLE
fix: use enter().append() instead of join()

### DIFF
--- a/packages/core/src/components/axes/zoom-bar.ts
+++ b/packages/core/src/components/axes/zoom-bar.ts
@@ -293,13 +293,19 @@ export class ZoomBar extends Component {
 			.style("display", null); // always display
 
 		// handle-bar
-		svg.select(this.brushSelector)
+		const handleBars = svg
+			.select(this.brushSelector)
 			.selectAll("rect.handle-bar")
-			.data([{ type: "w" }, { type: "e" }])
-			.join("rect")
+			.data([{ type: "w" }, { type: "e" }]);
+		// create rect if not exists
+		handleBars
+			.enter()
+			.append("rect")
 			.attr("class", function (d) {
 				return "handle-bar handle-bar--" + d.type;
-			})
+			});
+		// update positions
+		handleBars
 			.attr("x", function (d) {
 				if (d.type === "w") {
 					return Math.max(


### PR DESCRIPTION
### Updates
.join() could causes some problems in typescript project.
Use enter().append() instead.

### Demo screenshot or recording

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
