### PR TITLE
Set toolbar control background to transparent

### DIFF
--- a/packages/core/src/styles/components/_toolbar.scss
+++ b/packages/core/src/styles/components/_toolbar.scss
@@ -6,14 +6,14 @@ g.#{$prefix}--#{$charts-prefix}--toolbar {
 
 	.toolbar-container {
 		.toolbar-button {
-			fill: $ui-background;
+			fill: none;
 			cursor: pointer;
 			&:hover {
 				.toolbar-button-background {
 					fill: $hover-ui;
 				}
 				.toolbar-button-background--disabled {
-					fill: $ui-background;
+					fill: none;
 				}
 			}
 


### PR DESCRIPTION
### Updates
- use fill:none to allow transparent toolbar control background. It fixes the problem when user changes the chart background color.

### Demo screenshot or recording
No UI change in demo.

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
