### PR TITLE
feat: add panzoom component and examples

### DIFF
--- a/packages/react/src/diagrams/PanZoom/PanZoom.stories.js
+++ b/packages/react/src/diagrams/PanZoom/PanZoom.stories.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import PanZoomWrapper from './PanZoomWrapper';
+import PanZoomBody from './PanZoomBody';
+import PanZoomMap from './PanZoomMap';
+import CardNode, { CardNodeColumn, CardNodeTitle, CardNodeSubtitle } from '../../../dist/diagrams/CardNode';
+import Edge from '../../../dist/diagrams/Edge';
+import ShapeNode from '../../../dist/diagrams/ShapeNode';
+import { User20, Wikis20 } from '@carbon/icons-react';
+
+const stories = storiesOf('Diagrams|PanZoom', module);
+stories.addDecorator((story) => (
+	<div className="container theme--white" style={{ display: "flex" }}>{story()}</div>
+));
+
+const graphHeight = 800;
+const graphWidth = 1000;
+
+const GraphExample = ({simple = false}) => {
+	const nodeHeight = 64;
+	const nodeWidth = 200;
+	const circleSize = 64;
+
+	return (
+		<div style={{ height: graphHeight, width: graphWidth, backgroundColor: "#fff" }}>
+			<svg height="100%" width="100%">
+				<Edge
+					source={{ x: 200, y: 132 }}
+					target={{ x: 600, y: 132 }}
+					variant={!simple ? 'dash-sm' : null}
+				/>
+
+				<foreignObject
+					style={{ overflow: 'visible' }}
+					transform={`translate(${100},${100})`}
+					height={nodeHeight}
+					width={nodeWidth}>
+					<CardNode>
+						{ !simple &&
+						<React.Fragment>
+							<CardNodeColumn>
+								<User20 />
+							</CardNodeColumn>
+							<CardNodeColumn>
+								<CardNodeTitle>Title</CardNodeTitle>
+								<CardNodeSubtitle>Description</CardNodeSubtitle>
+							</CardNodeColumn>
+						</React.Fragment>
+						}
+					</CardNode>
+				</foreignObject>
+
+				<foreignObject
+					style={{ overflow: 'visible' }}
+					transform={`translate(${600},${100})`}>
+					<ShapeNode title={!simple ? 'Title' : null} size={circleSize} renderIcon={!simple ? <Wikis20 /> : null} />
+				</foreignObject>
+			</svg>
+		</div>
+	)
+}
+
+stories.add('Default', () => (
+	<PanZoomBody>
+		<GraphExample />
+	</PanZoomBody>
+));
+
+stories.add('With map', () => (
+		<PanZoomWrapper
+			outerDimensions={{ height: 400, width: 600 }}
+			innerDimensions={{ width: graphWidth, height: graphHeight }}
+		>
+			{ ({...rest}) =>
+				<React.Fragment>
+					<div style={{ border: "1px solid #e0e0e0" }}>
+						<PanZoomBody {...rest}>
+							<GraphExample />
+						</PanZoomBody>
+					</div>
+					<div style={{ margin: "1rem" }}>
+						<PanZoomMap {...rest}>
+							<GraphExample simple />
+						</PanZoomMap>
+					</div>
+				</React.Fragment>
+			}
+		</PanZoomWrapper>
+));

