### PR TITLE
fix(core): display correct toolbar controls based on provided options

### DIFF
--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -88,16 +88,22 @@ export namespace Tools {
 		defaultOptions: any,
 		providedOptions: any
 	) {
-		defaultOptions = Tools.clone(defaultOptions);
+		const clonedDefaultOptions = Tools.clone(defaultOptions);
 		const providedAxesNames = Object.keys(providedOptions.axes || {});
 
+		// Use provide controls list if it exists
+		// Prevents merging and element overriding of the two lists
+		if (providedOptions?.toolbar?.controls) {
+			delete clonedDefaultOptions.toolbar.controls;
+		}
+
 		if (providedAxesNames.length === 0) {
-			delete defaultOptions.axes;
+			delete clonedDefaultOptions.axes;
 		}
 
 		// Update deprecated options to work with the tabular data format
 		// Similar to the functionality in model.transformToTabularData()
-		for (const axisName in defaultOptions.axes) {
+		for (const axisName in clonedDefaultOptions.axes) {
 			if (providedAxesNames.includes(axisName)) {
 				const providedAxisOptions = providedOptions.axes[axisName];
 
@@ -123,13 +129,13 @@ export namespace Tools {
 					}
 				}
 			} else {
-				delete defaultOptions.axes[axisName];
+				delete clonedDefaultOptions.axes[axisName];
 			}
 		}
 
-		updateLegendAdditionalItems(defaultOptions, providedOptions);
+		updateLegendAdditionalItems(clonedDefaultOptions, providedOptions);
 
-		return Tools.merge(defaultOptions, providedOptions);
+		return Tools.merge(clonedDefaultOptions, providedOptions);
 	}
 
 	/**************************************


### PR DESCRIPTION
### Updates
- Assigned cloned object to a new variable instead of reusing parameter
- Added a condition to delete default controls if toolbar controls are provided by user
  - The problem was caused by merging default and provided options (lodash merge), it reassigning array elements of default with provided instead of outright replacing the variable with provided.
  - A possible solution too hard coding toolbar in long term is using MergeWith (https://lodash.com/docs/#mergeWith) which allows us to pass in a function. In this function we can probably iterate through the keys and if array, just replace them instead of trying to combine them.

Example of what was happening:
```
const obj1 = { x: ['One', 'Two', 'Three', 'Four'] };
const obj2 = { x: ['Three', 'Four'] };

// Equivalent to Tools.Merge
console.log(_.merge(obj1, obj2));
// { x: ['Three', 'Four', 'Three', 'Four'] };
```

If user passes in an empty controls list, then the toolbar will not be displayed.

fix #1109 

### Demo screenshot or recording
<img width="762" alt="image" src="https://user-images.githubusercontent.com/38994122/130507748-73d97b69-cbb4-434e-add1-fd5a3a5a1ab8.png">

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
