### PR TITLE
fix(tooltip): should use valueFormatter for single values

### DIFF
--- a/packages/core/src/components/essentials/tooltip-axis.ts
+++ b/packages/core/src/components/essentials/tooltip-axis.ts
@@ -65,10 +65,7 @@ export class AxisChartsTooltip extends Tooltip {
 					rangeLabel = "x-value";
 				}
 			}
-			let rangeValue = datum[rangeIdentifier];
-			if (rangeAxisScaleType === ScaleTypes.LINEAR) {
-				rangeValue = rangeValue.toLocaleString();
-			}
+
 			items = [
 				{
 					label: domainLabel,
@@ -76,7 +73,7 @@ export class AxisChartsTooltip extends Tooltip {
 				},
 				{
 					label: rangeLabel,
-					value: rangeValue
+					value: this.valueFormatter(datum[rangeIdentifier])
 				},
 				{
 					label: "Group",
@@ -94,7 +91,7 @@ export class AxisChartsTooltip extends Tooltip {
 
 			items = items.concat(
 				data
-					.map((datum) => ({
+					.map(datum => ({
 						label: datum[groupMapsTo],
 						value: this.valueFormatter(datum[rangeIdentifier]),
 						color: this.model.getStrokeColor(datum[groupMapsTo])


### PR DESCRIPTION
### Updates
Instead of hardcoding the formatting for single values, rely on the this.valueFormatter method. Fixes this issue:
https://github.com/carbon-design-system/carbon-charts/issues/778

### Demo screenshot or recording

### Review checklist (for reviewers only)
- [x] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
