### PR TITLE
fix(core): set a min-2px size for simple bars

### DIFF
--- a/packages/core/src/components/graphs/bar-simple.ts
+++ b/packages/core/src/components/graphs/bar-simple.ts
@@ -1,6 +1,11 @@
 // Internal Imports
 import { Bar } from './bar';
-import { Events, Roles, ColorClassNameTypes } from '../../interfaces';
+import {
+	Events,
+	Roles,
+	ColorClassNameTypes,
+	CartesianOrientations,
+} from '../../interfaces';
 import { Tools } from '../../tools';
 
 // D3 Imports
@@ -33,6 +38,8 @@ export class SimpleBar extends Bar {
 		const svg = this.getContainerSVG({ withinChartClip: true });
 
 		const data = this.model.getDisplayData(this.configs.groups);
+
+		const orientation = this.services.cartesianScales.getOrientation();
 
 		// Update data on all bars
 		const bars = svg
@@ -90,6 +97,21 @@ export class SimpleBar extends Bar {
 					y1 = this.services.cartesianScales.getRangeValue(d, i);
 				}
 
+				const difference = Math.abs(y1 - y0);
+				// Set a min-2px size for the bar
+				if (difference !== 0 && difference < 2) {
+					if (
+						(value > 0 &&
+							orientation === CartesianOrientations.VERTICAL) ||
+						(value < 0 &&
+							orientation === CartesianOrientations.HORIZONTAL)
+					) {
+						y1 = y0 - 2;
+					} else {
+						y1 = y0 + 2;
+					}
+				}
+
 				// don't show if part of bar is out of zoom domain
 				if (this.isOutsideZoomedDomain(x0, x1)) {
 					return;
@@ -97,7 +119,7 @@ export class SimpleBar extends Bar {
 
 				return Tools.generateSVGPathString(
 					{ x0, x1, y0, y1 },
-					this.services.cartesianScales.getOrientation()
+					orientation
 				);
 			})
 			.attr('opacity', 1)


### PR DESCRIPTION
in the example below the bar size ends up being less than 1px, however bc that renders as an invisible bar, we're keeping it at a min of 2px

![image](https://user-images.githubusercontent.com/14989804/116902928-c2ee1c80-ac09-11eb-8c0a-7966f77e84f6.png)
