### PR TITLE
fix(core): fix circlepacks with one dataset

### DIFF
--- a/packages/core/src/components/graphs/circle-pack.ts
+++ b/packages/core/src/components/graphs/circle-pack.ts
@@ -41,7 +41,7 @@ export class CirclePack extends Component {
 
 		// check if there is one root for the data
 		// that root will be the only datagroup (colorscale will be monochrome)
-		if (parentNode) {
+		if (parentNode && Tools.getProperty(displayData, 0, 'children')) {
 			// remove want to remove the parent from being rendered
 			displayData = Tools.getProperty(displayData, 0, 'children');
 		}

--- a/packages/core/src/model-circle-pack.ts
+++ b/packages/core/src/model-circle-pack.ts
@@ -56,7 +56,7 @@ export class CirclePackChartModel extends ChartModel {
 		const displayData = this.getDisplayData();
 		const zoomOptions = options ? options : this.getOptions();
 		const data =
-			displayData.length === 1
+			displayData.length === 1 && Tools.getProperty(displayData, 0, 'children')
 				? Tools.getProperty(displayData, 0, 'children')
 				: displayData;
 


### PR DESCRIPTION
fix #1031

### Updates
- fix so that circle pack can have just **one dataset** that is a depth 1


### Demo screenshot or recording
![image](https://user-images.githubusercontent.com/14351335/119712628-cb173180-be2e-11eb-8da3-fd82f7075011.png)

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
