### PR TITLE
feat(pie): add sortFunction option for pie chart

### DIFF
--- a/packages/core/src/components/graphs/pie.ts
+++ b/packages/core/src/components/graphs/pie.ts
@@ -82,6 +82,12 @@ export class Pie extends Component {
 			.sort(null)
 			.padAngle(Configuration.pie.padAngle);
 
+		// set sort function from options
+		const sortFunction = options?.pie?.sortFunction;
+		if (sortFunction) {
+			pieLayout.sort(sortFunction);
+		}
+
 		// Sort pie layout data based off of the indecies the layout creates
 		const pieLayoutData = pieLayout(displayData).sort(
 			(a: any, b: any) => a.index - b.index

--- a/packages/core/src/interfaces/charts.ts
+++ b/packages/core/src/interfaces/charts.ts
@@ -315,6 +315,7 @@ export interface PieChartOptions extends BaseChartOptions {
 			enabled?: Boolean;
 		};
 		alignment?: Alignments;
+		sortFunction?: Function;
 	};
 }
 

--- a/packages/core/src/interfaces/charts.ts
+++ b/packages/core/src/interfaces/charts.ts
@@ -315,7 +315,7 @@ export interface PieChartOptions extends BaseChartOptions {
 			enabled?: Boolean;
 		};
 		alignment?: Alignments;
-		sortFunction?: Function;
+		sortFunction?: (a: any, b: any) => number;
 	};
 }
 


### PR DESCRIPTION
### Updates
- Add sortFunction option for pie chart and doughnut chart

### Example

sort by group order

```
const groupOrders = ['group1', 'group2'];

option: {
	pie: {
      sortFunction: (a: any, b: any) => {
		return groupOrders.indexOf(a.group) - groupOrders.indexOf(b.group);  // sort by group orders
      },
    },
}
```

### Demo screenshot or recording

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
