### PR TITLE
fix(core): render empty zoom bar holder when there is 1 data point

### DIFF
--- a/packages/core/src/components/axes/zoom-bar.ts
+++ b/packages/core/src/components/axes/zoom-bar.ts
@@ -135,8 +135,11 @@ export class ZoomBar extends Component {
 
 		if (mainXScale && mainXScaleType === ScaleTypes.TIME) {
 			let zoomBarData = this.services.zoom.getZoomBarData();
-			if (Tools.isEmpty(zoomBarData)) {
-				// if there's no zoom bar data we can't do anything
+
+			// if there's no zoom bar data we can't do anything (true, undefined, null...)
+			// if zoom domain is based on a single data element
+			// doesn't make sense to allow zooming in
+			if (Tools.isEmpty(zoomBarData) || zoomBarData.length === 1) {
 				return;
 			}
 			this.xScale = mainXScale.copy();


### PR DESCRIPTION
### Updates
- Add condition to display zoom bar in an empty state if there is only 1 data point

fix #996 

### Demo screenshot or recording
<img width="736" alt="image" src="https://user-images.githubusercontent.com/38994122/132401243-91ec7008-57e8-471a-9102-2aafc80f52fa.png">

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
