### PR TITLE
fix: set definedZoomBarData to zoom bar data

### DIFF
--- a/packages/core/src/model-cartesian-charts.ts
+++ b/packages/core/src/model-cartesian-charts.ts
@@ -19,12 +19,20 @@ export class ChartModelCartesian extends ChartModel {
 				Tools.getProperty(
 					this.getOptions(),
 					"zoomBar",
-					"top",
+					AxisPositions.TOP,
 					"enabled"
 				)
 			) {
+				// get pre-defined zoom bar data
+				const definedZoomBarData = Tools.getProperty(
+					this.getOptions(),
+					"zoomBar",
+					AxisPositions.TOP,
+					"data"
+				);
 				// if we have zoom bar data we need to update it as well
-				this.setZoomBarData();
+				// with pre-defined zoom bar data
+				this.setZoomBarData(definedZoomBarData);
 			}
 		}
 


### PR DESCRIPTION
### Updates
- when set zoom bar data, use defined zoom bar data if exists.
- Without this fix, zoom bar will always use chart data instead of zoom bar data when setData is called.

### Demo screenshot or recording
No change in demos.
It only has impact when zoom bar data is updated in run time.

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
