### PR TITLE
feat(svelte): add Meter chart wrapper

### DIFF
--- a/packages/svelte/src/MeterChart.svelte
+++ b/packages/svelte/src/MeterChart.svelte
@@ -1,0 +1,6 @@
+<script>
+  import { MeterChart } from "@carbon/charts";
+  import BaseChart from "./BaseChart.svelte";
+</script>
+
+<BaseChart {...$$restProps} Chart={MeterChart} on:load on:update on:destroy />

--- a/packages/svelte/src/index.js
+++ b/packages/svelte/src/index.js
@@ -10,6 +10,7 @@ import PieChart from "./PieChart.svelte";
 import ScatterChart from "./ScatterChart.svelte";
 import RadarChart from "./RadarChart.svelte";
 import GaugeChart from "./GaugeChart.svelte";
+import MeterChart from "./MeterChart.svelte";
 
 export {
 	AreaChart,
@@ -24,4 +25,5 @@ export {
 	ScatterChart,
 	RadarChart,
 	GaugeChart,
+	MeterChart
 };


### PR DESCRIPTION
### Updates
- add Meter chart wrapper for Svelte

### Demo screenshot or recording

Run the storybook:

<img width="956" alt="Screen Shot 2020-08-12 at 2 44 19 PM" src="https://user-images.githubusercontent.com/10718366/90071578-ad674a00-dcaa-11ea-9c30-5a6ebc84ff28.png">


### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
