### PR TITLE
docs(readme): add svelte to component status table

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,22 +38,22 @@ Read the release change logs [here](./CHANGELOG.md)
 ## Component status
 :white_check_mark: Stable :hourglass_flowing_sand: In progress
 
-| Component   | Vanilla            | Angular                  | React | Vue |
-|-------------|--------------------|--------------------------|-------|-------|
-| Simple Bar  | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
-| Grouped Bar | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
-| Stacked Bar | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
-| Donut       | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
-| Line        | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
-| Curved Line | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
-| Pie         | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
-| Step        | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
-| Scatter     | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
-| Radar     | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
-| Area        | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
-| Gauge        | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
-| Meter        | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Combo        | :hourglass_flowing_sand: | :hourglass_flowing_sand: | :hourglass_flowing_sand: | :hourglass_flowing_sand: |
+| Component   | Vanilla            | Angular                  | React | Vue | Svelte |
+|-------------|--------------------|--------------------------|-------|-------| --- |
+| Simple Bar  | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: 
+| Grouped Bar | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
+| Stacked Bar | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
+| Donut       | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
+| Line        | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
+| Curved Line | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
+| Pie         | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
+| Step        | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
+| Scatter     | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
+| Radar     | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
+| Area        | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
+| Gauge        | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
+| Meter        | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
+| Combo        | :hourglass_flowing_sand: | :hourglass_flowing_sand: | :hourglass_flowing_sand: | :hourglass_flowing_sand: | :hourglass_flowing_sand: |
 
 ## Bugs and feature requests
 


### PR DESCRIPTION
### Updates
- docs(readme): add svelte to component status table

### Demo screenshot or recording

<img width="514" alt="Screen Shot 2020-09-21 at 4 17 30 PM" src="https://user-images.githubusercontent.com/10718366/93830767-f7d2d380-fc25-11ea-96c0-53942a69bb23.png">


### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