--- a/packages/react/src/diagrams/PanZoom/PanZoomBody.js
+++ b/packages/react/src/diagrams/PanZoom/PanZoomBody.js
@@ -1,0 +1,59 @@
+import React, {useRef, useLayoutEffect} from 'react';
+import settings from 'carbon-components/src/globals/js/settings';
+import { zoom, zoomIdentity } from 'd3-zoom';
+import { select, event } from 'd3-selection';
+
+const { prefix } = settings;
+
+export default ({
+	children,
+	outerDimensions = { height: "100%", width: "100%" },
+	onTransform = () => {},
+	scaleExtent = [0.25, 1.5],
+	transform = {
+		x: 0,
+		y: 0,
+		k: 1
+	}
+}) => {
+	const namespace = `${prefix}--cc--panzoom`;
+	const outerRef = useRef(null);
+	const innerRef = useRef(null);
+	const panZoomRef = useRef(null);
+
+	const {k,x,y} = transform;
+
+	const pz = zoom()
+		.scaleExtent(scaleExtent)
+		.on("zoom", () => {
+			const {x,y,k} = event.transform;
+			innerRef.current.style.transform = `translate(${x}px, ${y}px) scale(${k})`;
+			innerRef.current.style.transformOrigin = "0 0";
+
+			onTransform(event.transform);
+	});
+
+	useLayoutEffect(() => {
+		panZoomRef.current = select(outerRef.current);
+
+		panZoomRef.current
+			.call(pz)
+			.call(pz.transform, zoomIdentity.translate(x, y).scale(k))
+
+		return () => {
+			pz.on("zoom", null);
+		}
+	}, []);
+
+	useLayoutEffect(() => {
+		panZoomRef.current.call(pz.transform, zoomIdentity.translate(x, y).scale(k));
+	}, [x,y,k]);
+
+	return (
+		<div ref={outerRef} className={namespace} style={{ height: outerDimensions.height, width: outerDimensions.width, overflow: "hidden" }}>
+			<div ref={innerRef} style={{ height: "100%", width: "100%" }}>
+				{children}
+			</div>
+		</div>
+	);
+};

--- a/packages/react/src/diagrams/PanZoom/PanZoomMap.js
+++ b/packages/react/src/diagrams/PanZoom/PanZoomMap.js
@@ -1,0 +1,142 @@
+import React, {useState} from 'react';
+import { ZoomIn16, ZoomOut16, ZoomReset16 } from "@carbon/icons-react";
+import { Button } from "carbon-components-react";
+import settings from 'carbon-components/src/globals/js/settings';
+import {min} from 'd3-array';
+
+const { prefix } = settings;
+
+export default ({
+		children,
+		outerDimensions,
+		innerDimensions,
+		maxHeight = 136,
+		maxWidth = 176,
+		onZoomIn = () => {},
+		onZoomOut = () => {},
+		onReset = () => {},
+		onTransform = () => {},
+		transform = {}
+	}) =>
+{
+	const namespace = `${prefix}--cc--pan-zoom-map`;
+
+	const {k,x,y} = transform;
+
+	const invertMatrix = (scale, translateX, translateY) => {
+		const denominator = scale * scale;
+
+		return {
+		scale: scale / denominator,
+		translateX: (scale * translateX) / -denominator,
+		translateY: (scale * translateY) / -denominator
+	};}
+
+	const inverse = invertMatrix(k, x, y);
+	const { translateX, translateY, scale } = inverse;
+
+	const scaleFactor = min([maxHeight / innerDimensions.height, maxWidth / innerDimensions.width]);
+
+	const scalePercentage = Math.round(k * 100);
+
+	const [isDragging, setIsDragging] = useState(false)
+
+	const setPosition = (e) => {
+		let currentTargetRect = e.currentTarget.getBoundingClientRect();
+		const event_offsetX = e.pageX - currentTargetRect.left, event_offsetY = e.pageY - currentTargetRect.top;
+
+		const newPosX = (event_offsetX / scaleFactor) * k / -1;
+		const newPosY = (event_offsetY / scaleFactor) * k / -1;
+
+		onTransform({
+			x: newPosX + (outerDimensions.width / 2),
+			y: newPosY + (outerDimensions.height / 2),
+			k
+		})
+	}
+
+	const handleMouseMove = e => {
+		isDragging && setPosition(e);
+		e.preventDefault();
+	};
+
+	const handleMouseDown = e => {
+		setIsDragging(true);
+	};
+
+	const handleClick = (e) => {
+		setPosition(e);
+	}
+
+	const handleMouseUp = e => {
+		setIsDragging(false);
+	};
+
+	return (
+		<div className={namespace}>
+			<div className={`${namespace}__toolbar`}>
+				<div className={`${namespace}__percentage`}>
+					{`${scalePercentage}%`}
+				</div>
+				<div className={`${namespace}__controls`}>
+					<div className={`${namespace}__control`}>
+						<Button onClick={onZoomIn} hasIconOnly kind={`ghost`} size={`small`} renderIcon={ZoomIn16} iconDescription={"Zoom in"} />
+					</div>
+					<div className={`${namespace}__control`}>
+						<Button onClick={onZoomOut} hasIconOnly kind={`ghost`} size={`small`} renderIcon={ZoomOut16} iconDescription={"Zoom out"} />
+					</div>
+					<div className={`${namespace}__control`}>
+						<Button onClick={onReset} hasIconOnly kind={`ghost`} size={`small`} renderIcon={ZoomReset16} iconDescription={"Reset zoom"} />
+					</div>
+				</div>
+			</div>
+
+			<div
+				style={{
+					height: maxHeight,
+					width: maxWidth,
+					display: "flex",
+					alignItems: "center",
+					justifyContent: "center",
+					overflow: "hidden"
+				}}>
+			<div
+				onMouseDown={() => handleMouseDown()}
+				onMouseLeave={() => handleMouseUp()}
+				onClick={(e) => handleClick(e)}
+				onMouseUp={() => handleMouseUp()}
+				onMouseMove={e => handleMouseMove(e)}
+				style={{
+					height: innerDimensions.height * scaleFactor,
+					width: innerDimensions.width * scaleFactor,
+					boxSizing: "border-box",
+					position: "relative"
+				}}
+			>
+					<div style={{
+						height: innerDimensions.height,
+						width: innerDimensions.width,
+						transform: `scale(${scaleFactor})`,
+						transformOrigin: '0 0' }}
+					>
+						<div style={{
+							pointerEvents: "none",
+							userSelect: "none",
+						}}>
+							{children}
+						</div>
+
+						<div className={`${namespace}__screen`}
+							style={{
+								height: outerDimensions.height,
+								width: outerDimensions.width,
+								transformOrigin: '0 0',
+								transform: `matrix(${scale}, 0, 0, ${scale}, ${translateX}, ${translateY})`,
+								cursor: isDragging ? 'grabbing' : 'grab'
+						}}/>
+					</div>
+			</div>
+			</div>
+		</div>
+	);
+};

