### PR TITLE
feat(core): add alignment options for gauge charts

### DIFF
--- a/packages/core/src/components/graphs/gauge.ts
+++ b/packages/core/src/components/graphs/gauge.ts
@@ -6,7 +6,8 @@ import {
 	Events,
 	GaugeTypes,
 	ArrowDirections,
-	ColorClassNameTypes
+	ColorClassNameTypes,
+	Alignments
 } from "../../interfaces";
 import { Tools } from "../../tools";
 
@@ -145,14 +146,26 @@ export class Gauge extends Component {
 			.attr("aria-roledescription", "value")
 			.attr("aria-label", (d) => d.value);
 
-		// Position Arc
-		svg.attr("transform", `translate(${radius}, ${radius})`);
-
 		// draw the value and delta to the center
 		this.drawValueNumber();
 		this.drawDelta();
 
 		arcValue.exit().remove();
+
+		const alignment = Tools.getProperty(options, "gauge", "alignment");
+
+		const { width } = DOMUtils.getSVGElementSize(this.getParent(), {
+			useAttr: true
+		});
+
+		// Position gauge
+		let gaugeTranslateX = radius;
+		if (alignment === Alignments.CENTER) {
+			gaugeTranslateX = width / 2;
+		} else if (alignment === Alignments.RIGHT) {
+			gaugeTranslateX = width - radius;
+		}
+		svg.attr("transform", `translate(${gaugeTranslateX}, ${radius})`);
 
 		// Add event listeners
 		this.addEventListeners();

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -323,7 +323,8 @@ const gaugeChart: GaugeChartOptions = Tools.merge({}, chart, {
 		numberFormatter: (number) =>
 			number.toFixed(2) % 1 !== 0
 				? number.toFixed(2).toLocaleString()
-				: number.toFixed().toLocaleString()
+				: number.toFixed().toLocaleString(),
+		alignment: Alignments.LEFT
 	}
 } as GaugeChartOptions);
 

--- a/packages/core/src/interfaces/charts.ts
+++ b/packages/core/src/interfaces/charts.ts
@@ -255,7 +255,7 @@ export interface PieChartOptions extends BaseChartOptions {
 /**
  * options specific to gauge charts
  */
-export interface GaugeChartOptions extends PieChartOptions {
+export interface GaugeChartOptions extends BaseChartOptions {
 	gauge?: {
 		arcWidth?: number;
 		deltaArrow?: {
@@ -269,6 +269,7 @@ export interface GaugeChartOptions extends PieChartOptions {
 		numberFormatter?: Function;
 		valueFontSize?: Function;
 		type?: GaugeTypes;
+		alignment?: Alignments;
 	};
 }
 


### PR DESCRIPTION
`center | left | right` alignment for gauge charts

Closes #870