### PR TITLE
feat: change zoom bar handle cursor to ew-resize

### DIFF
--- a/packages/core/src/components/axes/zoom-bar.ts
+++ b/packages/core/src/components/axes/zoom-bar.ts
@@ -304,6 +304,8 @@ export class ZoomBar extends Component {
 		const handleBarXDiff = -handleBarWidth / 2;
 		const handleYBarDiff = (handleHeight - handleBarHeight) / 2;
 
+		const ewHandleCursor = "ew-resize";
+
 		// handle
 		svg.select(this.brushSelector)
 			.selectAll("rect.handle")
@@ -326,7 +328,7 @@ export class ZoomBar extends Component {
 			.attr("y", 0)
 			.attr("width", handleWidth)
 			.attr("height", handleHeight)
-			.attr("cursor", "pointer")
+			.attr("cursor", ewHandleCursor)
 			.style("display", null); // always display
 
 		// handle-bar
@@ -359,7 +361,7 @@ export class ZoomBar extends Component {
 			.attr("y", handleYBarDiff)
 			.attr("width", handleBarWidth)
 			.attr("height", handleBarHeight)
-			.attr("cursor", "pointer");
+			.attr("cursor", ewHandleCursor);
 
 		// Update slider selected area
 		if (zoombarType === ZoomBarTypes.SLIDER_VIEW) {

--- a/packages/core/src/components/axes/zoom-bar.ts
+++ b/packages/core/src/components/axes/zoom-bar.ts
@@ -304,8 +304,6 @@ export class ZoomBar extends Component {
 		const handleBarXDiff = -handleBarWidth / 2;
 		const handleYBarDiff = (handleHeight - handleBarHeight) / 2;
 
-		const ewHandleCursor = "ew-resize";
-
 		// handle
 		svg.select(this.brushSelector)
 			.selectAll("rect.handle")
@@ -328,7 +326,7 @@ export class ZoomBar extends Component {
 			.attr("y", 0)
 			.attr("width", handleWidth)
 			.attr("height", handleHeight)
-			.attr("cursor", ewHandleCursor)
+			.attr("cursor", "ew-resize")
 			.style("display", null); // always display
 
 		// handle-bar
@@ -361,7 +359,7 @@ export class ZoomBar extends Component {
 			.attr("y", handleYBarDiff)
 			.attr("width", handleBarWidth)
 			.attr("height", handleBarHeight)
-			.attr("cursor", ewHandleCursor);
+			.attr("cursor", "ew-resize");
 
 		// Update slider selected area
 		if (zoombarType === ZoomBarTypes.SLIDER_VIEW) {


### PR DESCRIPTION
### Updates
Since the tooltip for zoom bar handle was cancelled, it makes more sense to change the zoom bar handle cursor from pointer to ew-resize.


### Demo screenshot or recording

![image](https://user-images.githubusercontent.com/59426533/91026764-c5858480-e62d-11ea-9c25-96f3a3b390fd.png)


### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
