### PR TITLE
 fix(core): keep custom fill colors if custom getIsFilled is passed

### DIFF
--- a/packages/core/src/components/graphs/scatter.ts
+++ b/packages/core/src/components/graphs/scatter.ts
@@ -433,25 +433,24 @@ export class Scatter extends Component {
 					const domainIdentifier = self.services.cartesianScales.getDomainIdentifier(
 						datum
 					);
+					const isFilled = self.model.getIsFilled(
+						datum[groupMapsTo],
+						datum[domainIdentifier],
+						datum,
+						filled
+					);
 					hoveredElement
-						.classed(
-							'unfilled',
-							!self.model.getIsFilled(
-								datum[groupMapsTo],
-								datum[domainIdentifier],
-								datum,
-								filled
-							)
-						)
-						.style('fill', (d) =>
-							filled
-								? self.model.getFillColor(
-										d[groupMapsTo],
-										d[domainIdentifier],
-										d
-								  )
-								: null
-						);
+						.classed('unfilled', !isFilled)
+						.style('fill', (d) => {
+							if (isFilled || filled) {
+								return self.model.getFillColor(
+									d[groupMapsTo],
+									d[domainIdentifier],
+									d
+								)
+							}
+							return null;
+						});
 				}
 
 				// Dispatch mouse event


### PR DESCRIPTION
Keep custom fill colors if custom getIsFilled is passed on mouseover for line graph
fix #1032 

### Updates
- list
- out
- updates
- here (and don't forget to link the issues)

### Demo screenshot or recording
https://user-images.githubusercontent.com/38994122/123815757-be21ae00-d8c4-11eb-84de-503b0a3203fc.mov


### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide]
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
