### PR TITLE
Rehaul Svelte documentation to focus on vite-powered set-ups

### DIFF
--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -109,10 +109,11 @@ export default {
 If you encounter the error message `ReferenceError: process is not defined`,
 install
 [@rollup/plugin-replace](https://github.com/rollup/plugins/tree/master/packages/replace)
-and add it to the list of plugins in `rollup.config.js`.
+and add it to `plugins` in `rollup.config.js`.
 
 ```js
 // rollup.config.js
+import replace from "@rollup/plugin-replace";
 
 export default {
 	// ...
@@ -178,3 +179,9 @@ used,
 
 Customizable options (specific to chart type) can be found
 [here](https://carbon-design-system.github.io/carbon-charts/documentation/modules/_interfaces_charts_.html)
+
+## TypeScript support
+
+Svelte version 3.31 or greater is required to use this library with TypeScript.
+
+TypeScript definitions are located in the [types folder](types/).

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -248,7 +248,7 @@ Dynamically import a chart and instantiate it using the [svelte:component API](h
 
 ### Event listeners
 
-In this example, event listeners can be attached to instance exposed via the `chart` prop.
+In this example, an event listener is attached to the `BarChartSimple` component that fires when hovering over a bar.
 
 ```svelte
 <script>

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -33,6 +33,15 @@ bundled version of the library.
 
 ## Set-up
 
+This is an overview of using Carbon Charts with common Svelte set-ups.
+
+-   [sveltekit](#sveltekit)
+-   [vite](#vite)
+-   [sapper](#sapper)
+-   [rollup](#rollup)
+-   [webpack](#webpack)
+-   [snowpack](#snowpack)
+
 ### SvelteKit
 
 [SvelteKit](https://github.com/sveltejs/kit) is fast becoming the de facto
@@ -56,14 +65,14 @@ const config = {
 export default config;
 ```
 
-### vite (`@sveltejs/vite-plugin-svelte`)
+### Vite
 
 [vite-plugin-svelte](https://github.com/sveltejs/vite-plugin-svelte) is an
 alternative to using SvelteKit. Similarly, instruct `vite` to optimize
 `@carbon/charts` in vite.config.js.
 
 Note that `@sveltejs/vite-plugin-svelte` is the official vite/svelte integration
-and is not to be confused with [svite](https://github.com/svitejs/svite).
+not to be confused with [svite](https://github.com/svitejs/svite).
 
 ```js
 // vite.config.js
@@ -79,7 +88,7 @@ export default defineConfig(({ mode }) => {
 });
 ```
 
-### sapper
+### Sapper
 
 [sapper](https://github.com/sveltejs/sapper) is another official Svelte
 framework that supports server-side rendering (SSR).
@@ -88,7 +97,7 @@ Take care to install `@carbon/charts-svelte` as a development dependency.
 
 No additional configuration should be necessary.
 
-### rollup
+### Rollup
 
 When using this library with [rollup](https://github.com/rollup/rollup), set
 `context` to `"window"` in the exported configuration in `rollup.config.js`.
@@ -113,7 +122,7 @@ and add it to `plugins` in `rollup.config.js`.
 
 ```js
 // rollup.config.js
-import replace from "@rollup/plugin-replace";
+import replace from '@rollup/plugin-replace';
 
 export default {
 	// ...
@@ -127,14 +136,14 @@ export default {
 };
 ```
 
-### webpack
+### Webpack
 
 [webpack](https://github.com/webpack/webpack) is another popular application
 bundler used to build Svelte apps.
 
 No additional configuration should be necessary.
 
-### snowpack
+### Snowpack
 
 [snowpack](https://github.com/snowpackjs/snowpack) is an ESM-powered frontend
 build tool.
@@ -152,6 +161,135 @@ No additional configuration should be necessary.
 module.exports = {
 	plugins: ['@snowpack/plugin-svelte'],
 };
+```
+
+## Usage
+
+Import chart styles from `@carbon/charts`:
+
+- `@carbon/charts/styles.css`: White theme
+- `@carbon/charts/styles-g10.css`: Gray 10 theme
+- `@carbon/charts/styles-g90.css`: Gray 90 theme
+- `@carbon/charts/styles-g100.css`: Gray 100 theme
+
+### Basic
+
+```svelte
+<script>
+  import { BarChartSimple } from "@carbon/charts-svelte";
+  import "@carbon/charts/styles.min.css";
+</script>
+
+<BarChartSimple
+  data={[
+    { group: "Qty", value: 65000 },
+    { group: "More", value: 29123 },
+    { group: "Sold", value: 35213 },
+    { group: "Restocking", value: 51213 },
+    { group: "Misc", value: 16932 },
+  ]}
+  options={{
+    title: "Simple bar (discrete)",
+    height: "400px",
+    axes: {
+      left: { mapsTo: "value" },
+      bottom: { mapsTo: "group", scaleType: "labels" },
+    },
+  }}
+/>
+
+```
+
+
+
+
+
+
+
+### Dynamic import
+
+Dynamically import a chart and instantiate it using the [svelte:component API](https://svelte.dev/docs#svelte_component).
+
+```svelte
+<script>
+  import { onMount } from "svelte";
+  import "@carbon/charts/styles.min.css";
+
+  let chart;
+
+  onMount(async () => {
+    const charts = await import("@carbon/charts-svelte");
+    chart = charts.BarChartSimple;
+  });
+</script>
+
+<svelte:component
+  this={chart}
+  data={[
+    { group: "Qty", value: 65000 },
+    { group: "More", value: 29123 },
+    { group: "Sold", value: 35213 },
+    { group: "Restocking", value: 51213 },
+    { group: "Misc", value: 16932 },
+  ]}
+  options={{
+    title: "Simple bar (discrete)",
+    height: "400px",
+    axes: {
+      left: { mapsTo: "value" },
+      bottom: { mapsTo: "group", scaleType: "labels" },
+    },
+  }}
+/>
+
+```
+
+
+
+### Event listeners
+
+In this example, event listeners can be attached to instance exposed via the `chart` prop.
+
+```svelte
+<script>
+  import { onMount } from "svelte";
+  import { BarChartSimple } from "@carbon/charts-svelte";
+  import "@carbon/charts/styles.min.css";
+
+  let chart;
+
+  function barMouseOver(e) {
+    console.log(e.detail);
+  }
+
+  onMount(() => {
+    chart.services.events.addEventListener("bar-mouseover", barMouseOver);
+
+    return () => {
+      chart.services.events.removeEventListener("bar-mouseover", barMouseOver);
+    };
+  });
+</script>
+
+<BarChartSimple
+  bind:chart
+  data={[
+    { group: "Qty", value: 65000 },
+    { group: "More", value: 29123 },
+    { group: "Sold", value: 35213 },
+    { group: "Restocking", value: 51213 },
+    { group: "Misc", value: 16932 },
+  ]}
+  options={{
+    title: "Simple bar (discrete)",
+    height: "400px",
+    axes: {
+      left: { mapsTo: "value" },
+      bottom: { mapsTo: "group", scaleType: "labels" },
+    },
+  }}
+/>
+
 ```
 
 ## Codesandbox examples

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -15,14 +15,14 @@ Please direct all questions regarding support, bug fixes, and feature requests t
 Run the following command using [npm](https://www.npmjs.com/):
 
 ```bash
-npm install -S @carbon/charts @carbon/charts-svelte d3@5.x
+npm install -D @carbon/charts-svelte d3@5.x
 ```
 
 If you prefer [Yarn](https://yarnpkg.com/en/), use the following command
 instead:
 
 ```bash
-yarn add @carbon/charts @carbon/charts-svelte d3@5.x
+yarn add -D @carbon/charts-svelte d3@5.x
 ```
 
 **Note:** you'd also need to install `carbon-components` if you're not using a bundled version of the library.

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -167,10 +167,10 @@ module.exports = {
 
 Import chart styles from `@carbon/charts`:
 
-- `@carbon/charts/styles.css`: White theme
-- `@carbon/charts/styles-g10.css`: Gray 10 theme
-- `@carbon/charts/styles-g90.css`: Gray 90 theme
-- `@carbon/charts/styles-g100.css`: Gray 100 theme
+-   `@carbon/charts/styles.css`: White theme
+-   `@carbon/charts/styles-g10.css`: Gray 10 theme
+-   `@carbon/charts/styles-g90.css`: Gray 90 theme
+-   `@carbon/charts/styles-g100.css`: Gray 100 theme
 
 ### Basic
 
@@ -200,15 +200,30 @@ Import chart styles from `@carbon/charts`:
 
 ```
 
+### Dispatched events
 
+Each Svelte chart component dispatches the following events:
 
+-   **on:load**: fired when the chart is instantiated
+-   **on:update**: fired when `data` or `options` are updated
+-   **on:destroy**: fired when the component is unmounted and the chart is
+    destroyed
 
+```svelte
+<BarChartSimple
+  {data}
+  {options}
+  on:load
+  on:update
+  on:destroy
+/>
 
-
+```
 
 ### Dynamic import
 
-Dynamically import a chart and instantiate it using the [svelte:component API](https://svelte.dev/docs#svelte_component).
+Dynamically import a chart and instantiate it using the
+[svelte:component API](https://svelte.dev/docs#svelte_component).
 
 ```svelte
 <script>
@@ -244,11 +259,10 @@ Dynamically import a chart and instantiate it using the [svelte:component API](h
 
 ```
 
-
-
 ### Event listeners
 
-In this example, an event listener is attached to the `BarChartSimple` component that fires when hovering over a bar.
+In this example, an event listener is attached to the `BarChartSimple` component
+that fires when hovering over a bar.
 
 ```svelte
 <script>

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -7,11 +7,14 @@
 **[Storybook demo sources](https://github.com/carbon-design-system/carbon-charts/tree/master/packages/core/demo/data)**
 
 ## Maintenance & support
+
 These Svelte wrappers have been developed by Eric Liu.
 
-Please direct all questions regarding support, bug fixes, and feature requests to [@metonym](https://github.com/metonym).
+Please direct all questions regarding support, bug fixes, and feature requests
+to [@metonym](https://github.com/metonym).
 
 ## Getting started
+
 Run the following command using [npm](https://www.npmjs.com/):
 
 ```bash
@@ -25,106 +28,153 @@ instead:
 yarn add -D @carbon/charts-svelte d3@5.x
 ```
 
-**Note:** you'd also need to install `carbon-components` if you're not using a bundled version of the library.
+**Note:** you'd also need to install `carbon-components` if you're not using a
+bundled version of the library.
 
-## Step-by-step instructions
+## Set-up
 
-Quickly scaffold a project from the official [Svelte webpack template](https://github.com/sveltejs/template-webpack) using [degit](https://github.com/Rich-Harris/degit):
+### SvelteKit
 
-```bash
-npx degit sveltejs/template-webpack svelte-app
-cd svelte-app
-```
+[SvelteKit](https://github.com/sveltejs/kit) is fast becoming the de facto
+framework for building Svelte apps that supports both client-side rendering
+(CSR) and server-side rendering (SSR).
 
-Install the dependencies:
+For set-ups powered by [vite](https://github.com/vitejs/vite), add
+`@carbon/charts` to the list of dependencies for `vite` to optimize.
 
-```bash
-yarn add carbon-components @carbon/charts @carbon/charts-svelte d3
-```
-
-Let's add a simple bar chart from `@carbon/charts-svelte`.
-
-First, import the `BarChartSimple` component in `src/App.svelte`.
-
-```html
-<!-- src/App.svelte -->
-<script>
-  import { BarChartSimple } from "@carbon/charts-svelte";
-</script>
-```
-
-Next, add an external stylesheet using the svelte:head API.
-
-```html
-<!-- src/App.svelte -->
-<svelte:head>
-  <link rel="stylesheet" href="https://unpkg.com/@carbon/charts/styles.min.css" />
-</svelte:head>
-```
-
-Then, instantiate the `BarChartSimple` component with some sample data. 
-
-```html
-<!-- src/App.svelte -->
-<BarChartSimple
-	data={[
-	{
-		"group": "Qty",
-		"value": 65000
-	},
-	{
-		"group": "More",
-		"value": 29123
-	},
-	{
-		"group": "Sold",
-		"value": 35213
-	},
-	{
-		"group": "Restocking",
-		"value": 51213
-	},
-	{
-		"group": "Misc",
-		"value": 16932
-	}
-]}
-	options={{
-	"title": "Simple bar (discrete)",
-	"axes": {
-		"left": {
-			"mapsTo": "value"
+```js
+// svelte.config.js
+const config = {
+	kit: {
+		target: '#svelte',
+		vite: {
+			optimizeDeps: { include: ['@carbon/charts'] },
 		},
-		"bottom": {
-			"mapsTo": "group",
-			"scaleType": "labels"
-		}
 	},
-	"height": "400px"
-}}
-	/>
+};
+
+export default config;
 ```
 
-Run the app in development mode.
+### vite (`@sveltejs/vite-plugin-svelte`)
 
-```bash
-yarn dev
+[vite-plugin-svelte](https://github.com/sveltejs/vite-plugin-svelte) is an
+alternative to using SvelteKit. Similarly, instruct `vite` to optimize
+`@carbon/charts` in vite.config.js.
+
+Note that `@sveltejs/vite-plugin-svelte` is the official vite/svelte integration
+and is not to be confused with [svite](https://github.com/svitejs/svite).
+
+```js
+// vite.config.js
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { defineConfig } from 'vite';
+
+export default defineConfig(({ mode }) => {
+	return {
+		plugins: [svelte()],
+		build: { minify: mode === 'production' },
+		optimizeDeps: { include: ['@carbon/charts'] },
+	};
+});
 ```
 
-Navigate to [http://localhost:8080](http://localhost:8080). You should see the bar chart rendered in the browser.
+### sapper
+
+[sapper](https://github.com/sveltejs/sapper) is another official Svelte
+framework that supports server-side rendering (SSR).
+
+Take care to install `@carbon/charts-svelte` as a development dependency.
+
+No additional configuration should be necessary.
+
+### rollup
+
+When using this library with [rollup](https://github.com/rollup/rollup), set
+`context` to `"window"` in the exported configuration in `rollup.config.js`.
+
+```js
+// rollup.config.js
+
+export default {
+	context: 'window',
+	// ...
+};
+```
+
+#### Troubleshooting
+
+##### "process is not defined"
+
+If you encounter the error message `ReferenceError: process is not defined`,
+install
+[@rollup/plugin-replace](https://github.com/rollup/plugins/tree/master/packages/replace)
+and add it to the list of plugins in `rollup.config.js`.
+
+```js
+// rollup.config.js
+
+export default {
+	// ...
+	plugins: [
+		replace({
+			preventAssignment: true,
+			'process.env.NODE_ENV': JSON.stringify('production'),
+		}),
+		// ...
+	],
+};
+```
+
+### webpack
+
+[webpack](https://github.com/webpack/webpack) is another popular application
+bundler used to build Svelte apps.
+
+No additional configuration should be necessary.
+
+### snowpack
+
+[snowpack](https://github.com/snowpackjs/snowpack) is an ESM-powered frontend
+build tool.
+
+Ensure you have
+[@snowpack/plugin-svelte](https://yarnpkg.com/package/@snowpack/plugin-svelte)
+added as a plugin in `snowpack.config.js`.
+
+No additional configuration should be necessary.
+
+```js
+// snowpack.config.js
+
+/** @type {import("snowpack").SnowpackUserConfig } */
+module.exports = {
+	plugins: ['@snowpack/plugin-svelte'],
+};
+```
 
 ## Codesandbox examples
+
 [Sample use cases can be seen here](https://carbon-design-system.github.io/carbon-charts/svelte).
 
-**When opening the link above**, click on the **Edit on Codesandbox** button for each demo to see an isolated project showing you how to reproduce the demo.
+**When opening the link above**, click on the **Edit on Codesandbox** button for
+each demo to see an isolated project showing you how to reproduce the demo.
 
 ## Charting data & options
-Although we will definitely introduce new models in the future as we start shipping new components such as maps, Data and options follow the same model in all charts, with minor exceptions and differences in specific components.
 
-For instance in the case of a donut chart you're able to pass in an additional field called `center` in your options configuring the donut center.
+Although we will definitely introduce new models in the future as we start
+shipping new components such as maps, Data and options follow the same model in
+all charts, with minor exceptions and differences in specific components.
 
-For instructions on using the **tabular data format**, see [here](https://carbon-design-system.github.io/carbon-charts/?path=/story/tutorials--tabular-data-format)
+For instance in the case of a donut chart you're able to pass in an additional
+field called `center` in your options configuring the donut center.
 
-There are also additional options available depending on the chart type being used, [see our demo examples here](https://github.com/carbon-design-system/carbon-charts/tree/master/packages/core/demo/data).
+For instructions on using the **tabular data format**, see
+[here](https://carbon-design-system.github.io/carbon-charts/?path=/story/tutorials--tabular-data-format)
 
-Customizable options (specific to chart type) can be found [here](https://carbon-design-system.github.io/carbon-charts/documentation/modules/_interfaces_charts_.html)
+There are also additional options available depending on the chart type being
+used,
+[see our demo examples here](https://github.com/carbon-design-system/carbon-charts/tree/master/packages/core/demo/data).
+
+Customizable options (specific to chart type) can be found
+[here](https://carbon-design-system.github.io/carbon-charts/documentation/modules/_interfaces_charts_.html)

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -53,7 +53,6 @@
 		"@carbon/telemetry": "0.0.0-alpha.6"
 	},
 	"peerDependencies": {
-		"carbon-components": "^10.5.x",
 		"svelte": "^3.31.x"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Closes #1072 

- [x] omit `@carbon/charts` in installation command because it is a direct dependency of `@carbon/charts-svelte`
- [x] instruct users to install Svelte wrappers as *development* dependencies
- [x] remove `carbon-components` from peerDependencies as it is vendored by `@carbon/charts`
- [x] document CSS usage to use shipped StyleSheet instead of a CDN
- [x] add example for adding event listeners
- [x] add example for dispatched events (`on:load`, `on:update`, `on:destroy`)
- [x] add note on TypeScript usage, link to `types/` folder
- [x] add dynamic import example
- [ ] ~~document dynamic, client-side theming?~~ (#966)
- [x] document usage using the most popular example set-ups
  - [x] SvelteKit
  - [x] vite
  - [x] Sapper
  - [x] Rollup
  - [x] Webpack
  - [x] Snowpack


### Updates

**Fixes**

- chore(deps): remove `carbon-components` from `peerDependencies`

**Documentation**

- docs: update Svelte charts installation/set-up instructions
- docs: update Svelte chart examples
- docs: add note on TypeScript usage

### Demo screenshot or recording

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
