### PR TITLE
feat(svelte): add type definitions for BulletChart, CirclePackChart

### DIFF
--- a/packages/svelte/tests/BulletChart.test.svelte
+++ b/packages/svelte/tests/BulletChart.test.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+    import { BulletChart } from "../types";
+    import type { BulletChart as BC } from "@carbon/charts";
+    import { basicBulletData as data, basicBulletOptions  } from "@carbon/charts/demo/data";
+  
+    let chart: BC = null;
+    let ref = null;
+  
+    const options = basicBulletOptions as any;
+  </script>
+  
+  <BulletChart
+      bind:chart
+      bind:ref
+      on:load={e => {
+          console.log(e.detail);
+      }}
+      on:update={e => {
+          console.log(e.detail);
+      }}
+      on:destroy={e => {
+          console.log(e.detail);
+      }}
+      {data}
+      {options} />
+  
+  <svelte:component
+      this={BulletChart}
+      on:load={e => {
+          console.log(e.detail);
+      }}
+      on:update={e => {
+          console.log(e.detail);
+      }}
+      on:destroy={e => {
+          console.log(e.detail);
+      }}
+      {data}
+      {options} />
+  

--- a/packages/svelte/tests/CirclePackChart.test.svelte
+++ b/packages/svelte/tests/CirclePackChart.test.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+    import { CirclePackChart } from "../types";
+    import type { CirclePackChart as BC } from "@carbon/charts";
+    import { circlePackThreeLevelData as data, circlePackSingleOptions  } from "@carbon/charts/demo/data";
+  
+    let chart: BC = null;
+    let ref = null;
+  
+    const options = circlePackSingleOptions as any;
+  </script>
+  
+  <CirclePackChart
+      bind:chart
+      bind:ref
+      on:load={e => {
+          console.log(e.detail);
+      }}
+      on:update={e => {
+          console.log(e.detail);
+      }}
+      on:destroy={e => {
+          console.log(e.detail);
+      }}
+      {data}
+      {options} />
+  
+  <svelte:component
+      this={CirclePackChart}
+      on:load={e => {
+          console.log(e.detail);
+      }}
+      on:update={e => {
+          console.log(e.detail);
+      }}
+      on:destroy={e => {
+          console.log(e.detail);
+      }}
+      {data}
+      {options} />
+  

--- a/packages/svelte/types/BulletChart.d.ts
+++ b/packages/svelte/types/BulletChart.d.ts
@@ -1,0 +1,5 @@
+import { BulletChart as BC } from "@carbon/charts";
+import type { BulletChartOptions } from "@carbon/charts/interfaces";
+import BaseChart from "./BaseChart";
+
+export default class BulletChart extends BaseChart<BC, BulletChartOptions> {}

--- a/packages/svelte/types/CirclePackChart.d.ts
+++ b/packages/svelte/types/CirclePackChart.d.ts
@@ -1,0 +1,5 @@
+import { CirclePackChart as CC } from "@carbon/charts";
+import type { CirclePackChartOptions } from "@carbon/charts/interfaces";
+import BaseChart from "./BaseChart";
+
+export default class CirclePackChart extends BaseChart<CC, CirclePackChartOptions> {}

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -5,6 +5,8 @@ export { default as BarChartSimple } from "./BarChartSimple";
 export { default as BarChartStacked } from "./BarChartStacked";
 export { default as BoxplotChart } from "./BoxplotChart";
 export { default as BubbleChart } from "./BubbleChart";
+export { default as BulletChart } from "./BulletChart";
+export { default as CirclePackChart } from "./CirclePackChart";
 export { default as ComboChart } from "./ComboChart";
 export { default as DonutChart } from "./DonutChart";
 export { default as LineChart } from "./LineChart";


### PR DESCRIPTION
### Updates

- add type definitions for BulletChart, CirclePackChart

### Demo screenshot or recording

N/A

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
