### PR TITLE
fix(zoombar): use canvas instead of path for the preview

### DIFF
--- a/packages/core/demo/styles.scss
+++ b/packages/core/demo/styles.scss
@@ -31,7 +31,10 @@ div.container {
 	&.theme--white {
 		@import "../src/styles/styles-white.scss";
 
-		@include carbon--theme($carbon--theme--white) {
+		@include carbon--theme(
+			$theme: $carbon--theme--white,
+			$emit-custom-properties: true
+		) {
 			color: $text-01;
 			background-color: $ui-background;
 			line-height: 1;
@@ -41,7 +44,10 @@ div.container {
 	&.theme--g10 {
 		@import "../src/styles/styles-g10.scss";
 
-		@include carbon--theme($carbon--theme--g10) {
+		@include carbon--theme(
+			$theme: $carbon--theme--g10,
+			$emit-custom-properties: true
+		) {
 			color: $text-01;
 			background-color: $ui-background;
 			line-height: 1;
@@ -51,7 +57,10 @@ div.container {
 	&.theme--g90 {
 		@import "../src/styles/styles-g90.scss";
 
-		@include carbon--theme($carbon--theme--g90) {
+		@include carbon--theme(
+			$theme: $carbon--theme--g90,
+			$emit-custom-properties: true
+		) {
 			color: $text-01;
 			background-color: $ui-background;
 			line-height: 1;
@@ -82,7 +91,10 @@ div.container {
 	&.theme--g100 {
 		@import "../src/styles/styles-g100.scss";
 
-		@include carbon--theme($carbon--theme--g100) {
+		@include carbon--theme(
+			$theme: $carbon--theme--g100,
+			$emit-custom-properties: true
+		) {
 			color: $text-01;
 			background-color: $ui-background;
 			line-height: 1;

--- a/packages/core/src/components/axes/zoom-bar.ts
+++ b/packages/core/src/components/axes/zoom-bar.ts
@@ -556,9 +556,12 @@ export class ZoomBar extends Component {
 		const { width: selectionWidth, height: selectionHeight } =
 			svg.select("rect.selection").node()?.getBoundingClientRect() || {};
 
-		// If the width exactly matches the selection, then we need to clip the whole zoom bar, otherwise clip just half because the width is on the inner selector, not the outer selector
-		const zoomHandleAdjustment =
-			selectionWidth === width || !width ? 5 : 2.5;
+		// If the left handle is still on the left, the clip needs to adjust for the whole handle, otherwise adjust to the middle
+		const leftZoomHandleAdjustment =
+			x === this.model.get("axesMargins")?.left ? 5 : 2.5;
+		// If the right handle is still on the right, the clip needs to adjust for the whole handle, otherwise adjust to the middle
+		const rightZoomHandleAdjustment =
+			x + width === containerWidth || !width ? 5 : 2.5;
 
 		// clipPath is for the inner bounds
 		const zoomBarClipPath = DOMUtils.appendOrSelect(
@@ -566,10 +569,17 @@ export class ZoomBar extends Component {
 			`clipPath.clipPath`
 		).attr("id", clipId);
 		DOMUtils.appendOrSelect(zoomBarClipPath, "rect")
-			.attr("x", x + zoomHandleAdjustment)
+			.attr("x", x + leftZoomHandleAdjustment)
 			.attr("y", y)
-			.attr("width", width - zoomHandleAdjustment * 2)
-			.attr("height", height - 1); // clip up one to show the baseline
+			.attr(
+				"width",
+				Math.max(
+					width -
+						(leftZoomHandleAdjustment + rightZoomHandleAdjustment),
+					0
+				)
+			)
+			.attr("height", Math.max(height - 1, 0)); // clip up one to show the baseline
 
 		if (width > 0 || height > 0) {
 			// Need to attach an inverseClipPath for the outer bounds
@@ -583,16 +593,16 @@ export class ZoomBar extends Component {
 			)
 				.attr("x", 0)
 				.attr("y", 0)
-				.attr("width", x - zoomHandleAdjustment)
-				.attr("height", height - 1); // clip up one to show the baseline
+				.attr("width", Math.max(x - leftZoomHandleAdjustment, 0))
+				.attr("height", Math.max(height - 1, 0)); // clip up one to show the baseline
 			DOMUtils.appendOrSelect(
 				zoomBarInverseClipPath,
 				"rect.rightInverseClip"
 			)
-				.attr("x", x + width + zoomHandleAdjustment)
+				.attr("x", x + width + rightZoomHandleAdjustment)
 				.attr("y", 0)
 				.attr("width", containerWidth)
-				.attr("height", height - 1); // clip up one to show the baseline
+				.attr("height", Math.max(height - 1, 0)); // clip up one to show the baseline
 		}
 	}
 

--- a/packages/core/src/components/axes/zoom-bar.ts
+++ b/packages/core/src/components/axes/zoom-bar.ts
@@ -518,19 +518,14 @@ export class ZoomBar extends Component {
 		)
 			.attr("width", "100%")
 			.attr("height", "100%");
+		const body = DOMUtils.appendOrSelect(foreignObject, "body", "xhtml");
 
-		let canvas = <HTMLCanvasElement>document.getElementById(querySelector);
-		if (!canvas) {
-			canvas = <HTMLCanvasElement>document.createElement("CANVAS");
-			canvas.setAttribute("id", querySelector);
-			canvas.setAttribute("class", querySelector);
-
-			document.body.appendChild(canvas);
-			foreignObject.node().appendChild(canvas);
-		}
-
-		canvas.setAttribute("width", containerWidth);
-		canvas.setAttribute("height", containerHeight);
+		const canvas = <HTMLCanvasElement>(
+			DOMUtils.appendOrSelect(body, `canvas.${querySelector}`)
+				.attr("width", containerWidth)
+				.attr("height", containerHeight)
+				.node()
+		);
 		const areaContext = canvas.getContext("2d");
 
 		const areaGenerator = area()

--- a/packages/core/src/components/axes/zoom-bar.ts
+++ b/packages/core/src/components/axes/zoom-bar.ts
@@ -554,7 +554,8 @@ export class ZoomBar extends Component {
 			svg.node().getBoundingClientRect() || {};
 
 		const { width: selectionWidth, height: selectionHeight } =
-			svg.select("rect.selection").node()?.getBoundingClientRect() || {};
+			document.querySelector("rect.selection")?.getBoundingClientRect() || // for some reason we have to use this version as the d3 selector breaks the d3-brush
+			{};
 
 		// If the left handle is still on the left, the clip needs to adjust for the whole handle, otherwise adjust to the middle
 		const leftZoomHandleAdjustment =

--- a/packages/core/src/services/essentials/dom-utils.ts
+++ b/packages/core/src/services/essentials/dom-utils.ts
@@ -135,14 +135,14 @@ export class DOMUtils extends Service {
 		return finalDimensions;
 	}
 
-	static appendOrSelect(parent, query) {
+	static appendOrSelect(parent, query, schema?) {
 		const querySections = query.split(".");
 		const elementToAppend = querySections[0];
 
 		const selection = parent.select(query);
 		if (selection.empty()) {
 			return parent
-				.append(elementToAppend)
+				.append((schema ? `${schema}:` : "") + elementToAppend)
 				.attr("class", querySections.slice(1).join(" "));
 		}
 

--- a/packages/core/src/styles/components/_zoom-bar.scss
+++ b/packages/core/src/styles/components/_zoom-bar.scss
@@ -17,17 +17,6 @@ g.#{$prefix}--#{$charts-prefix}--zoom-bar {
 		stroke-width: 2;
 	}
 
-	canvas.zoom-graph-area {
-		fill: $ui-03;
-		stroke: $ui-04;
-		stroke-width: 1;
-	}
-
-	canvas.zoom-graph-area-unselected {
-		fill: $ui-01;
-		stroke: none;
-	}
-
 	g.zoom-bar-brush {
 		rect.handle {
 			fill: $icon-02;

--- a/packages/core/src/styles/components/_zoom-bar.scss
+++ b/packages/core/src/styles/components/_zoom-bar.scss
@@ -17,13 +17,13 @@ g.#{$prefix}--#{$charts-prefix}--zoom-bar {
 		stroke-width: 2;
 	}
 
-	path.zoom-graph-area {
+	canvas.zoom-graph-area {
 		fill: $ui-03;
 		stroke: $ui-04;
 		stroke-width: 1;
 	}
 
-	path.zoom-graph-area-unselected {
+	canvas.zoom-graph-area-unselected {
 		fill: $ui-01;
 		stroke: none;
 	}

--- a/packages/core/stories/all.stories.ts
+++ b/packages/core/stories/all.stories.ts
@@ -131,8 +131,6 @@ ${storyUtils.generateThemePickerHTML()}
 </a>
 			`;
 
-			storyUtils.addRadioButtonEventListeners(container);
-
 			// Initialize chart
 			const chart = new ClassToInitialize(
 				container.querySelector("div#chart-demo"),
@@ -142,6 +140,7 @@ ${storyUtils.generateThemePickerHTML()}
 				}
 			);
 
+			storyUtils.addRadioButtonEventListeners(container, chart);
 			return container;
 		});
 	});

--- a/packages/core/stories/all.stories.ts
+++ b/packages/core/stories/all.stories.ts
@@ -164,8 +164,6 @@ if (process.env.NODE_ENV !== "production") {
 	${storyUtils.generateThemePickerHTML()}
 `;
 
-		storyUtils.addRadioButtonEventListeners(container);
-
 		const getNewRow = () => {
 			const newRow = document.createElement("div");
 			newRow.setAttribute("class", "bx--row");
@@ -197,6 +195,8 @@ if (process.env.NODE_ENV !== "production") {
 					data: demo.data,
 					options: demo.options
 				});
+
+				storyUtils.addRadioButtonEventListeners(container, chart);
 
 				row.appendChild(column);
 

--- a/packages/core/stories/utils.ts
+++ b/packages/core/stories/utils.ts
@@ -36,7 +36,7 @@ export const generateThemePickerHTML = () => `
 	</fieldset>
 </div>`;
 
-export const addRadioButtonEventListeners = (container) => {
+export const addRadioButtonEventListeners = (container, chart?) => {
 	// Add event listeners for radio buttons
 	const radioButtons = container.querySelectorAll(
 		"div#theme-picker input.bx--radio-button"
@@ -45,6 +45,7 @@ export const addRadioButtonEventListeners = (container) => {
 		radioButton.addEventListener("click", (e: any) => {
 			const theme = e.target.value;
 			container.setAttribute("class", `container theme--${theme}`);
+			chart?.update();
 		});
 	});
 };


### PR DESCRIPTION
### Updates
- list
- out
- updates
To improve zoombar.ts performance this renders the zoombar graph-view as a canvas rather than an svg.path
- feat(zoombar.ts): set an inverse clip path because now we need to clip both canvases (otherwise they'll overwrite the brushHandles)
- feat(zoombar.ts): renderZoomBar needs to render canvas and foreignObjects now
- feat(zoomBar.scss): can not style canvas through css, need to pass the stroke color directly
- here (and don't forget to link the issues) #751 

### Demo screenshot or recording
See and test existing Zoombar stories

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
