### PR TITLE
fix: allow string dates in zoom bar configurations

### DIFF
--- a/packages/core/demo/data/index.ts
+++ b/packages/core/demo/data/index.ts
@@ -832,6 +832,12 @@ let allDemoGroups = [
 				isDemoExample: false
 			},
 			{
+				options: zoomBarDemos.zoomBarStringDateOptions,
+				data: zoomBarDemos.zoomBarStringDateData,
+				chartType: chartTypes.LineChart,
+				isDemoExample: false
+			},
+			{
 				options: zoomBarDemos.zoomBarSkeletonOptions,
 				data: zoomBarDemos.zoomBarSkeletonData,
 				chartType: chartTypes.StackedBarChart,

--- a/packages/core/demo/data/zoom-bar.ts
+++ b/packages/core/demo/data/zoom-bar.ts
@@ -121,6 +121,88 @@ export const zoomBarLineTimeSeriesInitDomainOptions = addZoomBarToOptions(
 zoomBarLineTimeSeriesInitDomainOptions["title"] += " (initial zoomed domain)";
 zoomBarLineTimeSeriesInitDomainOptions.zoomBar.top.initialZoomDomain = initialZoomDomain;
 
+export const zoomBarStringDateData = {
+	labels: ["Qty"],
+	datasets: [
+		{
+			label: "Dataset 1",
+			data: [
+				{
+					date: "2020-12-10T15:59:15.000Z",
+					value: 10
+				},
+				{
+					date: "2020-12-10T15:59:30.000Z",
+					value: 15
+				},
+				{
+					date: "2020-12-10T15:59:45.000Z",
+					value: 7
+				},
+				{
+					date: "2020-12-10T16:00:00.000Z",
+					value: 2
+				},
+				{
+					date: "2020-12-10T16:00:15.000Z",
+					value: 9
+				},
+				{
+					date: "2020-12-10T16:00:30.000Z",
+					value: 13
+				},
+				{
+					date: "2020-12-10T16:00:45.000Z",
+					value: 8
+				}
+			]
+		}
+	]
+};
+export const zoomBarStringDateOptions = addZoomBarToOptions({
+	title: "String dates",
+	axes: {
+		left: {},
+		bottom: {
+			scaleType: "time"
+		}
+	}
+});
+zoomBarStringDateOptions.zoomBar.top.initialZoomDomain = [
+	"2020-12-10T15:59:25.000Z",
+	"2020-12-10T16:00:25.000Z"
+];
+zoomBarStringDateOptions.zoomBar.top.data = [
+	{
+		date: "2020-12-10T15:59:15.000Z",
+		value: 15
+	},
+	{
+		date: "2020-12-10T15:59:30.000Z",
+		value: 10
+	},
+	{
+		date: "2020-12-10T15:59:45.000Z",
+		value: 2
+	},
+	{
+		date: "2020-12-10T16:00:00.000Z",
+		value: 15
+	},
+	{
+		date: "2020-12-10T16:00:15.000Z",
+		value: 13
+	},
+	{
+		date: "2020-12-10T16:00:30.000Z",
+		value: 3
+	},
+	{
+		date: "2020-12-10T16:00:45.000Z",
+		value: 10
+	}
+];
+
 // assume no data set while loading is true
 export const zoomBarSkeletonData = [];
 export const zoomBarSkeletonOptions = addZoomBarToOptions(

--- a/packages/core/src/components/axes/zoom-bar.ts
+++ b/packages/core/src/components/axes/zoom-bar.ts
@@ -123,7 +123,15 @@ export class ZoomBar extends Component {
 				"top",
 				"initialZoomDomain"
 			);
-
+			// change string date to Date object if necessary
+			if (
+				newInitialZoomDomain &&
+				newInitialZoomDomain[0] &&
+				newInitialZoomDomain[1]
+			) {
+				newInitialZoomDomain[0] = new Date(newInitialZoomDomain[0]);
+				newInitialZoomDomain[1] = new Date(newInitialZoomDomain[1]);
+			}
 			// update initialZoomDomain and set zoomDomain in model only if the option is changed
 			// not the same object, and both start date and end date are not equal
 			if (

--- a/packages/core/src/components/graphs/scatter.ts
+++ b/packages/core/src/components/graphs/scatter.ts
@@ -43,8 +43,10 @@ export class Scatter extends Component {
 		if (zoomDomain !== undefined) {
 			return data.filter(
 				(d) =>
-					d[domainIdentifier] > zoomDomain[0] &&
-					d[domainIdentifier] < zoomDomain[1]
+					new Date(d[domainIdentifier]).getTime() >
+						zoomDomain[0].getTime() &&
+					new Date(d[domainIdentifier]).getTime() <
+						zoomDomain[1].getTime()
 			);
 		}
 		return data;

--- a/packages/core/src/services/zoom.ts
+++ b/packages/core/src/services/zoom.ts
@@ -22,6 +22,7 @@ export class Zoom extends Service {
 			"top",
 			"data"
 		);
+
 		// if user already defines zoom bar data, use it
 		if (definedZoomBarData && definedZoomBarData.length > 1) {
 			zoomBarData = definedZoomBarData;
@@ -29,10 +30,13 @@ export class Zoom extends Service {
 			// use displayData if not defined
 			zoomBarData = this.model.getDisplayData();
 		}
+
 		// get all dates (Number) in displayData
 		let allDates = [];
 		zoomBarData.forEach((data) => {
-			allDates = allDates.concat(Number(data[domainIdentifier]));
+			allDates = allDates.concat(
+				new Date(data[domainIdentifier]).getTime()
+			);
 		});
 		allDates = Tools.removeArrayDuplicates(allDates).sort();
 		// Go through all date values
@@ -42,7 +46,7 @@ export class Zoom extends Service {
 			const datum = {};
 
 			zoomBarData.forEach((data) => {
-				if (Number(data[domainIdentifier]) === date) {
+				if (new Date(data[domainIdentifier]).getTime() === date) {
 					sum += data[rangeIdentifier];
 				}
 			});


### PR DESCRIPTION
### Updates
- allow string dates in zoom bar configurations

### Demo screenshot or recording
![image](https://user-images.githubusercontent.com/59426533/94515122-77c7f180-0255-11eb-9680-8f23d7d4dfea.png)

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
