### PR TITLE
perf(core): revoke object URL after downloading CSV data

### DIFF
--- a/packages/core/src/services/essentials/files.ts
+++ b/packages/core/src/services/essentials/files.ts
@@ -20,11 +20,12 @@ export class Files extends Service {
 			);
 		} else if (URL && 'download' in anchor) {
 			// HTML5
-			anchor.href = URL.createObjectURL(
+			const href = URL.createObjectURL(
 				new Blob([content], {
 					type: mimeType,
 				})
 			);
+			anchor.href = href;
 			anchor.setAttribute('download', filename);
 
 			// Add anchor to body
@@ -35,6 +36,7 @@ export class Files extends Service {
 
 			// Remove anchor from body
 			document.body.removeChild(anchor);
+			URL.revokeObjectURL(href);
 		} else {
 			location.href = `data:application/octet-stream,${encodeURIComponent(
 				content


### PR DESCRIPTION
It's recommended to invoke [`URL.revokeObjectUrl`](https://developer.mozilla.org/en-US/docs/Web/API/URL/revokeObjectURL) on an existing data URL when it's no longer needed.

This PR creates and assigns the URL to a variable `href` and revokes it after the download is initiated.

### Updates

- perf(core): revoke object URL after downloading CSV data

### Demo screenshot or recording

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
