### PR TITLE
fix(core): sanitize user provided axis domains

### DIFF
--- a/packages/core/src/services/scales-cartesian.ts
+++ b/packages/core/src/services/scales-cartesian.ts
@@ -375,6 +375,10 @@ export class CartesianScales extends Service {
 		if (axisOptions.domain) {
 			if (scaleType === ScaleTypes.LABELS) {
 				return axisOptions.domain;
+			} else if (scaleType === ScaleTypes.TIME) {
+				axisOptions.domain = axisOptions.domain.map((d) =>
+					d.getTime === undefined ? new Date(d) : d
+				);
 			}
 			return this.extendsDomain(axisPosition, axisOptions.domain);
 		}


### PR DESCRIPTION
wraps user-provided date strings in the `axes.AXIS_POSITION.domain` flag in the options with JS-date objects

Closes #885