### PR TITLE
fix: stacked scatter tooltip not show

### DIFF
--- a/packages/core/src/components/graphs/scatter-stacked.ts
+++ b/packages/core/src/components/graphs/scatter-stacked.ts
@@ -66,4 +66,48 @@ export class StackedScatter extends Scatter {
 		// Add event listeners to elements drawn
 		this.addEventListeners();
 	}
+
+	getTooltipData(hoveredX, hoveredY) {
+		const domainIdentifier = this.services.cartesianScales.getDomainIdentifier();
+		const rangeIdentifier = this.services.cartesianScales.getRangeIdentifier();
+		const options = this.model.getOptions();
+		const { groupMapsTo } = options.data;
+		const percentage = Object.keys(options.axes).some(
+			(axis) => options.axes[axis].percentage
+		);
+		const stackedData = this.model.getStackedData({ percentage });
+		const tooltipData = [];
+		stackedData.forEach((groupData, groupDataIndex) => {
+			groupData.forEach((data, dataIndex) => {
+				const group = data[groupMapsTo];
+				const domainValue = data["data"]["sharedStackKey"];
+				let rangeValue = data["data"][group];
+				const stackedRangeValue = data[1];
+				if (
+					rangeValue &&
+					hoveredX ===
+						this.services.cartesianScales.getDomainValue(
+							domainValue
+						) &&
+					hoveredY ===
+						this.services.cartesianScales.getRangeValue(
+							stackedRangeValue
+						)
+				) {
+					if (percentage) {
+						rangeValue = this.model.getStackedData()[
+							groupDataIndex
+						][dataIndex]["data"][group];
+					}
+
+					tooltipData.push({
+						[groupMapsTo]: group,
+						[domainIdentifier]: domainValue,
+						[rangeIdentifier]: rangeValue
+					});
+				}
+			});
+		});
+		return tooltipData;
+	}
 }

--- a/packages/core/src/components/graphs/scatter-stacked.ts
+++ b/packages/core/src/components/graphs/scatter-stacked.ts
@@ -78,11 +78,11 @@ export class StackedScatter extends Scatter {
 		const stackedData = this.model.getStackedData({ percentage });
 		const tooltipData = [];
 		stackedData.forEach((groupData, groupDataIndex) => {
-			groupData.forEach((data, dataIndex) => {
-				const group = data[groupMapsTo];
-				const domainValue = data["data"]["sharedStackKey"];
-				let rangeValue = data["data"][group];
-				const stackedRangeValue = data[1];
+			groupData.forEach((datum, dataIndex) => {
+				const group = datum[groupMapsTo];
+				const domainValue = datum["data"]["sharedStackKey"];
+				let rangeValue = datum["data"][group];
+				const stackedRangeValue = datum[1];
 				if (
 					rangeValue &&
 					hoveredX ===

--- a/packages/core/src/components/graphs/scatter.ts
+++ b/packages/core/src/components/graphs/scatter.ts
@@ -292,6 +292,15 @@ export class Scatter extends Component {
 			.attr("opacity", 1);
 	}
 
+	getTooltipData(hoveredX, hoveredY) {
+		return this.model.getDisplayData().filter((d) => {
+			return (
+				hoveredX === this.services.cartesianScales.getDomainValue(d) &&
+				hoveredY === this.services.cartesianScales.getRangeValue(d)
+			);
+		});
+	}
+
 	addEventListeners() {
 		const self = this;
 		const { groupMapsTo } = this.model.getOptions().data;
@@ -318,23 +327,11 @@ export class Scatter extends Component {
 				const hoveredY = self.services.cartesianScales.getRangeValue(
 					datum
 				);
-				const overlappingData = self.model
-					.getDisplayData()
-					.filter((d) => {
-						return (
-							hoveredX ===
-								self.services.cartesianScales.getDomainValue(
-									d
-								) &&
-							hoveredY ===
-								self.services.cartesianScales.getRangeValue(d)
-						);
-					});
-
+				const tooltipData = self.getTooltipData(hoveredX, hoveredY);
 				// Show tooltip
 				self.services.events.dispatchEvent(Events.Tooltip.SHOW, {
 					hoveredElement,
-					data: overlappingData
+					data: tooltipData
 				});
 
 				// Dispatch mouse event


### PR DESCRIPTION
- abstract getTooltipData function to allow override
- implement getTooltipData function in scatter-stacked with stacked data

### Updates
The scatter tooltip won't display in stacked charts except first data group because of the different data structure between normal data and stacked data.

### Demo screenshot or recording
Before fix:
![image](https://user-images.githubusercontent.com/59426533/91267420-eb359980-e7a5-11ea-9ecf-f3deb4fbac5b.png)

After fix:
![image](https://user-images.githubusercontent.com/59426533/91267311-b1649300-e7a5-11ea-8c4e-e178ea84659d.png)


### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
