### PR TITLE
fix(core): display donut-figure in the center when donut-title is empty

### DIFF
--- a/packages/core/src/components/graphs/donut.ts
+++ b/packages/core/src/components/graphs/donut.ts
@@ -33,10 +33,24 @@ export class Donut extends Pie {
 
 		// Compute the outer radius needed
 		const radius = this.computeRadius();
+		const donutTitle = Tools.getProperty(
+			options,
+			'donut',
+			'center',
+			'label'
+		);
 
 		// Add the number shown in the center of the donut
 		DOMUtils.appendOrSelect(svg, 'text.donut-figure')
 			.attr('text-anchor', 'middle')
+			.style('dominant-baseline', () => {
+				// Center figure if title is empty
+				if (donutTitle === null || donutTitle === '') {
+					return 'central';
+				}
+
+				return 'initial';
+			})
 			.style('font-size', () =>
 				options.donut.center.numberFontSize(radius)
 			)
@@ -52,14 +66,17 @@ export class Donut extends Pie {
 				return self.centerNumberTween(select(this));
 			});
 
-		// Add the label below the number in the center of the donut
-		DOMUtils.appendOrSelect(svg, 'text.donut-title')
-			.attr('text-anchor', 'middle')
-			.style('font-size', () =>
-				options.donut.center.titleFontSize(radius)
-			)
-			.attr('y', options.donut.center.titleYPosition(radius))
-			.text(Tools.getProperty(options, 'donut', 'center', 'label'));
+		// Title will be rendered only if it isn't empty
+		if (donutTitle !== null && donutTitle !== '') {
+			// Add the label below the number in the center of the donut
+			DOMUtils.appendOrSelect(svg, 'text.donut-title')
+				.attr('text-anchor', 'middle')
+				.style('font-size', () =>
+					options.donut.center.titleFontSize(radius)
+				)
+				.attr('y', options.donut.center.titleYPosition(radius))
+				.text(donutTitle);
+		}
 	}
 
 	getInnerRadius() {


### PR DESCRIPTION
fix #1146

### Updates
- Renders donut-title only if value exists
- Automatically renders donut-figure in the center of the circle (User's can still adjust the font-size)

### Demo screenshot or recording
<img width="284" alt="image" src="https://user-images.githubusercontent.com/38994122/133089916-8dc09d32-00aa-4315-8b2c-a0e051f57f90.png">
<img width="301" alt="image" src="https://user-images.githubusercontent.com/38994122/133090023-1bcd355b-9233-45ca-bf37-3f383f7c6da5.png">


### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
