### PR TITLE
fix(zoombar): use Tools.isEmpty instead of lodash.isEmpty import

### DIFF
--- a/packages/core/src/components/axes/zoom-bar.ts
+++ b/packages/core/src/components/axes/zoom-bar.ts
@@ -10,7 +10,6 @@ import {
 } from "../../interfaces";
 import { DOMUtils } from "../../services";
 import * as Configuration from "../../configuration";
-import isEmpty from "lodash/isEmpty";
 
 // D3 Imports
 import { extent } from "d3-array";
@@ -129,7 +128,7 @@ export class ZoomBar extends Component {
 
 		if (mainXScale && mainXScaleType === ScaleTypes.TIME) {
 			let zoomBarData = this.services.zoom.getZoomBarData();
-			if (isEmpty(zoomBarData)) {
+			if (Tools.isEmpty(zoomBarData)) {
 				// if there's no zoom bar data we can't do anything
 				return;
 			}

--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -17,6 +17,7 @@ import {
 	kebabCase as lodashKebabCase,
 	fromPairs as lodashFromPairs,
 	some as lodashSome,
+	isEmpty as lodashIsEmpty,
 	// the imports below are needed because of typescript bug (error TS4029)
 	Cancelable,
 	DebounceSettings
@@ -38,6 +39,7 @@ export namespace Tools {
 	export const kebabCase = lodashKebabCase;
 	export const fromPairs = lodashFromPairs;
 	export const some = lodashSome;
+	export const isEmpty = lodashIsEmpty;
 
 	export function debounceWithD3MousePosition(fn, delay, element) {
 		var timer = null;


### PR DESCRIPTION
Hi, our Webpack build throws an error with the latest version(s) of charts/react-charts packages:
```
ERROR in ./node_modules/@carbon/charts/components/axes/zoom-bar.js
 Module not found: Error: Can't resolve 'lodash/isEmpty' in '/node_modules/@carbon/charts/components/axes'
```

### Updates
I changed the `lodash.isEmpty` import to the `lodash-es` version and refactored the code to use it from the `Tools` namespace, like `Tools.isEmpty`.
This could fix our build, too. 😄 

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
