### PR TITLE
fix(core): pass all data to customHTML for scatter-stacked charts

### DIFF
--- a/packages/core/src/components/graphs/scatter-stacked.ts
+++ b/packages/core/src/components/graphs/scatter-stacked.ts
@@ -121,6 +121,17 @@ export class StackedScatter extends Scatter {
 				}
 			});
 		});
-		return tooltipData;
+
+		return this.model.getDisplayData().filter((datapoint) => {
+			return (
+				tooltipData.find((tooltipDatapoint) => {
+					return (
+						tooltipDatapoint[groupMapsTo] == datapoint[groupMapsTo] &&
+						tooltipDatapoint[domainIdentifier] == datapoint[domainIdentifier] &&
+						tooltipDatapoint[rangeIdentifier] == datapoint[rangeIdentifier]
+					);
+				}) !== undefined
+			);
+		});
 	}
 }


### PR DESCRIPTION
Provide all data to the customHTML tooltip callback for scatter-stacked, rather than just the group
name, domain and range values.

### Demo screenshot or recording
Before:
![image](https://user-images.githubusercontent.com/1922249/96621295-762e9e00-12d6-11eb-9b8f-4446208b0525.png)

After (with additional properties from data series):
![image](https://user-images.githubusercontent.com/1922249/96621893-36b48180-12d7-11eb-8522-9fb573cada0e.png)

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
