### PR TITLE
fix(svelte): fix BaseChart destroy behavior

### DIFF
--- a/packages/svelte/src/BaseChart.svelte
+++ b/packages/svelte/src/BaseChart.svelte
@@ -2,38 +2,44 @@
   export let Chart = undefined;
   export let data = {};
   export let options = {};
+  export let id = "chart-" + Math.random().toString(36);
 
-  import { onMount, createEventDispatcher } from "svelte";
+  import { onMount, afterUpdate, createEventDispatcher } from "svelte";
 
   const dispatch = createEventDispatcher();
-  const id = "chart-" + Math.random().toString(36);
 
-  let ref = undefined;
-  let chart = undefined;
+  let ref = null;
+  let chart = null;
+  let element = null;
+  let prevChart = undefined;
 
   onMount(() => {
     /**
      * CodeSandbox does not resolve Svelte components from the `svelte` package.json entry.
      * This causes `bind:ref` to be `undefined`; the chart can't mount to the element.
-     * 
+     *
      * We fallback to manually querying the DOM for the chart holder element because
      * CodeSandbox does not use uncompiled Svelte source code.
-     * 
+     *
      * See https://github.com/sveltejs/svelte/issues/2937
      */
-    const element = ref || document.getElementById(id);
-
-    if (element) {
-      chart = new Chart(element, { data, options });
-      dispatch("load", chart);
-    }
+    element = ref || document.getElementById(id);
 
     return () => {
       if (chart) {
-        chart.destroy();
+        chart.components.forEach((component) => component.destroy());
+        chart = null;
         dispatch("destroy");
       }
     };
+  });
+
+  afterUpdate(() => {
+    if (Chart && prevChart !== Chart) {
+      chart = new Chart(element, { data, options });
+      dispatch("load", chart);
+      prevChart = Chart;
+    }
   });
 
   $: if (chart) {
@@ -43,4 +49,4 @@
   }
 </script>
 
-<div {...$$restProps} bind:this={ref} {id} />
+<div {...$$restProps} bind:this={ref} {id}></div>

--- a/packages/svelte/src/BaseChart.svelte
+++ b/packages/svelte/src/BaseChart.svelte
@@ -4,14 +4,13 @@
   export let options = {};
   export let id = "chart-" + Math.random().toString(36);
 
-  import { onMount, afterUpdate, createEventDispatcher } from "svelte";
+  import { onMount, createEventDispatcher } from "svelte";
 
   const dispatch = createEventDispatcher();
 
   let ref = null;
   let chart = null;
   let element = null;
-  let prevChart = undefined;
 
   onMount(() => {
     /**
@@ -25,6 +24,11 @@
      */
     element = ref || document.getElementById(id);
 
+    if (element) {
+      chart = new Chart(element, { data, options });
+      dispatch("load", chart);
+    }
+
     return () => {
       if (chart) {
         chart.components.forEach((component) => component.destroy());
@@ -32,14 +36,6 @@
         dispatch("destroy");
       }
     };
-  });
-
-  afterUpdate(() => {
-    if (Chart && prevChart !== Chart) {
-      chart = new Chart(element, { data, options });
-      dispatch("load", chart);
-      prevChart = Chart;
-    }
   });
 
   $: if (chart) {

--- a/packages/svelte/src/BaseChart.svelte
+++ b/packages/svelte/src/BaseChart.svelte
@@ -2,15 +2,14 @@
   export let Chart = undefined;
   export let data = {};
   export let options = {};
-  export let id = "chart-" + Math.random().toString(36);
 
   import { onMount, createEventDispatcher } from "svelte";
 
   const dispatch = createEventDispatcher();
+  const id = "chart-" + Math.random().toString(36);
 
   let ref = null;
   let chart = null;
-  let element = null;
 
   onMount(() => {
     /**
@@ -22,7 +21,7 @@
      *
      * See https://github.com/sveltejs/svelte/issues/2937
      */
-    element = ref || document.getElementById(id);
+    const element = ref || document.getElementById(id);
 
     if (element) {
       chart = new Chart(element, { data, options });
@@ -45,4 +44,4 @@
   }
 </script>
 
-<div {...$$restProps} bind:this={ref} {id}></div>
+<div {...$$restProps} bind:this={ref} {id} />


### PR DESCRIPTION
Fixes #799

### Updates
- fix: rewrite component destroy method of `BaseChart.svelte` for usage with the `svelte:component` API
- refactor: initialize `ref`, `chart` variables to `null` instead of `undefined`

TODO:

- [x] test with `svelte:component`
- [x] test with unmounting instance
- [x] test with swapping charts and updating data/options
- [x] test in Storybook

### Demo screenshot or recording

<img width="1189" alt="Screen Shot 2020-09-11 at 6 33 41 AM" src="https://user-images.githubusercontent.com/10718366/92931768-cde50a00-f3f8-11ea-966a-a295b82e5543.png">

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