--- a/packages/react/src/diagrams/PanZoom/PanZoomWrapper.js
+++ b/packages/react/src/diagrams/PanZoom/PanZoomWrapper.js
@@ -1,0 +1,60 @@
+import React, {useRef, useState} from 'react';
+
+export default ({
+	children,
+	outerDimensions = { height: "100%", width: "100%" },
+	innerDimensions = {},
+	initialTransform = {
+		x: 0,
+		y: 0,
+		k: 1
+	},
+	scaleExtent = [0.25, 1.5]
+}) => {
+	const [transform, setTransform] = useState(initialTransform);
+
+	const onTransform = (transform) => {
+		setTransform(transform);
+	};
+
+	const onZoomIn = () => {
+		if (transform.k < scaleExtent[1]) {
+			setTransform({
+				...transform,
+				k: transform.k + 0.25
+			})
+		}
+	}
+
+	const onZoomOut = () => {
+		if (transform.k > scaleExtent[0]) {
+			setTransform({
+				...transform,
+				k: transform.k - 0.25
+			})
+		}
+	}
+
+	const onReset = () => {
+		setTransform({
+			x: 0,
+			y: 0,
+			k: 1
+		})
+	}
+
+	return (
+		<React.Fragment>
+			{children({
+				innerDimensions,
+				outerDimensions,
+				onReset,
+				onTransform,
+				onZoomIn,
+				onZoomOut,
+				scaleExtent,
+				transform
+			})}
+		</React.Fragment>
+	);
+};


### PR DESCRIPTION
Adds a panzoom react component example, based on `d3-zoom` and stories.

**Adds**
- `PanZoomBody` to zoom and pan child components
- `PanZoomWrapper` to pass zoom / transform state between components
- `PanZoomMap` to display a mini map that shows and manipulates zoom position and scale

**Known issues**
- Pinch to zoom does not work with this version of `d3-zoom`
- Style conflicts with carbon cause the mini map buttons to render incorrectly in carbon charts
- Missing angular implementation and documentation
- Further visual design work needed

### Demo screenshot or recording
![Screenshot 2021-07-06 at 17 30 32](https://user-images.githubusercontent.com/12685163/124635917-e2aaf680-de7f-11eb-9fd0-63a7dcfb1bde.png)

### Review checklist (for reviewers only)
- [x] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
