### PR TITLE
Render zoom bar skeleton whenever loading is true

### DIFF
--- a/packages/core/src/components/axes/zoom-bar.ts
+++ b/packages/core/src/components/axes/zoom-bar.ts
@@ -110,14 +110,16 @@ export class ZoomBar extends Component {
 				.attr("x", axesLeftMargin)
 				.attr("y", 0)
 				.attr("width", width - axesLeftMargin)
-				.attr("height", "100%");
+				.attr("height", "100%")
+				.classed("zoom-bg-skeleton", isTopZoomBarLoading);
 		} else if (zoombarType === ZoomBarTypes.SLIDER_VIEW) {
 			// Draw zoombar background line
 			DOMUtils.appendOrSelect(container, "rect.zoom-slider-bg")
 				.attr("x", axesLeftMargin)
 				.attr("y", zoombarHeight / 2 - 1)
 				.attr("width", width - axesLeftMargin)
-				.attr("height", 2);
+				.attr("height", 2)
+				.classed("zoom-slider-bg-skeleton", isTopZoomBarLoading);
 		}
 
 		if (isTopZoomBarLoading) {
@@ -574,7 +576,7 @@ export class ZoomBar extends Component {
 		return zoomBarData;
 	}
 
-	renderZoomBarBaseline(container, startX, endX) {
+	renderZoomBarBaseline(container, startX, endX, skeletonClass = false) {
 		const zoombarType = Tools.getProperty(
 			this.model.getOptions(),
 			"zoomBar",
@@ -586,10 +588,9 @@ export class ZoomBar extends Component {
 			[startX, zoombarHeight],
 			[endX, zoombarHeight]
 		]);
-		DOMUtils.appendOrSelect(container, "path.zoom-bg-baseline").attr(
-			"d",
-			baselineGenerator
-		);
+		DOMUtils.appendOrSelect(container, "path.zoom-bg-baseline")
+			.attr("d", baselineGenerator)
+			.classed("zoom-bg-baseline-skeleton", skeletonClass);
 	}
 
 	renderSkeleton(container, startX, endX) {
@@ -613,8 +614,17 @@ export class ZoomBar extends Component {
 			this.getContainerSVG(),
 			this.brushSelector
 		).html(null);
+
 		// re-render baseline because no axis labels in skeleton so the baseline length needs to change
-		this.renderZoomBarBaseline(container, startX, endX);
+		const zoombarType = Tools.getProperty(
+			this.getOptions(),
+			"zoomBar",
+			AxisPositions.TOP,
+			"type"
+		);
+		if (zoombarType === ZoomBarTypes.GRAPH_VIEW) {
+			this.renderZoomBarBaseline(container, startX, endX, true);
+		}
 	}
 
 	destroy() {

--- a/packages/core/src/components/axes/zoom-bar.ts
+++ b/packages/core/src/components/axes/zoom-bar.ts
@@ -348,6 +348,10 @@ export class ZoomBar extends Component {
 				zoomBarEventType = Events.ZoomBar.SELECTION_IN_PROGRESS;
 			} else if (event.type === "end") {
 				zoomBarEventType = Events.ZoomBar.SELECTION_END;
+				// only dispatch zoom domain change event for triggering api call when event type equals to end
+				this.services.events.dispatchEvent(Events.ZoomDomain.CHANGE, {
+					newDomain
+				});
 			}
 			this.services.events.dispatchEvent(zoomBarEventType, {
 				selection,

--- a/packages/core/src/styles/components/_zoom-bar.scss
+++ b/packages/core/src/styles/components/_zoom-bar.scss
@@ -2,10 +2,18 @@ g.#{$prefix}--#{$charts-prefix}--zoom-bar {
 	rect.zoom-bg {
 		fill: $ui-background;
 		stroke: $ui-01;
+
+		&-skeleton {
+			stroke: url(#shimmer-lines);
+		}
 	}
 
 	rect.zoom-slider-bg {
 		fill: $ui-01;
+
+		&-skeleton {
+			stroke: url(#shimmer-lines);
+		}
 	}
 
 	rect.zoom-slider-selected-area {
@@ -15,6 +23,10 @@ g.#{$prefix}--#{$charts-prefix}--zoom-bar {
 	path.zoom-bg-baseline {
 		stroke: $ui-04;
 		stroke-width: 2;
+
+		&-skeleton {
+			stroke: url(#shimmer-lines);
+		}
 	}
 
 	path.zoom-graph-area {


### PR DESCRIPTION
### Updates
- render zoom bar skeleton whenever loading is true
  -- needed if charts is changing from loaded to loading
- dispatch Events.ZoomDomain.CHANGE when zoom bar selection is completed
  -- useful for user to listen to Events.ZoomDomain.CHANGE instead of Events.ZoomBar.SELECTION_END

### Demo screenshot or recording
- No UI change

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
