### PR TITLE
fix(core): eliminate style conflicts with carbon-components

### DIFF
--- a/packages/core/src/components/essentials/modal.ts
+++ b/packages/core/src/components/essentials/modal.ts
@@ -135,10 +135,8 @@ export class Modal extends Component {
 				<p class="bx--modal-header__label bx--type-delta">Tabular representation</p>
 				<p class="bx--modal-header__heading bx--type-beta">${options.title}</p>
 				<button class="bx--modal-close" type="button" data-modal-close aria-label="close modal"  data-modal-primary-focus>
-					<svg class="bx--modal-close__icon" width="10" height="10" viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
-						<title>Close Modal</title>
-						<path d="M6.32 5L10 8.68 8.68 10 5 6.32 1.32 10 0 8.68 3.68 5 0 1.32 1.32 0 5 3.68 8.68 0 10 1.32 6.32 5z" fill-rule="nonzero"
-						/>
+					<svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-label="Close" width="20" height="20" viewBox="0 0 32 32" role="img" class="bx--modal-close__icon">
+						<path d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"></path>
 					</svg>
 				</button>
 			</div>

--- a/packages/core/src/styles/components/_modal.scss
+++ b/packages/core/src/styles/components/_modal.scss
@@ -1,53 +1,56 @@
-.#{$prefix}--modal {
-	z-index: 9999;
+@import './../vendor/carbon-components/src/components/modal/modal';
 
-	.#{$prefix}--modal-container {
-		.#{$prefix}--modal-header {
-			&__label {
-				margin-top: 0;
-				margin-bottom: 0;
-			}
+.#{$prefix}--chart-holder {
+	@include modal;
 
-			&__heading {
-				margin-top: 0.5rem;
-				margin-bottom: 1rem;
-			}
+	.#{$prefix}--modal {
+		&.is-visible {
+			z-index: 99999;
 		}
 
-		.#{$prefix}--modal-close__icon {
-			width: 0.75rem;
-			height: 0.75rem;
-		}
+		.#{$prefix}--modal-container {
+			.#{$prefix}--modal-header {
+				&__label {
+					margin-top: 0;
+					margin-bottom: 0;
+				}
 
-		.#{$prefix}--modal-content {
-			// padding-right: 1rem;
-			padding: 0;
-			margin-bottom: 0;
-
-			table {
-				position: relative;
-				border-collapse: collapse;
-
-				th {
-					position: sticky;
-					top: 0;
+				&__heading {
+					margin-top: 0.5rem;
+					margin-bottom: 1rem;
 				}
 			}
 
-			@if $ui-background ==
-				map-get($carbon--theme--g90, 'ui-background') or
-				$ui-background ==
-				map-get($carbon--theme--g100, 'ui-background')
-			{
-				color-scheme: dark;
+			.#{$prefix}--modal-content {
+				// padding-right: 1rem;
+				padding: 0;
+				margin-bottom: 0;
+
+				table {
+					position: relative;
+					border-collapse: collapse;
+
+					th {
+						position: sticky;
+						top: 0;
+					}
+				}
+
+				@if $ui-background ==
+					map-get($carbon--theme--g90, 'ui-background') or
+					$ui-background ==
+					map-get($carbon--theme--g100, 'ui-background')
+				{
+					color-scheme: dark;
+				}
 			}
-		}
 
-		.#{$prefix}--modal-footer {
-			background-color: transparent;
+			.#{$prefix}--modal-footer {
+				background-color: transparent;
 
-			.#{$prefix}--#{$charts-prefix}-modal-footer-spacer {
-				width: 50%;
+				.#{$prefix}--#{$charts-prefix}-modal-footer-spacer {
+					width: 50%;
+				}
 			}
 		}
 	}

--- a/packages/core/src/styles/components/_toolbar.scss
+++ b/packages/core/src/styles/components/_toolbar.scss
@@ -1,55 +1,55 @@
 $css--reset: false;
 @import './../vendor/carbon-components/src/components/overflow-menu/overflow-menu';
-@import './../vendor/carbon-components/src/components/loading/loading';
 
-.#{$prefix}--#{$charts-prefix}--toolbar {
-	display: flex;
+.#{$prefix}--chart-holder {
+	@include overflow-menu;
 
-	div.toolbar-control {
-		&.disabled {
-			&,
-			button {
-				cursor: default;
-			}
+	.#{$prefix}--#{$charts-prefix}--toolbar {
+		display: flex;
 
-			&:hover,
-			button:hover {
-				background-color: transparent;
-			}
+		div.toolbar-control {
+			&.disabled {
+				&,
+				button {
+					cursor: default;
+				}
 
-			button:focus {
-				outline: none;
-			}
+				&:hover,
+				button:hover {
+					background-color: transparent;
+				}
 
-			svg {
-				fill: $disabled-03;
+				button:focus {
+					outline: none;
+				}
+
+				svg {
+					fill: $disabled-03;
+				}
 			}
 		}
-	}
 
-	.bx--overflow-menu--flip {
-		right: 0;
-		left: unset;
+		.bx--overflow-menu--flip {
+			right: 0;
+			left: unset;
 
-		&.is-open {
-			display: table;
+			&.is-open {
+				display: table;
+			}
+
+			ul {
+				margin: 0;
+				padding: 0;
+			}
 		}
 
-		ul {
-			margin: 0;
-			padding: 0;
+		.bx--loading__background {
+			fill: transparent;
 		}
-	}
 
-	.bx--loading__background {
-		fill: transparent;
-	}
-
-	.bx--loading__stroke {
-		stroke-dashoffset: 99;
-		fill: transparent;
+		.bx--loading__stroke {
+			stroke-dashoffset: 99;
+			fill: transparent;
+		}
 	}
 }
-
-@include overflow-menu;
-@include loading;


### PR DESCRIPTION
This is for the `modal` & `overflow-menu` components used from `carbon-components`