### PR TITLE
fix(core): fix legend hover opacity results in radar graph

### DIFF
--- a/packages/core/src/components/graphs/radar.ts
+++ b/packages/core/src/components/graphs/radar.ts
@@ -727,21 +727,23 @@ export class Radar extends Component {
 					return Configuration.radar.opacity.unselected;
 				}
 				return Configuration.radar.opacity.selected;
+			})
+			.style("stroke-opacity", (group) => {
+				if (group.name !== hoveredElement.datum().name) {
+					return Configuration.radar.opacity.unselected;
+				}
+				return 1;
 			});
 	};
 
 	handleLegendMouseOut = (event: CustomEvent) => {
-		const opacity = Tools.getProperty(
-			this.model.getOptions(),
-			"radar",
-			"opacity"
-		);
 		this.parent
 			.selectAll("g.blobs path")
 			.transition(
 				this.services.transitions.getTransition("legend-mouseout-blob")
 			)
-			.style("fill-opacity", Tools.getProperty(opacity, "selected"));
+			.style("fill-opacity", Configuration.radar.opacity.selected)
+			.style("stroke-opacity", 1);
 	};
 
 	destroy() {


### PR DESCRIPTION
Currently after the legend hover interaction, radar blobs get a fill-opacity of 100%

![image](https://user-images.githubusercontent.com/14989804/95348558-28547780-088c-11eb-89c4-e6edc225361d.png)

This PR will revert the opacity back to the initial state of rendering