### PR TITLE
docs(tutorials): event name should be "bar-mouseover"

### DIFF
--- a/packages/core/stories/tutorials/api.ts
+++ b/packages/core/stories/tutorials/api.ts
@@ -59,7 +59,7 @@ Services are globalized functions that have proven useful across the board. Gene
 Event listeners can be added through the events service:
 
 \`\`\`js
-barChart.services.events.addEventListener("bar-onmouseover", e => {
+barChart.services.events.addEventListener("bar-mouseover", e => {
     console.log(e.detail);
 });
 \`\`\`

--- a/packages/core/stories/tutorials/event-listeners.ts
+++ b/packages/core/stories/tutorials/event-listeners.ts
@@ -14,7 +14,7 @@ To listen for event just use a reference to the chart to add an event listener f
 This is an example for adding an event listener for a mouseover event on bar chart \`rect\`s.
 
 \`\`\`js
-barChart.services.events.addEventListener("bar-onmouseover", e => {
+barChart.services.events.addEventListener("bar-mouseover", e => {
 	console.log(e.detail);
 });
 \`\`\`


### PR DESCRIPTION
The [tutorial on event listeners](https://carbon-design-system.github.io/carbon-charts/?path=/story/docs-tutorials--event-listeners) uses "bar-onmouseover" as an example event name. However, the [generated documentation](https://carbon-design-system.github.io/carbon-charts/documentation/enums/_interfaces_events_.bar.html#bar_mouseover) for `Bar` event interfaces lists "bar-mouseover" as the correct enum.

### Updates

- fix(tutorial): event name should be "bar-mouseover"

