### PR TITLE
create StyleSheet containing chart styles for all themes

### DIFF
--- a/packages/core/build.sh
+++ b/packages/core/build.sh
@@ -35,6 +35,9 @@ sass --load-path ../../node_modules dist/styles/styles-g90.scss dist/styles-g90.
 sass --load-path ../../node_modules dist/styles/styles-g100.scss dist/styles-g100.css
 sass --load-path ../../node_modules dist/styles/styles-g100.scss dist/styles-g100.min.css --style=compressed
 
+sass --load-path ../../node_modules dist/styles/styles-all.scss dist/styles-all.css
+sass --load-path ../../node_modules dist/styles/styles-all.scss dist/styles-all.min.css --style=compressed
+
 sass demo/styles.scss dist/demo/styles.css
 sass demo/styles.scss dist/demo/styles.min.css --style=compressed
 

--- a/packages/core/src/styles/styles-all.scss
+++ b/packages/core/src/styles/styles-all.scss
@@ -1,0 +1,26 @@
+@import './vendor/carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/themes/mixins';
+
+:root {
+	@import './styles';
+}
+
+:root[theme='g10'] {
+	@include carbon--theme($carbon--theme--g10) {
+		$carbon--theme: $carbon--theme--g10;
+		@import './styles';
+	}
+}
+
+:root[theme='g90'] {
+	@include carbon--theme($carbon--theme--g90) {
+		$carbon--theme: $carbon--theme--g90;
+		@import './styles';
+	}
+}
+
+:root[theme='g100'] {
+	@include carbon--theme($carbon--theme--g100) {
+		$carbon--theme: $carbon--theme--g100;
+		@import './styles';
+	}
+}


### PR DESCRIPTION
This PR creates an additional StyleSheet to support dynamic, client-side theming. Addresses #966 

This creates the following files in `core/dist`:

- styles-all.css
- styles-all.css.map
- styles-all.min.css
- styles-all.min.css.map

### Updates

- feat(core): create StyleSheet containing chart styles for all themes

### Usage

Update the theme dynamically by setting the `"theme"` attribute on the HTML element (`document.documentElement`).

```svelte
<script>
    import { BarChartSimple } from "@carbon/charts-svelte";
    import "@carbon/charts/styles-all.css";
  
    let theme = ''; // default theme is white
  
    $: document.documentElement.setAttribute("theme", theme);
  </script>
  
  <button on:click={() => (theme = "")}>Set white</button>
  <button on:click={() => (theme = "g10")}>Set g10</button>
  <button on:click={() => (theme = "g90")}>Set g90</button>
  <button on:click={() => (theme = "g100")}>Set g100</button>
  
  <BarChartSimple
    data={[
      { group: "Qty", value: 65000 },
      { group: "More", value: 29123 },
      { group: "Sold", value: 35213 },
      { group: "Restocking", value: 51213 },
      { group: "Misc", value: 16932 },
    ]}
    options={{
      title: "Simple bar (discrete)",
      height: "400px",
      axes: {
        left: { mapsTo: "value" },
        bottom: { mapsTo: "group", scaleType: "labels" },
      },
    }}
  />
  
```

### Demo screenshot or recording

https://user-images.githubusercontent.com/10718366/126538034-46b5844f-c61d-43cd-b6c6-4d65554ba6e1.mov

