### PR TITLE
ci(monorepo): update github release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - master
 jobs:
   build:
-    if: github.actor != 'carbon-bot' &&	startsWith(github.event.head_commit.message, 'release - ')
+    if: github.actor != 'carbon-bot' &&	contains(github.event.pull_request.labels.*.name, 'release')
     name: Create release - Node.js v11.x
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
The new workflow will require the `release` label being added to the PR in order to trigger a release after merging