### PR TITLE
feat(zoombar): canvas implementation of zoom bar graph view

### DIFF
--- a/packages/core/demo/data/index.ts
+++ b/packages/core/demo/data/index.ts
@@ -1045,6 +1045,12 @@ let allDemoGroups = [
 				isDemoExample: false,
 			},
 			{
+				options: zoomBarDemos.zoomBarAreaCanvasOptions,
+				data: zoomBarDemos.zoomBarAreaCanvasData,
+				chartType: chartTypes.AreaChart,
+				isDemoExample: false,
+			},
+			{
 				options: zoomBarDemos.zoomBarLockedOptions,
 				data: zoomBarDemos.zoomBarLockedData,
 				chartType: chartTypes.StackedBarChart,

--- a/packages/core/demo/data/zoom-bar.ts
+++ b/packages/core/demo/data/zoom-bar.ts
@@ -59,6 +59,31 @@ export const addZoomBarToOptions = (
 	return options;
 };
 
+export const addCanvasZoomBar = (
+	options,
+	configs: any = { includeDefinedZoomBarData: false }
+) => {
+	options['experimental'] = true;
+	options.title += ' - Canvas zoom bar enabled';
+		options.zoomBar = {
+			canvas: true,
+			top: {
+				enabled: true,
+				...(configs.sliderView
+					? {
+							type: 'slider_view',
+					  }
+					: null),
+			},
+		};
+	return options;
+};
+
+export const zoomBarAreaCanvasData = areaChart.areaTimeSeriesCurvedData;
+export const zoomBarAreaCanvasOptions = addCanvasZoomBar(
+	Object.assign({}, areaChart.areaTimeSeriesCurvedOptions)
+);
+
 export const zoomBarStackedAreaTimeSeriesData =
 	areaChart.stackedAreaTimeSeriesData;
 export const zoomBarStackedAreaTimeSeriesOptions = addZoomBarToOptions(

--- a/packages/core/src/components/axes/zoom-bar.ts
+++ b/packages/core/src/components/axes/zoom-bar.ts
@@ -113,6 +113,7 @@ export class ZoomBar extends Component {
 		let zoomGraphArea;
 
 		if (zoombarType === ZoomBarTypes.GRAPH_VIEW) {
+			// Draw zoombar background rectangle
 			DOMUtils.appendOrSelect(container, 'rect.zoom-bg')
 				.attr('x', axesLeftMargin)
 				.attr('y', 0)
@@ -121,7 +122,10 @@ export class ZoomBar extends Component {
 				.classed('zoom-bg-skeleton', isTopZoomBarLoading);
 
 			if (canvas) {
-				const canvasContainer = this.addCanvasContainer(width,zoombarHeight);
+				const canvasContainer = this.addCanvasContainer(
+					width,
+					zoombarHeight
+				);
 
 				// Append canvases
 				zoomGraphAreaUnselected = DOMUtils.appendOrSelectCanvas(
@@ -129,7 +133,7 @@ export class ZoomBar extends Component {
 					{ width: String(width), height: zoombarHeight },
 					'zoom-graph-area-unselected-canvas'
 				);
-		
+
 				zoomGraphArea = DOMUtils.appendOrSelectCanvas(
 					canvasContainer,
 					{ width: String(width), height: zoombarHeight },
@@ -218,17 +222,19 @@ export class ZoomBar extends Component {
 					},
 					{ skipUpdate: true }
 				);
-			} else if (newInitialZoomDomain === null && oldInitialZoomDomain != null){
+			} else if (
+				newInitialZoomDomain === null &&
+				oldInitialZoomDomain != null
+			) {
 				// if newInitialZoomDomain is set to null (when oldInitialZoomDomain is not null)
 				// save initialZoomDomain and reset zoom domain to default domain
 				this.model.set(
 					{
 						initialZoomDomain: null,
-						zoomDomain: Tools.merge([], defaultDomain)
+						zoomDomain: Tools.merge([], defaultDomain),
 					},
 					{ skipUpdate: true }
 				);
-
 			}
 
 			this.xScale.range([axesLeftMargin, width]).domain(defaultDomain);
@@ -257,9 +263,17 @@ export class ZoomBar extends Component {
 					this.clipId
 				);
 				// Draw the zoom bar base line
-				this.renderZoomBarBaseline((canvas ? zoomGraphAreaUnselected : container), axesLeftMargin, width);
+				this.renderZoomBarBaseline(
+					canvas ? zoomGraphAreaUnselected : container,
+					axesLeftMargin,
+					width
+				);
 				if (canvas) {
-					this.renderZoomBarBaseline(zoomGraphArea, axesLeftMargin, width);
+					this.renderZoomBarBaseline(
+						zoomGraphArea,
+						axesLeftMargin,
+						width
+					);
 				}
 			}
 
@@ -308,7 +322,7 @@ export class ZoomBar extends Component {
 		}
 	}
 
-	addCanvasContainer(width, zoombarHeight){
+	addCanvasContainer(width, zoombarHeight) {
 		const chartprefix = Tools.getProperty(
 			this.getOptions(),
 			'style',
@@ -318,29 +332,36 @@ export class ZoomBar extends Component {
 		// Done this way to ensure cross browser compatability
 		// As canvas positioning is not the same across browsers when canvas appended onto svg
 		let canvasContainerPosition;
-		const zoomSvgPosition = select(`svg.${settings.prefix}--${chartprefix}--zoom-bar`)
-		if(!zoomSvgPosition.empty()){
+		const zoomSvgPosition = select(
+			`svg.${settings.prefix}--${chartprefix}--zoom-bar`
+		);
+		if (!zoomSvgPosition.empty()) {
 			canvasContainerPosition = `${zoomSvgPosition.attr('y')}px`;
 		}
 
 		let canvasContainer;
-		const holder = select(this.model.get('holder'))
-		const selection = holder.select(`div.${settings.prefix}--${chartprefix}--canvas-container`);
+		const holder = select(this.model.get('holder'));
+		const selection = holder.select(
+			`div.${settings.prefix}--${chartprefix}--canvas-container`
+		);
 
-		if (selection.empty()){
+		if (selection.empty()) {
 			// Use of xhtml causes errors in DOMUtils appendorselect method
-			canvasContainer = holder.append('xhtml:div')
-				.attr('class', `${settings.prefix}--${chartprefix}--canvas-container`)
+			canvasContainer = holder
+				.append('xhtml:div')
+				.attr(
+					'class',
+					`${settings.prefix}--${chartprefix}--canvas-container`
+				)
 				.style('width', `${width}px`)
 				.style('height', `${zoombarHeight}px`)
 				.style('position', 'absolute')
 				.style('top', canvasContainerPosition);
 		} else {
-			canvasContainer = 
-				selection
-					.style('width', `${width}px`)
-					.style('height', `${zoombarHeight}px`)
-					.style('top', canvasContainerPosition);
+			canvasContainer = selection
+				.style('width', `${width}px`)
+				.style('height', `${zoombarHeight}px`)
+				.style('top', canvasContainerPosition);
 		}
 		return canvasContainer;
 	}
@@ -608,37 +629,48 @@ export class ZoomBar extends Component {
 			const handleWidth = Configuration.zoomBar.handleWidth;
 
 			const axesMargins = this.model.get('axesMargins');
-			const axesLeftMargin = axesMargins && axesMargins.left ? axesMargins.left : null;
+			const axesLeftMargin =
+				axesMargins && axesMargins.left ? axesMargins.left : null;
 			const { width } = DOMUtils.getSVGElementSize(this.parent, {
 				useAttrs: true,
 			});
 
 			const zoomDomain = this.model.get('zoomDomain');
-			const selection = zoomDomain ? zoomDomain.map((domain) =>
-				this.xScale(domain)
-			): [axesLeftMargin, width-axesLeftMargin];
+			const selection = zoomDomain
+				? zoomDomain.map((domain) => this.xScale(domain))
+				: [axesLeftMargin, width - axesLeftMargin];
 
 			// clip the canvas based on selected area
 			if (querySelector !== 'path.zoom-graph-area-unselected') {
-
 				const clipStart = Math.max(
 					selection[0] + handleWidth / 2,
 					this.maxSelectionRange[0] + handleWidth
 				);
 
-				const clipWidth = Math.min(
-					selection[1] - handleWidth / 2,
-					this.maxSelectionRange[1] - handleWidth
-				) - clipStart;
+				const clipWidth =
+					Math.min(
+						selection[1] - handleWidth / 2,
+						this.maxSelectionRange[1] - handleWidth
+					) - clipStart;
 
-				container.rect(clipStart, 0, clipWidth , zoombarHeight);
+				container.rect(clipStart, 0, clipWidth, zoombarHeight);
 				container.clip();
 			}
 
 			// clip the canvas based on unselected area
 			if (querySelector === 'path.zoom-graph-area-unselected') {
-				container.rect(0, 0, selection[0] - (handleWidth / 2) , zoombarHeight);
-				container.rect(selection[1] + handleWidth / 2, 0, this.maxSelectionRange[1] - selection[1], zoombarHeight);
+				container.rect(
+					0,
+					0,
+					selection[0] - handleWidth / 2,
+					zoombarHeight
+				);
+				container.rect(
+					selection[1] + handleWidth / 2,
+					0,
+					this.maxSelectionRange[1] - selection[1],
+					zoombarHeight
+				);
 				container.clip();
 			}
 
@@ -647,19 +679,27 @@ export class ZoomBar extends Component {
 
 			//non position based styling on canvas does not work through css
 			//so have to apply here
-			if(querySelector !== 'path.zoom-graph-area-unselected'){
-				container.lineWidth = 2
-				container.fillStyle = DOMUtils.getComponentStyle('canvas.zoom-graph-area-canvas','fill');
-				container.strokeStyle = DOMUtils.getComponentStyle('canvas.zoom-graph-area-canvas','stroke');
+			if (querySelector !== 'path.zoom-graph-area-unselected') {
+				container.lineWidth = 2;
+				container.fillStyle = DOMUtils.getComponentStyle(
+					'canvas.zoom-graph-area-canvas',
+					'fill'
+				);
+				container.strokeStyle = DOMUtils.getComponentStyle(
+					'canvas.zoom-graph-area-canvas',
+					'stroke'
+				);
 				container.stroke();
 			} else {
-				container.fillStyle = DOMUtils.getComponentStyle('canvas.zoom-graph-area-unselected-canvas','fill');
+				container.fillStyle = DOMUtils.getComponentStyle(
+					'canvas.zoom-graph-area-unselected-canvas',
+					'fill'
+				);
 			}
 
 			container.fill();
 			container.closePath();
 		} else {
-
 			const areaGraph = DOMUtils.appendOrSelect(container, querySelector)
 				.datum(data)
 				.attr('d', areaGenerator);
@@ -725,7 +765,10 @@ export class ZoomBar extends Component {
 		const zoombarHeight = Configuration.zoomBar.height[zoombarType];
 
 		if (canvas) {
-			container.strokeStyle =  DOMUtils.getComponentStyle('canvas.zoom-graph-area-canvas','stroke');
+			container.strokeStyle = DOMUtils.getComponentStyle(
+				'canvas.zoom-graph-area-canvas',
+				'stroke'
+			);
 			container.beginPath();
 			container.lineWidth = 2;
 			container.moveTo(startX, zoombarHeight);

--- a/packages/core/src/interfaces/components.ts
+++ b/packages/core/src/interfaces/components.ts
@@ -182,6 +182,11 @@ export interface ZoomBarsOptions {
 	 * whether keep updating range axis in real time while zoom domain is changing
 	 */
 	updateRangeAxis?: boolean;
+	/**
+	 * whether to use the canvas option 
+	 * currently only works for graph view
+	 */
+	canvas?: boolean;
 }
 
 /**

--- a/packages/core/src/services/essentials/dom-utils.ts
+++ b/packages/core/src/services/essentials/dom-utils.ts
@@ -183,6 +183,35 @@ export class DOMUtils extends Service {
 		return alignmentOffset;
 	}
 
+	static appendOrSelectCanvas(parent, attributes, query) {
+		const selection = parent.select("canvas." + `${query}`);
+
+		if (selection.empty()) {
+			// creates a new canvas if one is not there already
+			const canvas = document.createElement("canvas");
+			Object.keys(attributes).forEach((key) => {
+				canvas.setAttribute(key, attributes[key]);
+
+			});
+			canvas.setAttribute("class", query);
+			parent.node().appendChild(canvas);
+
+			return canvas.getContext("2d");;
+		}
+
+		Object.keys(attributes).forEach((key) => {
+			selection.attr(key, attributes[key]);
+		});
+		return selection.node().getContext("2d");
+	}
+
+	static getComponentStyle(component, style) {
+		const styledComponent = select(component);
+		if(!styledComponent.empty()){
+			return styledComponent.style(style);
+		}
+	}
+
 	protected svg: Element;
 	protected width: string;
 	protected height: string;

--- a/packages/core/src/styles/components/_zoom-bar.scss
+++ b/packages/core/src/styles/components/_zoom-bar.scss
@@ -56,3 +56,27 @@ g.#{$prefix}--#{$charts-prefix}--zoom-bar {
 		}
 	}
 }
+div.#{$prefix}--#{$charts-prefix}--canvas-container {
+	position: relative;
+	left: 0;
+	top: 0;
+	z-index: 0;
+	pointer-events: none;
+
+	canvas.zoom-graph-area-canvas {	
+		left: 0;
+		position: absolute;
+		top: 0;
+		z-index: 2;
+		fill: $ui-03;
+		stroke: $ui-04;
+	}
+
+	canvas.zoom-graph-area-unselected-canvas {
+		left: 0;
+		position: absolute;
+		top: 0;
+		z-index: 1;
+		fill: $ui-01;
+	}
+} 


### PR DESCRIPTION
### Updates
Add in canvas implementation of zoom bar for graph view
Has "flag" in options needed to activate, svg implementation is default.
I've tried to keep the changes to be minimal so only the graph is changed, but please let me know of any parts which you think need refactoring or if you're unsure of why things have been done a specific way.

### Demo screenshot or recording
The styling and everything is the same as the standard zoombar.
However, as expected with canvas, the outline may not be as crisp as that by svg. But for me it isn't noticeable. 

<img width="809" alt="Screenshot 2021-04-07 at 16 05 17" src="https://user-images.githubusercontent.com/44590418/113890754-57589100-97bc-11eb-8264-58c2ecd8bc60.png">

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
