### PR TITLE
chore(react): update readme

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -7,18 +7,17 @@
 **[Storybook demo sources](https://github.com/carbon-design-system/carbon-charts/tree/master/packages/core/demo/data)**
 
 ## Getting started
-
 Run the following command using [npm](https://www.npmjs.com/):
 
 ```bash
-npm install -S @carbon/charts @carbon/charts-react d3@5.x
+npm install -S @carbon/charts-react d3@5.x
 ```
 
 If you prefer [Yarn](https://yarnpkg.com/en/), use the following command
 instead:
 
 ```bash
-yarn add @carbon/charts @carbon/charts-react d3@5.x
+yarn add @carbon/charts-react d3@5.x
 ```
 
 **Note:** you'd also need to install `carbon-components` if you're not using a
@@ -54,3 +53,16 @@ used,
 
 Customizable options (specific to chart type) can be found
 [here](https://carbon-design-system.github.io/carbon-charts/documentation/modules/_interfaces_charts_.html)
+
+## Errors trying to resolve `@carbon/charts/styles.css`
+If you're having issues importing `@carbon/charts/styles.css` with an error similar to `can't resolve this module` you may need to install `@carbon/charts` seperately so that your environment can resolve it. To install `@carbon/charts` seperately:
+
+Run the following command using [npm](https://www.npmjs.com/):
+  ```bash
+  npm install -S @carbon/charts
+  ```
+If you prefer [Yarn](https://yarnpkg.com/en/), use the following command
+instead:
+  ```bash
+  yarn add @carbon/charts
+  ```


### PR DESCRIPTION
### Updates
This PR updates the install instructions for React and makes them consistent with the [step-by-step install instructions](https://carbon-design-system.github.io/carbon-charts/?path=/story/tutorials-getting-started--react).

Previously, the install instructions had the user install `@carbon/charts` as part of the install process, but this library brings it in without the _need_ to install it separately. From a conversation with @theiliad the reason it was written this way is because some users had issues where their environment wouldn't resolve `@carbon/charts/styles.css`, for which I added a section addressing this issue.

### Reason
In my case another team member had installed this library. I wanted to use the `GaugeChart` component and had to update to the latest `@carbon/charts-react`. After updating chart styles were only partially applied. After reaching out and digging around in `package.json` I realized that I also needed to update `@carbon/charts`, which could have been prevented with just simply installing `@carbon/charts-react` initially.

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
