### PR TITLE
feat(core): Add options to map value to other keys

### DIFF
--- a/packages/core/demo/data/donut.ts
+++ b/packages/core/demo/data/donut.ts
@@ -1,4 +1,4 @@
-import { pieData } from './pie';
+import { pieData, pieDataMapsTo } from './pie';
 
 export const donutData = pieData;
 
@@ -25,6 +25,16 @@ export const donutCenteredOptions = {
 			label: 'Browsers',
 		},
 		alignment: 'center',
+	},
+};
+
+// donut - using a different value key
+export const donutDataMapsTo = pieDataMapsTo;
+export const donutMapsToOptions = {
+	title: 'Donut (value maps to count)',
+	resizable: true,
+	pie: {
+		mapsTo: 'count',
 	},
 };
 

--- a/packages/core/demo/data/donut.ts
+++ b/packages/core/demo/data/donut.ts
@@ -34,7 +34,7 @@ export const donutMapsToOptions = {
 	title: 'Donut (value maps to count)',
 	resizable: true,
 	pie: {
-		mapsTo: 'count',
+		valueMapsTo: 'count',
 	},
 };
 

--- a/packages/core/demo/data/index.ts
+++ b/packages/core/demo/data/index.ts
@@ -738,6 +738,11 @@ const simpleChartDemos = [
 				chartType: chartTypes.DonutChart,
 			},
 			{
+				options: donutDemos.donutMapsToOptions,
+				data: donutDemos.donutDataMapsTo,
+				chartType: chartTypes.DonutChart,
+			},
+			{
 				options: donutDemos.donutEmptyStateOptions,
 				data: donutDemos.donutEmptyStateData,
 				chartType: chartTypes.DonutChart,
@@ -856,6 +861,11 @@ const simpleChartDemos = [
 			{
 				options: pieDemos.pieCenteredOptions,
 				data: pieDemos.pieCenteredData,
+				chartType: chartTypes.PieChart,
+			},
+			{
+				options: pieDemos.pieMapToOptions,
+				data: pieDemos.pieDataMapsTo,
 				chartType: chartTypes.PieChart,
 			},
 			{

--- a/packages/core/demo/data/pie.ts
+++ b/packages/core/demo/data/pie.ts
@@ -25,6 +25,24 @@ export const pieCenteredOptions = {
 	},
 };
 
+// pie - using a different value key
+export const pieDataMapsTo = [
+	{ group: '2V2N 9KYPM version 1', count: 28000 },
+	{ group: 'L22I P66EP L22I P66EP L22I P66EP', count: 65000 },
+	{ group: 'JQAI 2M4L1', count: 75000 },
+	{ group: 'J9DZ F37AP', count: 3200 },
+	{ group: 'YEL48 Q6XK YEL48', count: 15000 },
+	{ group: 'Misc', count: 25000 },
+];
+
+export const pieMapToOptions = {
+	title: 'Pie (value maps to count)',
+	resizable: true,
+	pie: {
+		mapsTo: 'count',
+	},
+};
+
 // pie - empty state
 export const pieEmptyStateData = [];
 export const pieEmptyStateOptions = {

--- a/packages/core/demo/data/pie.ts
+++ b/packages/core/demo/data/pie.ts
@@ -39,7 +39,7 @@ export const pieMapToOptions = {
 	title: 'Pie (value maps to count)',
 	resizable: true,
 	pie: {
-		mapsTo: 'count',
+		valueMapsTo: 'count',
 	},
 };
 

--- a/packages/core/src/components/graphs/donut.ts
+++ b/packages/core/src/components/graphs/donut.ts
@@ -82,7 +82,7 @@ export class Donut extends Pie {
 			donutCenterFigure = this.model
 				.getDisplayData()
 				.reduce((accumulator, d) => {
-					return accumulator + d.value;
+					return accumulator + d[options.pie.mapsTo];
 				}, 0);
 		}
 

--- a/packages/core/src/components/graphs/donut.ts
+++ b/packages/core/src/components/graphs/donut.ts
@@ -82,7 +82,7 @@ export class Donut extends Pie {
 			donutCenterFigure = this.model
 				.getDisplayData()
 				.reduce((accumulator, d) => {
-					return accumulator + d[options.pie.mapsTo];
+					return accumulator + d[options.pie.valueMapsTo];
 				}, 0);
 		}
 

--- a/packages/core/src/components/graphs/pie.ts
+++ b/packages/core/src/components/graphs/pie.ts
@@ -62,12 +62,14 @@ export class Pie extends Component {
 		const self = this;
 		const svg = this.getComponentContainer();
 
+		const options = this.getOptions();
+		const { groupMapsTo } = options.data;
+		const valueMapsTo = options.pie.mapsTo;
+
 		// remove any slices that are valued at 0 because they dont need to be rendered and will create extra padding
 		const displayData = this.model
 			.getDisplayData()
-			.filter((data) => data.value > 0);
-		const options = this.getOptions();
-		const { groupMapsTo } = options.data;
+			.filter((data) => data[valueMapsTo] > 0);
 
 		// Compute the outer radius needed
 		const radius = this.computeRadius();
@@ -81,7 +83,7 @@ export class Pie extends Component {
 
 		// Setup the pie layout
 		const pieLayout = pie()
-			.value((d: any) => d.value)
+			.value((d: any) => d[valueMapsTo])
 			.sort(Tools.getProperty(options, 'pie', 'sortFunction'))
 			.padAngle(Configuration.pie.padAngle);
 
@@ -136,10 +138,11 @@ export class Pie extends Component {
 			.attr(
 				'aria-label',
 				(d) =>
-					`${d.value}, ${
+					`${d[valueMapsTo]}, ${
 						Tools.convertValueToPercentage(
-							d.data.value,
-							displayData
+							d.data[valueMapsTo],
+							displayData,
+							valueMapsTo
 						) + '%'
 					}`
 			)
@@ -151,7 +154,7 @@ export class Pie extends Component {
 		// Draw the slice labels
 		const renderLabels = options.pie.labels.enabled;
 		const labelData = renderLabels
-			? pieLayoutData.filter((x) => x.value > 0)
+			? pieLayoutData.filter((x) => x.data[valueMapsTo] > 0)
 			: [];
 		const labelsGroup = DOMUtils.appendOrSelect(svg, 'g.labels')
 			.attr('role', Roles.GROUP)
@@ -181,8 +184,11 @@ export class Pie extends Component {
 				}
 
 				return (
-					Tools.convertValueToPercentage(d.data.value, displayData) +
-					'%'
+					Tools.convertValueToPercentage(
+						d.data[valueMapsTo],
+						displayData,
+						valueMapsTo
+					) + '%'
 				);
 			})
 			// Calculate dimensions in order to transform
@@ -433,6 +439,7 @@ export class Pie extends Component {
 				});
 
 				const { groupMapsTo } = self.getOptions().data;
+				const { mapsTo } = self.getOptions().pie;
 				// Show tooltip
 				self.services.events.dispatchEvent(Events.Tooltip.SHOW, {
 					event,
@@ -440,7 +447,7 @@ export class Pie extends Component {
 					items: [
 						{
 							label: datum.data[groupMapsTo],
-							value: datum.data.value,
+							value: datum.data[mapsTo],
 						},
 					],
 				});

--- a/packages/core/src/components/graphs/pie.ts
+++ b/packages/core/src/components/graphs/pie.ts
@@ -64,7 +64,7 @@ export class Pie extends Component {
 
 		const options = this.getOptions();
 		const { groupMapsTo } = options.data;
-		const valueMapsTo = options.pie.mapsTo;
+		const { valueMapsTo } = options.pie;
 
 		// remove any slices that are valued at 0 because they dont need to be rendered and will create extra padding
 		const displayData = this.model
@@ -439,7 +439,7 @@ export class Pie extends Component {
 				});
 
 				const { groupMapsTo } = self.getOptions().data;
-				const { mapsTo } = self.getOptions().pie;
+				const { valueMapsTo } = self.getOptions().pie;
 				// Show tooltip
 				self.services.events.dispatchEvent(Events.Tooltip.SHOW, {
 					event,
@@ -447,7 +447,7 @@ export class Pie extends Component {
 					items: [
 						{
 							label: datum.data[groupMapsTo],
-							value: datum.data[mapsTo],
+							value: datum.data[valueMapsTo],
 						},
 					],
 				});

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -440,7 +440,7 @@ const pieChart: PieChartOptions = Tools.merge({}, chart, {
 		},
 		alignment: Alignments.LEFT,
 		sortFunction: null,
-		mapsTo: 'value',
+		valueMapsTo: 'value',
 	},
 } as PieChartOptions);
 

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -440,6 +440,7 @@ const pieChart: PieChartOptions = Tools.merge({}, chart, {
 		},
 		alignment: Alignments.LEFT,
 		sortFunction: null,
+		mapsTo: 'value',
 	},
 } as PieChartOptions);
 

--- a/packages/core/src/interfaces/charts.ts
+++ b/packages/core/src/interfaces/charts.ts
@@ -261,7 +261,7 @@ export interface HistogramChartOptions extends AxisChartOptions {
 	 */
 	bins?: {
 		rangeLabel?: string;
-	}
+	};
 }
 
 /**
@@ -348,6 +348,11 @@ export interface PieChartOptions extends BaseChartOptions {
 			enabled?: Boolean;
 		};
 		alignment?: Alignments;
+		/**
+		 * identifier for value key in your charting data
+		 * defaults to value
+		 */
+		mapsTo?: string;
 		sortFunction?: (a: any, b: any) => number;
 	};
 }

--- a/packages/core/src/interfaces/charts.ts
+++ b/packages/core/src/interfaces/charts.ts
@@ -352,7 +352,7 @@ export interface PieChartOptions extends BaseChartOptions {
 		 * identifier for value key in your charting data
 		 * defaults to value
 		 */
-		mapsTo?: string;
+		valueMapsTo?: string;
 		sortFunction?: (a: any, b: any) => number;
 	};
 }

--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -245,12 +245,12 @@ export namespace Tools {
 	 * @export
 	 * @param {any} item
 	 * @param {any} fullData
+	 * @param {string} key
 	 * @returns The percentage in the form of a number (1 significant digit if necessary)
 	 */
-	export function convertValueToPercentage(item, fullData) {
+	export function convertValueToPercentage(item, fullData, key = 'value') {
 		const percentage =
-			(item / fullData.reduce((accum, val) => accum + val.value, 0)) *
-			100;
+			(item / fullData.reduce((accum, val) => accum + val[key], 0)) * 100;
 		// if the value has any significant figures, keep 1
 		return percentage % 1 !== 0
 			? parseFloat(percentage.toFixed(1))


### PR DESCRIPTION
### Updates
- Add support for mapping value to different keys in pie
- Extended support to donut since it extends pie
- Added value mapping demos for both donut and pie chart

fix #1110 

### Demo screenshot or recording
<img width="381" alt="Screen Shot 2021-08-19 at 12 00 40 PM" src="https://user-images.githubusercontent.com/38994122/130102652-a0b19224-e41d-49e9-8792-9ecd35b50e9b.png">
<img width="385" alt="Screen Shot 2021-08-19 at 11 59 54 AM" src="https://user-images.githubusercontent.com/38994122/130102658-1c33f925-8e7b-4160-8ddc-7b1643f18f30.png">


### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
