### PR TITLE
fix(core): display the correct total sum for circle pack

### DIFF
--- a/packages/core/src/components/graphs/circle-pack.ts
+++ b/packages/core/src/components/graphs/circle-pack.ts
@@ -274,21 +274,13 @@ export class CirclePack extends Component {
 						}
 						childrenData = datum.children.map((child) => {
 							if (child !== null) {
-								// sum up the children values if there are any 3rd level
-								let value;
+								// retrieve the children values if there are any 3rd level
 								if (typeof child.data.value === 'number') {
-									value = child.data.value;
-
 									return {
 										label: child.data.name,
-										value: value,
+										value: child.data.value,
 									};
 								} else {
-									value = child.data.children.reduce(
-										(a, b) => a + b.value,
-										0
-									);
-
 									return {
 										label: child.data.name,
 										labelIcon:
@@ -296,7 +288,7 @@ export class CirclePack extends Component {
 											hierarchyLevel <= 2
 												? self.getZoomIcon()
 												: null,
-										value: value,
+										value: child.value,
 									};
 								}
 							}


### PR DESCRIPTION
Correctly display the tooltip value on hover for circle pack.
fix #1039

### Updates
- list
- out
- updates
- here (and don't forget to link the issues)

### Demo screenshot or recording
<img width="487" alt="Screen Shot 2021-06-28 at 11 47 11 PM" src="https://user-images.githubusercontent.com/38994122/123817593-4bb1cd80-d8c6-11eb-93a8-7f9642ab204e.png">

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
