### PR TITLE
fix(core): fix division by zero & timescale issues

### DIFF
--- a/packages/core/src/components/graphs/scatter-stacked.ts
+++ b/packages/core/src/components/graphs/scatter-stacked.ts
@@ -92,8 +92,10 @@ export class StackedScatter extends Scatter {
 				const domainValue = datum["data"]["sharedStackKey"];
 				let rangeValue = datum["data"][group];
 				const stackedRangeValue = datum[1];
+
 				if (
-					rangeValue &&
+					rangeValue !== null &&
+					rangeValue !== undefined &&
 					hoveredX ===
 						this.services.cartesianScales.getDomainValue(
 							domainValue
@@ -109,11 +111,13 @@ export class StackedScatter extends Scatter {
 						][dataIndex]["data"][group];
 					}
 
-					tooltipData.push({
-						[groupMapsTo]: group,
-						[domainIdentifier]: domainValue,
-						[rangeIdentifier]: rangeValue
-					});
+					if (rangeValue !== null) {
+						tooltipData.push({
+							[groupMapsTo]: group,
+							[domainIdentifier]: domainValue,
+							[rangeIdentifier]: rangeValue
+						});
+					}
 				}
 			});
 		});

--- a/packages/core/src/model.ts
+++ b/packages/core/src/model.ts
@@ -52,14 +52,16 @@ export class ChartModel {
 
 		const axesOptions = this.getOptions().axes;
 
-
 		if (axesOptions) {
 			Object.keys(axesOptions).forEach((axis) => {
 				const mapsTo = axesOptions[axis].mapsTo;
 				const scaleType = axesOptions[axis].scaleType;
 				// make sure linear/log values are numbers
-				if (scaleType === ScaleTypes.LINEAR || scaleType === ScaleTypes.LOG) {
-					displayData = displayData.map(datum => {
+				if (
+					scaleType === ScaleTypes.LINEAR ||
+					scaleType === ScaleTypes.LOG
+				) {
+					displayData = displayData.map((datum) => {
 						return { ...datum, [mapsTo]: Number(datum[mapsTo]) };
 					});
 				}
@@ -258,7 +260,11 @@ export class ChartModel {
 			// cycle through data values to get percentage
 			dataValuesGroupedByKeys.forEach((d: any) => {
 				dataGroupNames.forEach((name) => {
-					d[name] = (d[name] / maxByKey[d.sharedStackKey]) * 100;
+					if (maxByKey[d.sharedStackKey]) {
+						d[name] = (d[name] / maxByKey[d.sharedStackKey]) * 100;
+					} else {
+						d[name] = 0;
+					}
 				});
 			});
 		}

--- a/packages/core/src/services/scales-cartesian.ts
+++ b/packages/core/src/services/scales-cartesian.ts
@@ -420,6 +420,8 @@ export class CartesianScales extends Service {
 			allDataValues = dataValuesGroupedByKeys.map((dataValues) =>
 				sum(values(dataValues) as any)
 			);
+		} else if (scaleType === ScaleTypes.TIME) {
+			allDataValues = displayData.map((datum) => +new Date(datum[mapsTo]));
 		} else {
 			allDataValues = displayData.map((datum) => datum[mapsTo]);
 		}


### PR DESCRIPTION
Fixes 2 issues:
- Timescale was missing parsing of JS-dates in 1 place
- Division by zero was being allowed in the stacked area chart