### PR TITLE
fix(svelte): use latest CDN styles for generated CodeSandbox examples

### DIFF
--- a/packages/core/demo/create-codesandbox.ts
+++ b/packages/core/demo/create-codesandbox.ts
@@ -343,7 +343,7 @@ export default app;
 </script>
 
 <svelte:head>
-  <link rel="stylesheet" href="https://unpkg.com/@carbon/charts@0.30.10/styles.min.css" />
+  <link rel="stylesheet" href="https://unpkg.com/@carbon/charts/styles.min.css" />
 </svelte:head>
 
 <${chartComponent}


### PR DESCRIPTION
The generated CodeSandbox examples for Svelte chart wrappers use an older CSS stylesheet (`@carbon/charts@v0.30.10`) that is hardcoded in the generation script. This causes some visual discrepancies that can be fixed by always pulling styles from the latest version.

### Updates
- use latest CDN styles for generated CodeSandbox examples

### Demo screenshot or recording

*Above*: current
*Below*: expected

![svelte-codesanbox (1)](https://user-images.githubusercontent.com/10718366/98038285-b9f2ce80-1dd1-11eb-80fb-d0ade3571cba.png)


### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
