### PR TITLE
fix(core): set $css--default-type to false in the styles

### DIFF
--- a/packages/core/src/styles/styles.scss
+++ b/packages/core/src/styles/styles.scss
@@ -5,6 +5,7 @@ $carbon-dataviz-alert: #b28600;
 $carbon-dataviz-yellow-10: #fcf4d6;
 
 $css--reset: false;
+$css--default-type: false;
 
 // Carbon imports
 @import './vendor/@carbon/colors/scss/colors';


### PR DESCRIPTION
we probably don't want any css-reset code coming into the charting styles