### PR TITLE
fix: avoid duplicate spacer

### DIFF
--- a/packages/core/src/components/layout/spacer.ts
+++ b/packages/core/src/components/layout/spacer.ts
@@ -1,13 +1,13 @@
 // Internal Imports
 import { Component } from "../component";
+import { DOMUtils } from "../../services";
 import * as Configuration from "../../configuration";
 
 export class Spacer extends Component {
 	type = "spacer";
 
 	render() {
-		this.getContainerSVG()
-			.append("rect")
+		DOMUtils.appendOrSelect(this.getContainerSVG(), "rect")
 			.attr("x", 0)
 			.attr("y", 0)
 			.attr(


### PR DESCRIPTION
### Updates
Use DOMUtils.appendOrSelect() to avoid duplicate spacer component.

### Demo screenshot or recording
No UI impact.

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
