### PR TITLE
feat(core): add custom chart - standalone components renders

### DIFF
--- a/packages/core/src/charts/custom.ts
+++ b/packages/core/src/charts/custom.ts
@@ -1,0 +1,43 @@
+// Internal Imports
+import { Chart } from "../chart";
+import * as Configuration from "../configuration";
+import { ChartConfig } from "../interfaces/index";
+import { Tools } from "../tools";
+
+export class CustomChart extends Chart {
+	constructor(holder: Element, chartConfigs: ChartConfig<any>) {
+		super(holder, chartConfigs);
+
+		// Merge all possible default options together
+		let optionsToMerge = {};
+		Object.keys(Configuration.options).forEach((optionName) => {
+			const options = Configuration.options[optionName];
+
+			optionsToMerge = Tools.merge({}, optionsToMerge, options);
+		});
+
+		// Merge the default options with the user provided options
+		this.model.setOptions(
+			Tools.mergeDefaultChartOptions(optionsToMerge, chartConfigs.options)
+		);
+
+		// Initialize data, services, components etc.
+		this.init(holder, chartConfigs);
+	}
+
+	getComponents() {
+		const userProvidedComponents = Tools.getProperty(
+			this.model.getOptions(),
+			"components"
+		);
+
+		return userProvidedComponents.map(
+			(userProvidedComponent) =>
+				new userProvidedComponent.component(
+					this.model,
+					this.services,
+					userProvidedComponent.configs
+				)
+		);
+	}
+}

--- a/packages/core/src/charts/index.ts
+++ b/packages/core/src/charts/index.ts
@@ -4,6 +4,7 @@ export * from "./bar-simple";
 export * from "./bar-grouped";
 export * from "./bar-stacked";
 export * from "./bubble";
+export * from "./custom";
 export * from "./line";
 export * from "./scatter";
 export * from "./pie";

--- a/packages/core/stories/custom-charts.stories.ts
+++ b/packages/core/stories/custom-charts.stories.ts
@@ -1,0 +1,69 @@
+import { storiesOf } from "@storybook/html";
+import { withKnobs, object } from "@storybook/addon-knobs";
+
+import { storybookDemoGroups } from "../demo/data";
+import * as ChartComponents from "../src/charts";
+import * as storyUtils from "./utils";
+
+import "../demo/styles.scss";
+import { Legend } from "../src/components";
+
+const groupStories = storiesOf("Standalone components", module).addDecorator(
+	withKnobs
+);
+
+// Loop through the demos for the group
+groupStories.add("Demo", () => {
+	// container creation
+	const container = document.createElement("div");
+	container.setAttribute("class", "container theme--g100");
+
+	container.innerHTML = `
+<h3>
+<b class="component">Component</b>
+<span class="bx--tag bx--tag--green component-name">CustomChart</span>
+</h3>
+<p class="props">
+<span><b>Props: </b><span><a href="/?path=/story/tutorials--tabular-data-format">data</a>, </span><a href="https://carbon-design-system.github.io/carbon-charts/documentation/modules/_interfaces_charts_.html" target="_blank">options</a></span>
+</p>
+
+<div id="charting-controls">
+</div>
+
+<div class="marginTop-30" id="chart-demo">
+</div>
+	`;
+
+	// Initialize chart
+	const chart = new ChartComponents.CustomChart(
+		container.querySelector("div#chart-demo"),
+		{
+			data: object("Data", [
+				{ group: "2V2N 9KYPM version 1", value: 20000 },
+				{ group: "L22I P66EP L22I P66EP L22I P66EP", value: 65000 },
+				{ group: "JQAI 2M4L1", value: 75000 },
+				{ group: "J9DZ F37AP", value: 1200 },
+				{ group: "YEL48 Q6XK YEL48", value: 10000 },
+				{ group: "Misc", value: 25000 }
+			]) as any,
+			options: object("Options", {
+				data: {
+					groupMapsTo: "group"
+				},
+				components: [
+					{
+						component: Legend,
+						configs: {
+							one: true
+						}
+					}
+				]
+			})
+		}
+	);
+
+	storyUtils.addDemoDataFormListeners(container, {}, chart);
+	storyUtils.addControls(container, chart);
+
+	return container;
+});


### PR DESCRIPTION
👋 

This is a thought/proposal...
Closes #903 

I've added a `Standalone components` group to the **vanilla** storybook demos. It is rendering a legend component as a standalone.

![image](https://user-images.githubusercontent.com/14989804/103787632-d1d21300-500b-11eb-82c1-4dcefdc5a783.png)
https://deploy-preview-918--carbon-charts-core.netlify.app/?path=/story/standalone-components--demo

This is the quickest method that I could think of... However, it does have a few downsides of its own

To name a few downsides:
1. This works as if you're initializing an entire chart with just a legend visible (you'd need extra options added, e.g. rather than saying I need a legend rendered with `these` items, you're rather providing some data, providing a `groupMapsTo` field and getting the legend to render the correct datagroups...)
2. The above makes it easier to combine components through the `LayoutComponent`, however may introduce many breaking changes as we change the library