### PR TITLE
fix(core): separate out non-customizables in configuration.ts

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,31 +1,19 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 # [0.35.0](https://github.com/carbon-design-system/carbon-charts/compare/v0.34.11...v0.35.0) (2020-08-13)
 
 **Note:** Version bump only for package @carbon/charts
 
-
-
-
-
 ## [0.34.11](https://github.com/carbon-design-system/carbon-charts/compare/v0.34.10...v0.34.11) (2020-08-12)
 
 **Note:** Version bump only for package @carbon/charts
 
-
-
-
-
 ## [0.34.10](https://github.com/carbon-design-system/carbon-charts/compare/v0.34.9...v0.34.10) (2020-08-11)
 
 **Note:** Version bump only for package @carbon/charts
-
-
-
-
 
 # Change Log
 

--- a/packages/core/demo/data/index.ts
+++ b/packages/core/demo/data/index.ts
@@ -158,7 +158,7 @@ let allDemoGroups = [
 			{
 				options: barDemos.simpleBarCustomLegendOrderOptions,
 				data: barDemos.simpleBarData,
-				chartType: chartTypes.SimpleBarChart,
+				chartType: chartTypes.SimpleBarChart
 			},
 			{
 				options: barDemos.simpleBarCenteredLegendOptions,

--- a/packages/core/src/components/axes/axis.ts
+++ b/packages/core/src/components/axes/axis.ts
@@ -220,7 +220,7 @@ export class Axis extends Component {
 					numberOfTicks = this.getNumberOfFittingTicks(
 						height,
 						tickHeight,
-						Configuration.tickSpaceRatioVertical
+						Configuration.axis.ticks.verticalSpaceRatio
 					);
 				}
 			}
@@ -479,7 +479,7 @@ export class Axis extends Component {
 						this.getNumberOfFittingTicks(
 							width,
 							tickHeight,
-							Configuration.tickSpaceRatioHorizontal
+							Configuration.axis.ticks.horizontalSpaceRatio
 						)
 					);
 

--- a/packages/core/src/components/axes/grid.ts
+++ b/packages/core/src/components/axes/grid.ts
@@ -213,7 +213,6 @@ export class Grid extends Component {
 
 	cleanGrid(g) {
 		const options = this.model.getOptions();
-		g.selectAll("line").attr("stroke", options.grid.strokeColor);
 
 		// Remove extra elements
 		g.selectAll("text").remove();

--- a/packages/core/src/components/essentials/legend.ts
+++ b/packages/core/src/components/essentials/legend.ts
@@ -8,6 +8,7 @@ import {
 	TruncationTypes
 } from "../../interfaces";
 import { DOMUtils } from "../../services";
+import * as Configuration from "../../configuration";
 
 // D3 Imports
 import { select } from "d3-selection";
@@ -40,11 +41,11 @@ export class Legend extends Component {
 			.append("g")
 			.classed("legend-item", true)
 			.classed("active", function (d, i) {
-				return d.status === options.legend.items.status.ACTIVE;
+				return d.status === Configuration.legend.items.status.ACTIVE;
 			});
 
 		// Configs
-		const checkboxRadius = options.legend.checkbox.radius;
+		const checkboxRadius = Configuration.legend.checkbox.radius;
 
 		// Truncation
 		// get user provided custom values for truncation
@@ -73,12 +74,12 @@ export class Legend extends Component {
 			.attr("rx", 1)
 			.attr("ry", 1)
 			.style("fill", (d) => {
-				return d.status === options.legend.items.status.ACTIVE
+				return d.status === Configuration.legend.items.status.ACTIVE
 					? this.model.getStrokeColor(d.name)
 					: null;
 			})
 			.classed("active", function (d, i) {
-				return d.status === options.legend.items.status.ACTIVE;
+				return d.status === Configuration.legend.items.status.ACTIVE;
 			});
 		const addedLegendItemsText = addedLegendItems
 			.append("text")
@@ -134,8 +135,10 @@ export class Legend extends Component {
 
 	sortDataGroups(dataGroups, legendOrder) {
 		// Sort data in user defined order
-		dataGroups.sort((dataA, dataB) => 
-			legendOrder.indexOf(dataA.name) - legendOrder.indexOf(dataB.name)
+		dataGroups.sort(
+			(dataA, dataB) =>
+				legendOrder.indexOf(dataA.name) -
+				legendOrder.indexOf(dataB.name)
 		);
 
 		// If user only defined partial ordering, ordered items are placed before unordered ones
@@ -154,16 +157,17 @@ export class Legend extends Component {
 		const options = this.model.getOptions();
 
 		// Configs
-		const checkboxRadius = options.legend.checkbox.radius;
+		const checkboxRadius = Configuration.legend.checkbox.radius;
 		const legendItemsHorizontalSpacing =
-			options.legend.items.horizontalSpace;
-		const legendItemsVerticalSpacing = options.legend.items.verticalSpace;
-		const legendTextYOffset = options.legend.items.textYOffset;
+			Configuration.legend.items.horizontalSpace;
+		const legendItemsVerticalSpacing =
+			Configuration.legend.items.verticalSpace;
+		const legendTextYOffset = Configuration.legend.items.textYOffset;
 		const spaceNeededForCheckbox =
-			checkboxRadius * 2 + options.legend.checkbox.spaceAfter;
+			checkboxRadius * 2 + Configuration.legend.checkbox.spaceAfter;
 
 		// Check if there are disabled legend items
-		const { DISABLED } = options.legend.items.status;
+		const { DISABLED } = Configuration.legend.items.status;
 		const dataGroups = this.model.getDataGroups();
 		const hasDeactivatedItems = dataGroups.some(
 			(dataGroup) => dataGroup.status === DISABLED
@@ -327,7 +331,7 @@ export class Legend extends Component {
 				});
 
 				// Configs
-				const checkboxRadius = options.legend.checkbox.radius;
+				const checkboxRadius = Configuration.legend.checkbox.radius;
 				const hoveredItem = select(this);
 				hoveredItem
 					.append("rect")

--- a/packages/core/src/components/essentials/title-meter.ts
+++ b/packages/core/src/components/essentials/title-meter.ts
@@ -3,6 +3,7 @@ import { Title } from "./title";
 import { DOMUtils } from "../../services";
 import { Tools } from "../../tools";
 import { Statuses } from "./../../interfaces/enums";
+import * as Configuration from "../../configuration";
 
 export class MeterTitle extends Title {
 	type = "meter-title";
@@ -68,8 +69,7 @@ export class MeterTitle extends Title {
 
 		// get the status from the model
 		const status = this.model.getStatus();
-		const radius =
-			Tools.getProperty(options, "meter", "status", "indicatorSize") / 2;
+		const radius = Configuration.meter.status.indicatorSize / 2;
 
 		// create a group for the icon/inner path
 		const statusGroup = DOMUtils.appendOrSelect(svg, `g.status-indicator`)
@@ -127,12 +127,7 @@ export class MeterTitle extends Title {
 		const percentage = svg.selectAll("text.percent-value").data(data);
 
 		// the horizontal offset of the percentage value from the title
-		const offset = Tools.getProperty(
-			this.model.getOptions(),
-			"meter",
-			"statusBar",
-			"paddingRight"
-		);
+		const offset = Configuration.meter.statusBar.paddingRight;
 
 		percentage
 			.enter()
@@ -160,12 +155,7 @@ export class MeterTitle extends Title {
 
 		// update the position on the percentage to be inline with the title
 		const tspan = DOMUtils.appendOrSelect(this.parent, "tspan");
-		const offset = Tools.getProperty(
-			this.model.getOptions(),
-			"meter",
-			"statusBar",
-			"paddingRight"
-		);
+		const offset = Configuration.meter.statusBar.paddingRight;
 		const tspanLength = Math.ceil(tspan.node().getComputedTextLength());
 
 		const percentage = DOMUtils.appendOrSelect(
@@ -199,12 +189,7 @@ export class MeterTitle extends Title {
 			"text.percent-value"
 		);
 		// the title needs to fit the width of the container without crowding the status, and percentage value
-		const offset = Tools.getProperty(
-			this.model.getOptions(),
-			"meter",
-			"statusBar",
-			"paddingRight"
-		);
+		const offset = Configuration.meter.statusBar.paddingRight;
 		const percentageWidth = percentage.node().getComputedTextLength();
 
 		const statusGroup = DOMUtils.appendOrSelect(
@@ -213,12 +198,7 @@ export class MeterTitle extends Title {
 		).node();
 		const statusWidth =
 			DOMUtils.getSVGElementSize(statusGroup, { useBBox: true }).width +
-			Tools.getProperty(
-				this.model.getOptions(),
-				"meter",
-				"status",
-				"paddingLeft"
-			);
+			Configuration.meter.status.paddingLeft;
 
 		return containerWidth - percentageWidth - offset - statusWidth;
 	}

--- a/packages/core/src/components/essentials/tooltip.ts
+++ b/packages/core/src/components/essentials/tooltip.ts
@@ -2,6 +2,8 @@ import { Component } from "../component";
 import { Tools } from "../../tools";
 import { DOMUtils } from "../../services";
 import { ChartModel } from "../../model";
+import { Events, TruncationTypes } from "../../interfaces";
+import * as Configuration from "../../configuration";
 
 // Carbon position service
 import Position, { PLACEMENTS } from "@carbon/utils-position";
@@ -11,8 +13,6 @@ import settings from "carbon-components/es/globals/js/settings";
 
 // D3 Imports
 import { select, mouse } from "d3-selection";
-import { TooltipPosition, Events, TruncationTypes } from "../../interfaces";
-import * as Configuration from "../../configuration";
 
 export class Tooltip extends Component {
 	type = "tooltip";
@@ -58,7 +58,7 @@ export class Tooltip extends Component {
 		this.services.events.addEventListener(
 			Events.Tooltip.SHOW,
 			(e: CustomEvent) => {
-				const data = e.detail.data;
+				const data = e.detail.data || e.detail.items;
 				const defaultHTML = this.getTooltipHTML(e);
 
 				// if there is a provided tooltip HTML function call it
@@ -258,7 +258,7 @@ export class Tooltip extends Component {
 			})
 		);
 
-		let { horizontalOffset } = this.model.getOptions().tooltip;
+		let { horizontalOffset } = Configuration.tooltips;
 		if (bestPlacementOption === PLACEMENTS.LEFT) {
 			horizontalOffset *= -1;
 		}

--- a/packages/core/src/components/graphs/pie.ts
+++ b/packages/core/src/components/graphs/pie.ts
@@ -186,7 +186,9 @@ export class Pie extends Component {
 
 				// check if last 2 slices (or just last) are < the threshold
 				if (i >= totalSlices - 2) {
-					if (sliceAngleDeg < Configuration.pie.callout.minSliceDegree) {
+					if (
+						sliceAngleDeg < Configuration.pie.callout.minSliceDegree
+					) {
 						let labelTranslateX, labelTranslateY;
 						if (d.index === totalSlices - 1) {
 							labelTranslateX =
@@ -289,7 +291,10 @@ export class Pie extends Component {
 				// end position for the callout line
 				d.endPos = {
 					x: xPosition + Configuration.pie.callout.offsetX,
-					y: yPosition - Configuration.pie.callout.offsetY + d.textOffsetY
+					y:
+						yPosition -
+						Configuration.pie.callout.offsetY +
+						d.textOffsetY
 				};
 
 				// the intersection point of the vertical and horizontal line
@@ -305,7 +310,10 @@ export class Pie extends Component {
 				// end position for the callout line should be bottom aligned to the title
 				d.endPos = {
 					x: xPosition - Configuration.pie.callout.offsetX,
-					y: yPosition - Configuration.pie.callout.offsetY + d.textOffsetY
+					y:
+						yPosition -
+						Configuration.pie.callout.offsetY +
+						d.textOffsetY
 				};
 
 				// the intersection point of the vertical and horizontal line

--- a/packages/core/src/components/graphs/pie.ts
+++ b/packages/core/src/components/graphs/pie.ts
@@ -3,6 +3,7 @@ import { Component } from "../component";
 import { DOMUtils } from "../../services";
 import { Tools } from "../../tools";
 import { CalloutDirections, Roles, Events, Alignments } from "../../interfaces";
+import * as Configuration from "../../configuration";
 
 // D3 Imports
 import { select } from "d3-selection";
@@ -45,8 +46,7 @@ export class Pie extends Component {
 	}
 
 	getInnerRadius() {
-		const options = this.model.getOptions();
-		return options.pie.innerRadius;
+		return Configuration.pie.innerRadius;
 	}
 
 	render(animate = true) {
@@ -65,13 +65,13 @@ export class Pie extends Component {
 		// Set the hover arc radius
 		this.hoverArc = arc()
 			.innerRadius(this.getInnerRadius())
-			.outerRadius(radius + options.pie.hoverArc.outerRadiusOffset);
+			.outerRadius(radius + Configuration.pie.hoverArc.outerRadiusOffset);
 
 		// Setup the pie layout
 		const pieLayout = pie()
 			.value((d: any) => d.value)
 			.sort(null)
-			.padAngle(options.pie.padAngle);
+			.padAngle(Configuration.pie.padAngle);
 
 		// Sort pie layout data based off of the indecies the layout creates
 		const pieLayoutData = pieLayout(displayData).sort(
@@ -186,16 +186,16 @@ export class Pie extends Component {
 
 				// check if last 2 slices (or just last) are < the threshold
 				if (i >= totalSlices - 2) {
-					if (sliceAngleDeg < options.pie.callout.minSliceDegree) {
+					if (sliceAngleDeg < Configuration.pie.callout.minSliceDegree) {
 						let labelTranslateX, labelTranslateY;
 						if (d.index === totalSlices - 1) {
 							labelTranslateX =
 								d.xPosition +
-								options.pie.callout.offsetX +
-								options.pie.callout.textMargin +
+								Configuration.pie.callout.offsetX +
+								Configuration.pie.callout.textMargin +
 								d.textOffsetX;
 							labelTranslateY =
-								d.yPosition - options.pie.callout.offsetY;
+								d.yPosition - Configuration.pie.callout.offsetY;
 
 							// Set direction of callout
 							d.direction = CalloutDirections.RIGHT;
@@ -203,11 +203,11 @@ export class Pie extends Component {
 						} else {
 							labelTranslateX =
 								d.xPosition -
-								options.pie.callout.offsetX -
+								Configuration.pie.callout.offsetX -
 								d.textOffsetX -
-								options.pie.callout.textMargin;
+								Configuration.pie.callout.textMargin;
 							labelTranslateY =
-								d.yPosition - options.pie.callout.offsetY;
+								d.yPosition - Configuration.pie.callout.offsetY;
 
 							// Set direction of callout
 							d.direction = CalloutDirections.LEFT;
@@ -234,16 +234,16 @@ export class Pie extends Component {
 		});
 
 		// Position Pie
-		let pieTranslateX = radius + options.pie.xOffset;
+		let pieTranslateX = radius + Configuration.pie.xOffset;
 		if (alignment === Alignments.CENTER) {
 			pieTranslateX = width / 2;
 		} else if (alignment === Alignments.RIGHT) {
-			pieTranslateX = width - radius - options.pie.xOffset;
+			pieTranslateX = width - radius - Configuration.pie.xOffset;
 		}
 
-		let pieTranslateY = radius + options.pie.yOffset;
+		let pieTranslateY = radius + Configuration.pie.yOffset;
 		if (calloutData.length > 0) {
-			pieTranslateY += options.pie.yOffsetCallout;
+			pieTranslateY += Configuration.pie.yOffsetCallout;
 		}
 
 		svg.attr("transform", `translate(${pieTranslateX}, ${pieTranslateY})`);
@@ -288,13 +288,13 @@ export class Pie extends Component {
 
 				// end position for the callout line
 				d.endPos = {
-					x: xPosition + options.pie.callout.offsetX,
-					y: yPosition - options.pie.callout.offsetY + d.textOffsetY
+					x: xPosition + Configuration.pie.callout.offsetX,
+					y: yPosition - Configuration.pie.callout.offsetY + d.textOffsetY
 				};
 
 				// the intersection point of the vertical and horizontal line
 				d.intersectPointX =
-					d.endPos.x - options.pie.callout.horizontalLineLength;
+					d.endPos.x - Configuration.pie.callout.horizontalLineLength;
 			} else {
 				// start position for the callout line
 				d.startPos = {
@@ -304,13 +304,13 @@ export class Pie extends Component {
 
 				// end position for the callout line should be bottom aligned to the title
 				d.endPos = {
-					x: xPosition - options.pie.callout.offsetX,
-					y: yPosition - options.pie.callout.offsetY + d.textOffsetY
+					x: xPosition - Configuration.pie.callout.offsetX,
+					y: yPosition - Configuration.pie.callout.offsetY + d.textOffsetY
 				};
 
 				// the intersection point of the vertical and horizontal line
 				d.intersectPointX =
-					d.endPos.x + options.pie.callout.horizontalLineLength;
+					d.endPos.x + Configuration.pie.callout.horizontalLineLength;
 			}
 
 			// Store the necessary data in the DOM element
@@ -464,6 +464,6 @@ export class Pie extends Component {
 		});
 		const radius: number = Math.min(width, height) / 2;
 
-		return radius + options.pie.radiusOffset;
+		return radius + Configuration.pie.radiusOffset;
 	}
 }

--- a/packages/core/src/components/graphs/radar.ts
+++ b/packages/core/src/components/graphs/radar.ts
@@ -11,6 +11,7 @@ import {
 	polarToCartesianCoords,
 	distanceBetweenPointOnCircAndVerticalDiameter
 } from "../../services/angle-utils";
+import * as Configuration from "../../configuration";
 
 // D3 Imports
 import { select } from "d3-selection";
@@ -61,9 +62,8 @@ export class Radar extends Component {
 			yLabelPadding,
 			yTicksNumber,
 			minRange,
-			xAxisRectHeight,
-			opacity
-		} = Tools.getProperty(options, "radar");
+			xAxisRectHeight
+		} = Configuration.radar;
 
 		this.uniqueKeys = Array.from(new Set(data.map((d) => d[angle])));
 		this.uniqueGroups = Array.from(
@@ -201,92 +201,6 @@ export class Radar extends Component {
 						)
 						.attr("d", (tick) =>
 							radialLineGenerator(shapeData(tick))
-						)
-						.attr("opacity", 0)
-						.remove()
-				)
-		);
-
-		// y labels (show only the min and the max labels)
-		const yLabels = DOMUtils.appendOrSelect(svg, "g.y-labels").attr(
-			"role",
-			Roles.GROUP
-		);
-		const yLabelUpdate = yLabels.selectAll("text").data(extent(yTicks));
-		yLabelUpdate.join(
-			(enter) =>
-				enter
-					.append("text")
-					.attr("opacity", 0)
-					.text((tick) => tick)
-					.attr(
-						"x",
-						(tick) =>
-							polarToCartesianCoords(
-								-Math.PI / 2,
-								yScale(tick),
-								c
-							).x + yLabelPadding
-					)
-					.attr(
-						"y",
-						(tick) =>
-							polarToCartesianCoords(
-								-Math.PI / 2,
-								yScale(tick),
-								c
-							).y
-					)
-					.style("text-anchor", "start")
-					.style("dominant-baseline", "middle")
-					.call((selection) =>
-						selection
-							.transition(
-								this.services.transitions.getTransition(
-									"radar_y_labels_enter",
-									animate
-								)
-							)
-							.attr("opacity", 1)
-					),
-			(update) =>
-				update.call((selection) =>
-					selection
-						.transition(
-							this.services.transitions.getTransition(
-								"radar_y_labels_update",
-								animate
-							)
-						)
-						.text((tick) => tick)
-						.attr("opacity", 1)
-						.attr(
-							"x",
-							(tick) =>
-								polarToCartesianCoords(
-									-Math.PI / 2,
-									yScale(tick),
-									c
-								).x + yLabelPadding
-						)
-						.attr(
-							"y",
-							(tick) =>
-								polarToCartesianCoords(
-									-Math.PI / 2,
-									yScale(tick),
-									c
-								).y
-						)
-				),
-			(exit) =>
-				exit.call((selection) =>
-					selection
-						.transition(
-							this.services.transitions.getTransition(
-								"radar_y_labels_exit",
-								animate
-							)
 						)
 						.attr("opacity", 0)
 						.remove()
@@ -541,7 +455,7 @@ export class Radar extends Component {
 					.attr("opacity", 0)
 					.attr("transform", `translate(${c.x}, ${c.y})`)
 					.attr("fill", (group) => colorScale(group.name))
-					.style("fill-opacity", opacity.selected)
+					.style("fill-opacity", Configuration.radar.opacity.selected)
 					.attr("stroke", (group) => colorScale(group.name))
 					.attr("d", (group) => oldRadialLineGenerator(group.data))
 					.call((selection) =>
@@ -649,6 +563,92 @@ export class Radar extends Component {
 				(key) => `rotate(${radToDeg(xScale(key))}, ${c.x}, ${c.y})`
 			);
 
+		// y labels (show only the min and the max labels)
+		const yLabels = DOMUtils.appendOrSelect(svg, "g.y-labels").attr(
+			"role",
+			Roles.GROUP
+		);
+		const yLabelUpdate = yLabels.selectAll("text").data(extent(yTicks));
+		yLabelUpdate.join(
+			(enter) =>
+				enter
+					.append("text")
+					.attr("opacity", 0)
+					.text((tick) => tick)
+					.attr(
+						"x",
+						(tick) =>
+							polarToCartesianCoords(
+								-Math.PI / 2,
+								yScale(tick),
+								c
+							).x + yLabelPadding
+					)
+					.attr(
+						"y",
+						(tick) =>
+							polarToCartesianCoords(
+								-Math.PI / 2,
+								yScale(tick),
+								c
+							).y
+					)
+					.style("text-anchor", "start")
+					.style("dominant-baseline", "middle")
+					.call((selection) =>
+						selection
+							.transition(
+								this.services.transitions.getTransition(
+									"radar_y_labels_enter",
+									animate
+								)
+							)
+							.attr("opacity", 1)
+					),
+			(update) =>
+				update.call((selection) =>
+					selection
+						.transition(
+							this.services.transitions.getTransition(
+								"radar_y_labels_update",
+								animate
+							)
+						)
+						.text((tick) => tick)
+						.attr("opacity", 1)
+						.attr(
+							"x",
+							(tick) =>
+								polarToCartesianCoords(
+									-Math.PI / 2,
+									yScale(tick),
+									c
+								).x + yLabelPadding
+						)
+						.attr(
+							"y",
+							(tick) =>
+								polarToCartesianCoords(
+									-Math.PI / 2,
+									yScale(tick),
+									c
+								).y
+						)
+				),
+			(exit) =>
+				exit.call((selection) =>
+					selection
+						.transition(
+							this.services.transitions.getTransition(
+								"radar_y_labels_exit",
+								animate
+							)
+						)
+						.attr("opacity", 0)
+						.remove()
+				)
+		);
+
 		const alignment = Tools.getProperty(options, "radar", "alignment");
 
 		const alignmentOffset = DOMUtils.getAlignmentOffset(
@@ -717,11 +717,6 @@ export class Radar extends Component {
 
 	handleLegendOnHover = (event: CustomEvent) => {
 		const { hoveredElement } = event.detail;
-		const opacity = Tools.getProperty(
-			this.model.getOptions(),
-			"radar",
-			"opacity"
-		);
 		this.parent
 			.selectAll("g.blobs path")
 			.transition(
@@ -729,9 +724,9 @@ export class Radar extends Component {
 			)
 			.style("fill-opacity", (group) => {
 				if (group.name !== hoveredElement.datum().name) {
-					return Tools.getProperty(opacity, "unselected");
+					return Configuration.radar.opacity.unselected;
 				}
-				return Tools.getProperty(opacity, "selected");
+				return Configuration.radar.opacity.selected;
 			});
 	};
 
@@ -771,8 +766,7 @@ export class Radar extends Component {
 	addEventListeners() {
 		const self = this;
 		const {
-			axes: { angle },
-			dotsRadius
+			axes: { angle }
 		} = Tools.getProperty(this.model.getOptions(), "radar");
 
 		// events on x axes rects
@@ -803,7 +797,7 @@ export class Radar extends Component {
 					.attr("stroke-dasharray", "4 4");
 				dots.classed("hovered", true)
 					.attr("opacity", 1)
-					.attr("r", dotsRadius);
+					.attr("r", Configuration.radar.dotsRadius);
 
 				// get the items that should be highlighted
 				const itemsToHighlight = self.displayDataNormalized.filter(

--- a/packages/core/src/configuration-non-customizable.ts
+++ b/packages/core/src/configuration-non-customizable.ts
@@ -1,0 +1,122 @@
+import { ZoomBarTypes } from "./interfaces";
+
+export const area = {
+	opacity: {
+		unselected: 0,
+		selected: 0.4
+	}
+};
+
+export const axis = {
+	ticks: {
+		number: 7,
+		rotateIfSmallerThan: 30,
+		verticalSpaceRatio: 2.5,
+		horizontalSpaceRatio: 3.5
+	},
+	paddingRatio: 0.1
+};
+
+export const legend = {
+	items: {
+		status: {
+			ACTIVE: 1,
+			DISABLED: 0
+		},
+		horizontalSpace: 12,
+		verticalSpace: 24,
+		textYOffset: 8
+	},
+	checkbox: {
+		radius: 6.5,
+		spaceAfter: 4
+	}
+};
+
+export const lines = {
+	opacity: {
+		unselected: 0.3,
+		selected: 1
+	}
+};
+
+export const meter = {
+	statusBar: {
+		paddingRight: 5
+	},
+	status: {
+		indicatorSize: 16,
+		paddingLeft: 15
+	}
+};
+
+export const pie = {
+	radiusOffset: -15,
+	innerRadius: 2,
+	padAngle: 0.007,
+	hoverArc: {
+		outerRadiusOffset: 3
+	},
+	xOffset: 30,
+	yOffset: 20,
+	yOffsetCallout: 10,
+	callout: {
+		minSliceDegree: 5,
+		offsetX: 15,
+		offsetY: 12,
+		horizontalLineLength: 8,
+		textMargin: 2
+	}
+};
+
+export const radar = {
+	opacity: {
+		unselected: 0.1,
+		selected: 0.3
+	},
+	xLabelPadding: 10,
+	yLabelPadding: 8,
+	yTicksNumber: 4,
+	minRange: 10,
+	xAxisRectHeight: 50,
+	dotsRadius: 5
+};
+
+export const spacers = {
+	default: {
+		size: 24
+	}
+};
+
+export const tooltips = {
+	horizontalOffset: 10
+};
+
+/**
+ * Base transition configuration
+ */
+export const transitions = {
+	default: {
+		duration: 300
+	},
+	pie_slice_mouseover: {
+		duration: 100
+	},
+	pie_chart_titles: {
+		duration: 375
+	},
+	graph_element_mouseover_fill_update: {
+		duration: 100
+	},
+	graph_element_mouseout_fill_update: {
+		duration: 100
+	}
+};
+
+export const zoomBar = {
+	height: {
+		[ZoomBarTypes.GRAPH_VIEW]: 32,
+		[ZoomBarTypes.SLIDER_VIEW]: 10
+	},
+	spacerHeight: 8
+};

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -48,23 +48,10 @@ const standardTruncationOptions = {
 /**
  * Legend options
  */
-export const legend: LegendOptions = {
+const legend: LegendOptions = {
 	enabled: true,
 	position: LegendPositions.BOTTOM,
 	clickable: true,
-	items: {
-		status: {
-			ACTIVE: 1,
-			DISABLED: 0
-		},
-		horizontalSpace: 12,
-		verticalSpace: 24,
-		textYOffset: 8
-	},
-	checkbox: {
-		radius: 6.5,
-		spaceAfter: 4
-	},
 	truncation: standardTruncationOptions,
 	alignment: Alignments.LEFT,
 	order: null
@@ -75,7 +62,7 @@ export const legend: LegendOptions = {
  */
 export const grid: GridOptions = {
 	x: {
-		numberOfTicks: 5
+		numberOfTicks: 15
 	},
 	y: {
 		numberOfTicks: 5
@@ -86,7 +73,6 @@ export const grid: GridOptions = {
  * Tooltip options
  */
 export const baseTooltip: TooltipOptions = {
-	horizontalOffset: 10,
 	showTotal: true,
 	valueFormatter: (d) => d.toLocaleString(),
 	truncation: standardTruncationOptions
@@ -269,22 +255,6 @@ const bubbleChart: BubbleChartOptions = Tools.merge({}, axisChart, {
  */
 const pieChart: PieChartOptions = Tools.merge({}, chart, {
 	pie: {
-		radiusOffset: -15,
-		innerRadius: 2,
-		padAngle: 0.007,
-		hoverArc: {
-			outerRadiusOffset: 3
-		},
-		xOffset: 30,
-		yOffset: 20,
-		yOffsetCallout: 10,
-		callout: {
-			minSliceDegree: 5,
-			offsetX: 15,
-			offsetY: 12,
-			horizontalLineLength: 8,
-			textMargin: 2
-		},
 		labels: {
 			formatter: null
 		},
@@ -340,17 +310,12 @@ const meterChart: MeterChartOptions = Tools.merge({}, chart, {
 	meter: {
 		height: 8,
 		statusBar: {
-			paddingRight: 5,
 			percentageIndicator: {
 				enabled: true
 			}
 		},
-		status: {
-			indicatorSize: 16,
-			paddingLeft: 15
-		}
 	}
-});
+} as MeterChartOptions);
 
 /**
  * options specific to radar charts
@@ -361,16 +326,6 @@ const radarChart: RadarChartOptions = Tools.merge({}, chart, {
 			angle: "key",
 			value: "value"
 		},
-		opacity: {
-			unselected: 0.1,
-			selected: 0.3
-		},
-		xLabelPadding: 10,
-		yLabelPadding: 8,
-		yTicksNumber: 4,
-		minRange: 10,
-		xAxisRectHeight: 50,
-		dotsRadius: 5,
 		alignment: Alignments.LEFT
 	},
 	tooltip: {
@@ -400,78 +355,4 @@ export const options = {
 	gaugeChart
 };
 
-/**
- * Options for line behaviour
- */
-export const lines = {
-	opacity: {
-		unselected: 0.3,
-		selected: 1
-	}
-};
-
-/**
- * Options for area behaviour
- */
-export const area = {
-	opacity: {
-		unselected: 0,
-		selected: 0.4
-	}
-};
-
-/**
- * Options for area behaviour
- */
-export const areas = {
-	opacity: {
-		unselected: 0.3,
-		selected: 1
-	}
-};
-
-/**
- * Base transition configuration
- */
-export const transitions = {
-	default: {
-		duration: 300
-	},
-	pie_slice_mouseover: {
-		duration: 100
-	},
-	pie_chart_titles: {
-		duration: 375
-	},
-	graph_element_mouseover_fill_update: {
-		duration: 100
-	},
-	graph_element_mouseout_fill_update: {
-		duration: 100
-	}
-};
-
-export const axis = {
-	ticks: {
-		number: 7,
-		rotateIfSmallerThan: 30
-	},
-	paddingRatio: 0.1
-};
-
-export const spacers = {
-	default: {
-		size: 24
-	}
-};
-
-export const zoomBar = {
-	height: {
-		[ZoomBarTypes.GRAPH_VIEW]: 32,
-		[ZoomBarTypes.SLIDER_VIEW]: 10
-	},
-	spacerHeight: 8
-};
-
-export const tickSpaceRatioVertical = 2.5;
-export const tickSpaceRatioHorizontal = 3.5;
+export * from "./configuration-non-customizable";

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -313,7 +313,7 @@ const meterChart: MeterChartOptions = Tools.merge({}, chart, {
 			percentageIndicator: {
 				enabled: true
 			}
-		},
+		}
 	}
 } as MeterChartOptions);
 

--- a/packages/core/src/interfaces/charts.ts
+++ b/packages/core/src/interfaces/charts.ts
@@ -221,22 +221,6 @@ export interface StackedAreaChartOptions extends ScatterChartOptions {
  */
 export interface PieChartOptions extends BaseChartOptions {
 	pie?: {
-		radiusOffset?: number;
-		innerRadius?: number;
-		padAngle?: number;
-		hoverArc?: {
-			outerRadiusOffset?: number;
-		};
-		xOffset?: number;
-		yOffset?: number;
-		yOffsetCallout?: number;
-		callout?: {
-			minSliceDegree?: number;
-			offsetX?: number;
-			offsetY?: number;
-			horizontalLineLength?: number;
-			textMargin?: number;
-		};
 		labels?: {
 			formatter?: Function;
 		};
@@ -284,20 +268,12 @@ export interface MeterChartOptions extends BaseChartOptions {
 	meter?: {
 		height?: number;
 		title?: {
-			/**
-			 * offsets the percentage value from the title
-			 */
-			paddingRight?: number;
 			percentageIndicator?: {
 				/**
 				 * rendering of the percentage value relative to the dataset within title
 				 */
 				enabled?: boolean;
 			};
-		};
-		status?: {
-			indicatorSize?: number;
-			paddingLeft?: number;
 		};
 	};
 }
@@ -307,20 +283,10 @@ export interface MeterChartOptions extends BaseChartOptions {
  */
 export interface RadarChartOptions extends BaseChartOptions {
 	radar?: {
-		opacity: {
-			unselected: number;
-			selected: number;
-		};
 		axes: {
 			angle: string;
 			value: string;
 		};
-		xLabelPadding: number;
-		yLabelPadding: number;
-		yTicksNumber: number;
-		minRange: number;
-		xAxisRectHeight: number;
-		dotsRadius: number;
 		alignment?: Alignments;
 	};
 }

--- a/packages/core/src/interfaces/components.ts
+++ b/packages/core/src/interfaces/components.ts
@@ -39,19 +39,6 @@ export interface LegendOptions {
 	 * the clickability of legend items
 	 */
 	clickable?: boolean;
-	items?: {
-		status?: {
-			ACTIVE?: number;
-			DISABLED?: number;
-		};
-		horizontalSpace?: number;
-		verticalSpace?: number;
-		textYOffset?: number;
-	};
-	checkbox?: {
-		radius?: number;
-		spaceAfter?: number;
-	};
 	truncation?: TruncationOptions;
 	alignment?: Alignments;
 	order?: string[];
@@ -67,10 +54,6 @@ export interface TooltipOptions {
 	 * passed an array or object with the data, and then the default tooltip markup
 	 */
 	customHTML?: Function;
-	/**
-	 * offset of the tooltip from the mouse position
-	 */
-	horizontalOffset?: number;
 	/**
 	 * show total of items
 	 */
@@ -107,7 +90,6 @@ export interface GridOptions {
 	x?: {
 		numberOfTicks?: number;
 	};
-	strokeColor?: string;
 }
 
 export interface BarOptions {

--- a/packages/core/src/interfaces/enums.ts
+++ b/packages/core/src/interfaces/enums.ts
@@ -61,15 +61,6 @@ export enum ScaleTypes {
 }
 
 /**
- * enum of supported tooltip position relative to
- */
-export enum TooltipPosition {
-	MOUSE = "mouse",
-	TOP = "top",
-	BOTTOM = "bottom"
-}
-
-/**
  * enum of all possible legend positions
  */
 export enum LegendPositions {

--- a/packages/core/src/model.ts
+++ b/packages/core/src/model.ts
@@ -95,7 +95,9 @@ export class ChartModel {
 
 		return allDataFromDomain.filter((datum) => {
 			return dataGroups.find(
-				(dataGroup) => dataGroup.name === datum[groupMapsTo] && dataGroup.status === ACTIVE
+				(dataGroup) =>
+					dataGroup.name === datum[groupMapsTo] &&
+					dataGroup.status === ACTIVE
 			);
 		});
 	}

--- a/packages/vue/CHANGELOG.md
+++ b/packages/vue/CHANGELOG.md
@@ -7,25 +7,13 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @carbon/charts-vue
 
-
-
-
-
 ## [0.34.11](https://github.com/carbon-design-system/carbon-charts/compare/v0.34.10...v0.34.11) (2020-08-12)
 
 **Note:** Version bump only for package @carbon/charts-vue
 
-
-
-
-
 ## [0.34.10](https://github.com/carbon-design-system/carbon-charts/compare/v0.34.9...v0.34.10) (2020-08-11)
 
 **Note:** Version bump only for package @carbon/charts-vue
-
-
-
-
 
 ## [0.34.9](https://github.com/carbon-design-system/carbon-charts/compare/v0.34.8...v0.34.9) (2020-08-06)
 


### PR DESCRIPTION
This had been long overdue. I've separated out anything that shouldn't be customized into a separate `configuration-non-customizables.ts` file