### PR TITLE
fix(bounded area chart): update bounded area chart so bounds don't sh…

### DIFF
--- a/packages/core/src/components/graphs/area.ts
+++ b/packages/core/src/components/graphs/area.ts
@@ -41,17 +41,16 @@ export class Area extends Component {
 		const { cartesianScales } = this.services;
 
 		const orientation = cartesianScales.getOrientation();
-		const areaGenerator = area().curve(this.services.curves.getD3Curve())
-		.defined((datum: any, i) => {
-			if (boundsEnabled) {
+		const areaGenerator = area()
+			.curve(this.services.curves.getD3Curve())
+			.defined((datum: any, i) => {
 				const rangeIdentifier = cartesianScales.getRangeIdentifier();
 				const value = datum[rangeIdentifier];
 				if (value === null || value === undefined) {
 					return false;
 				}
-			}
-			return true;
-		});
+				return true;
+			});
 
 		// Update the bound data on area groups
 		const groupedData = this.model.getGroupedData(this.configs.groups);
@@ -136,7 +135,7 @@ export class Area extends Component {
 				.select(
 					`path.${this.model.getColorClassName({
 						classNameTypes: [ColorClassNameTypes.STROKE],
-						dataGroupName: groupedData[0].name
+						dataGroupName: groupedData[0].name,
 					})}`
 				)
 				.node();

--- a/packages/core/src/components/graphs/area.ts
+++ b/packages/core/src/components/graphs/area.ts
@@ -41,7 +41,17 @@ export class Area extends Component {
 		const { cartesianScales } = this.services;
 
 		const orientation = cartesianScales.getOrientation();
-		const areaGenerator = area().curve(this.services.curves.getD3Curve());
+		const areaGenerator = area().curve(this.services.curves.getD3Curve())
+		.defined((datum: any, i) => {
+			if (boundsEnabled) {
+				const rangeIdentifier = cartesianScales.getRangeIdentifier();
+				const value = datum[rangeIdentifier];
+				if (value === null || value === undefined) {
+					return false;
+				}
+			}
+			return true;
+		});
 
 		// Update the bound data on area groups
 		const groupedData = this.model.getGroupedData(this.configs.groups);


### PR DESCRIPTION
…ow for null values

Behaviour of bounded area chart now match that of the line chart where null values are shown as a
break in the chart

fix #980

### Updates
- Fix for issue https://github.com/carbon-design-system/carbon-charts/issues/980

### Demo screenshot or recording
Not sure if this is ok, but this is how it looks with a null value in
<img width="799" alt="Screenshot 2021-03-30 at 10 18 41" src="https://user-images.githubusercontent.com/44590418/112978230-fd6a2280-914e-11eb-964b-804fb780a4c8.png">


### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
