### PR TITLE
fix(core): fix font size issues with title tooltips

### DIFF
--- a/packages/core/src/components/essentials/tooltip.ts
+++ b/packages/core/src/components/essentials/tooltip.ts
@@ -42,7 +42,7 @@ export class Tooltip extends Component {
 			Tools.getProperty(this.getOptions(), "tooltip", "customHTML")
 		) {
 			if (e.detail.content) {
-				const labelHTML = `<div class="title-tooltip">${e.detail.content}</div>`;
+				const labelHTML = `<div class="title-tooltip"><p>${e.detail.content}</p></div>`;
 				tooltipTextContainer.html(labelHTML);
 			} else {
 				tooltipTextContainer.html(
@@ -184,7 +184,7 @@ export class Tooltip extends Component {
 	getTooltipHTML(e: CustomEvent) {
 		let defaultHTML;
 		if (e.detail.content) {
-			defaultHTML = `<div class="title-tooltip">${e.detail.content}</div>`;
+			defaultHTML = `<div class="title-tooltip"><p>${e.detail.content}</p></div>`;
 		} else {
 			const items = this.getItems(e);
 			const formattedItems = this.formatItems(items);

--- a/packages/core/src/styles/components/_tooltip.scss
+++ b/packages/core/src/styles/components/_tooltip.scss
@@ -26,12 +26,13 @@
 
 		.title-tooltip {
 			p {
-				line-height: 16px;
+				margin: 2px;
 				font-size: 12px;
 			}
 			width: auto;
 			padding: 4px;
 			min-width: 20px;
+			max-width: 270px;
 		}
 
 		.datapoint-tooltip {


### PR DESCRIPTION
Font sizes in the title tooltips (truncations) are currently inconsistent with our regular tooltips. This PR fixes that issue

![image](https://user-images.githubusercontent.com/14989804/100139979-4be47900-2e5e-11eb-9190-76731261d425.png)