### PR TITLE
improvement(core): optimize valueFormatter logic in tooltips

### DIFF
--- a/packages/core/src/components/essentials/tooltip-axis.ts
+++ b/packages/core/src/components/essentials/tooltip-axis.ts
@@ -1,13 +1,6 @@
 import { Tooltip } from './tooltip';
-import {
-	AxisPositions,
-	ScaleTypes,
-	ColorClassNameTypes,
-} from '../../interfaces';
+import { AxisPositions, ColorClassNameTypes } from '../../interfaces';
 import { Tools } from '../../tools';
-
-import { format } from 'date-fns';
-
 export class AxisChartsTooltip extends Tooltip {
 	getItems(e: CustomEvent) {
 		if (e.detail.items) {
@@ -23,7 +16,6 @@ export class AxisChartsTooltip extends Tooltip {
 		const { cartesianScales } = this.services;
 		const domainAxisOptions = cartesianScales.getDomainAxisOptions();
 		const domainIdentifier = cartesianScales.getDomainIdentifier();
-		const domainAxisScaleType = cartesianScales.getDomainAxisScaleType();
 
 		// Generate default tooltip
 		const { groupMapsTo } = options.data;
@@ -41,15 +33,6 @@ export class AxisChartsTooltip extends Tooltip {
 		}
 
 		let domainValue = data[0][domainIdentifier];
-		if (domainAxisScaleType === ScaleTypes.TIME) {
-			domainValue = format(
-				new Date(data[0][domainIdentifier]),
-				'MMM d, yyyy'
-			);
-		} else if (domainAxisScaleType === ScaleTypes.LINEAR) {
-			domainValue = domainValue.toLocaleString();
-		}
-
 		let items: any[];
 		if (data.length === 1) {
 			const datum = data[0];
@@ -96,7 +79,7 @@ export class AxisChartsTooltip extends Tooltip {
 			items = [
 				{
 					label: domainLabel,
-					value: this.valueFormatter(domainValue),
+					value: domainValue,
 				},
 			];
 
@@ -104,9 +87,7 @@ export class AxisChartsTooltip extends Tooltip {
 				data
 					.map((datum) => ({
 						label: datum[groupMapsTo],
-						value: this.valueFormatter(
-							datum[cartesianScales.getRangeIdentifier(datum)]
-						),
+						value: datum[cartesianScales.getRangeIdentifier(datum)],
 						color: this.model.getFillColor(datum[groupMapsTo]),
 						class: this.model.getColorClassName({
 							classNameTypes: [ColorClassNameTypes.TOOLTIP],
@@ -125,12 +106,10 @@ export class AxisChartsTooltip extends Tooltip {
 				const rangeIdentifier = cartesianScales.getRangeIdentifier();
 				items.push({
 					label: options.tooltip.totalLabel || 'Total',
-					value: this.valueFormatter(
-						data.reduce(
-							(accumulator, datum) =>
-								accumulator + datum[rangeIdentifier],
-							0
-						)
+					value: data.reduce(
+						(accumulator, datum) =>
+							accumulator + datum[rangeIdentifier],
+						0
 					),
 					bold: true,
 				});

--- a/packages/core/src/components/essentials/tooltip.ts
+++ b/packages/core/src/components/essentials/tooltip.ts
@@ -229,7 +229,7 @@ export class Tooltip extends Component {
 		}
 
 		if (typeof value.getTime === "function") {
-			return format(new Date(value), 'MMM d, yyyy');
+			return format(value, 'MMM d, yyyy');
 		}
 
 		return value.toLocaleString();

--- a/packages/core/src/components/essentials/tooltip.ts
+++ b/packages/core/src/components/essentials/tooltip.ts
@@ -228,8 +228,6 @@ export class Tooltip extends Component {
 			return valueFormatter(value, label);
 		}
 
-		const { cartesianScales } = this.services;
-
 		if (typeof value.getTime === "function") {
 			return format(new Date(value), 'MMM d, yyyy');
 		}

--- a/packages/core/src/components/essentials/tooltip.ts
+++ b/packages/core/src/components/essentials/tooltip.ts
@@ -2,7 +2,7 @@ import { Component } from '../component';
 import { Tools } from '../../tools';
 import { DOMUtils } from '../../services';
 import { ChartModel } from '../../model';
-import { Events, TruncationTypes } from '../../interfaces';
+import { Events, ScaleTypes, TruncationTypes } from '../../interfaces';
 import * as Configuration from '../../configuration';
 
 // Carbon position service
@@ -13,6 +13,8 @@ import settings from 'carbon-components/es/globals/js/settings';
 
 // D3 Imports
 import { select, mouse } from 'd3-selection';
+
+import { format } from 'date-fns';
 
 export class Tooltip extends Component {
 	type = 'tooltip';
@@ -154,7 +156,7 @@ export class Tooltip extends Component {
 		if (truncationType !== TruncationTypes.NONE) {
 			return items.map((item) => {
 				item.value = item.value
-					? this.valueFormatter(item.value)
+					? this.valueFormatter(item.value, item.label)
 					: item.value;
 				if (item.label && item.label.length > truncationThreshold) {
 					item.label = Tools.truncateLabel(
@@ -214,7 +216,7 @@ export class Tooltip extends Component {
 		return defaultHTML;
 	}
 
-	valueFormatter(value: any) {
+	valueFormatter(value: any, label: string) {
 		const options = this.getOptions();
 		const valueFormatter = Tools.getProperty(
 			options,
@@ -223,7 +225,14 @@ export class Tooltip extends Component {
 		);
 
 		if (valueFormatter) {
-			return valueFormatter(value);
+			return valueFormatter(value, label);
+		}
+
+		const { cartesianScales } = this.services;
+		const domainAxisScaleType = cartesianScales.getDomainAxisScaleType();
+
+		if (domainAxisScaleType === ScaleTypes.TIME) {
+			return format(new Date(value), 'MMM d, yyyy');
 		}
 
 		return value.toLocaleString();

--- a/packages/core/src/components/essentials/tooltip.ts
+++ b/packages/core/src/components/essentials/tooltip.ts
@@ -2,7 +2,7 @@ import { Component } from '../component';
 import { Tools } from '../../tools';
 import { DOMUtils } from '../../services';
 import { ChartModel } from '../../model';
-import { Events, ScaleTypes, TruncationTypes } from '../../interfaces';
+import { Events, TruncationTypes } from '../../interfaces';
 import * as Configuration from '../../configuration';
 
 // Carbon position service
@@ -229,9 +229,8 @@ export class Tooltip extends Component {
 		}
 
 		const { cartesianScales } = this.services;
-		const domainAxisScaleType = cartesianScales.getDomainAxisScaleType();
 
-		if (domainAxisScaleType === ScaleTypes.TIME) {
+		if (typeof value.getTime === "function") {
 			return format(new Date(value), 'MMM d, yyyy');
 		}
 

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -95,7 +95,6 @@ export const ruler: RulerOptions = {
 export const baseTooltip: TooltipOptions = {
 	enabled: true,
 	showTotal: true,
-	valueFormatter: (d) => d.toLocaleString(),
 	truncation: standardTruncationOptions,
 };
 


### PR DESCRIPTION
- calls `valueFormatter` on all tooltip values
- adds `label` to the valueFormatter.... `(value, label) => ...`