### PR TITLE
fix(core): fix Legend and Tooltip group color

### DIFF
--- a/packages/core/src/components/essentials/legend.ts
+++ b/packages/core/src/components/essentials/legend.ts
@@ -82,7 +82,7 @@ export class Legend extends Component {
 			.attr("ry", 1)
 			.style("fill", (d) => {
 				return d.status === Configuration.legend.items.status.ACTIVE
-					? this.model.getStrokeColor(d.name)
+					? this.model.getColorForGroup(d.name)
 					: null;
 			})
 			.classed("active", function (d, i) {

--- a/packages/core/src/components/essentials/tooltip-axis.ts
+++ b/packages/core/src/components/essentials/tooltip-axis.ts
@@ -78,7 +78,7 @@ export class AxisChartsTooltip extends Tooltip {
 				{
 					label: options.tooltip.groupLabel || "Group",
 					value: datum[groupMapsTo],
-					color: this.model.getStrokeColor(datum[groupMapsTo])
+					color: this.model.getColorForGroup(datum[groupMapsTo])
 				}
 			];
 		} else if (data.length > 1) {
@@ -94,7 +94,7 @@ export class AxisChartsTooltip extends Tooltip {
 					.map((datum) => ({
 						label: datum[groupMapsTo],
 						value: this.valueFormatter(datum[rangeIdentifier]),
-						color: this.model.getStrokeColor(datum[groupMapsTo])
+						color: this.model.getColorForGroup(datum[groupMapsTo])
 					}))
 					.sort((a, b) => b.value - a.value)
 			);

--- a/packages/core/src/model.ts
+++ b/packages/core/src/model.ts
@@ -454,6 +454,16 @@ export class ChartModel {
 		return this.colorScale;
 	}
 
+	getColorForGroup(group: any, key?: any, data?: any) {
+		const options = this.getOptions()
+		const shouldUseFillColorForGroup = !!options.getFillColor && !options.getStrokeColor
+		if (shouldUseFillColorForGroup) {
+			return this.getFillColor(group, key, data)
+		} else {
+			return this.getStrokeColor(group, key, data)
+		}
+	}
+
 	/**
 	 * For charts that might hold an associated status for their dataset
 	 */


### PR DESCRIPTION
Fix Legend and Tooltip Group colors to be based on the getFillColor option as well

### Updates
- Update Legend fill color function to take into consideration custom fill and stroke colors
- Update Tooltip 'Group' fill color function to take into consideration custom fill and stroke colors
- Fixes issue #828 
### Demo screenshot or recording
![image](https://user-images.githubusercontent.com/9557884/95143790-6d25c480-074d-11eb-93c2-fdcb3609d222.png)

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
