### PR TITLE
fix(angular): remove .ts from the area chart export

### DIFF
--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -1,7 +1,7 @@
 export * from './charts.module';
 
 export * from './base-chart.component';
-export * from './area-chart.component.ts';
+export * from './area-chart.component';
 export * from './area-chart-stacked.component';
 export * from './bar-chart-simple.component';
 export * from './bar-chart-grouped.component';


### PR DESCRIPTION
remove `.ts` extension from export