### PR TITLE
fix(core): display the first and last data elements when addSpaceOnEdges is set to 0

### DIFF
--- a/packages/core/src/components/graphs/scatter.ts
+++ b/packages/core/src/components/graphs/scatter.ts
@@ -46,8 +46,8 @@ export class Scatter extends Component {
 		if (zoomDomain !== undefined) {
 			return data.filter(
 				(d) =>
-					d[domainIdentifier].getTime() > zoomDomain[0].getTime() &&
-					d[domainIdentifier].getTime() < zoomDomain[1].getTime()
+					d[domainIdentifier].getTime() >= zoomDomain[0].getTime() &&
+					d[domainIdentifier].getTime() <= zoomDomain[1].getTime()
 			);
 		}
 		return data;
@@ -447,7 +447,7 @@ export class Scatter extends Component {
 									d[groupMapsTo],
 									d[domainIdentifier],
 									d
-								)
+								);
 							}
 							return null;
 						});


### PR DESCRIPTION
fix #763

### Updates
- You will now be able to see first and last scatter elements, but they will not be overlapping the axes due to clipping.

### Demo screenshot or recording
<img width="730" alt="image" src="https://user-images.githubusercontent.com/38994122/125485265-fca6e35a-2f41-4ba2-b9ae-780da808743c.png">


### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
