### PR TITLE
fix(core): correctly draw the threshold from multiple axes

### DIFF
--- a/packages/core/src/components/essentials/threshold.ts
+++ b/packages/core/src/components/essentials/threshold.ts
@@ -91,8 +91,7 @@ export class Threshold extends Component {
 				d.thresholds.map((threshold) => {
 					// Merge relevant keys into the threshold object
 					threshold.axisPosition = d.axisPosition;
-					threshold.correspondingDatasets = d?.correspondingDatasets;
-					threshold.mapsTo = d?.mapsTo;
+					threshold.datum = this.constructDatumObj(d, threshold);
 					return threshold;
 				})
 			);
@@ -173,14 +172,14 @@ export class Threshold extends Component {
 					.attr('y2', yScaleEnd)
 					.attr(
 						'x1',
-						(d) =>
-							getXValue(self.constructDatumObj(d)) +
+						({ datum }) =>
+							getXValue(datum) +
 							(isScaleTypeLabels ? scale.step() / 2 : 0)
 					)
 					.attr(
 						'x2',
-						(d) =>
-							getXValue(self.constructDatumObj(d)) +
+						({ datum }) =>
+							getXValue(datum) +
 							(isScaleTypeLabels ? scale.step() / 2 : 0)
 					)
 					.style('stroke', ({ fillColor }) => fillColor);
@@ -189,7 +188,7 @@ export class Threshold extends Component {
 				group
 					.selectAll('rect.threshold-hoverable-area')
 					.attr('x', 0)
-					.attr('y', (d) => -getXValue(self.constructDatumObj(d)))
+					.attr('y', ({ datum }) => -getXValue(datum))
 					.attr('width', Math.abs(yScaleEnd - yScaleStart))
 					.classed('rotate', true);
 			} else {
@@ -207,14 +206,14 @@ export class Threshold extends Component {
 					.attr('x2', xScaleEnd)
 					.attr(
 						'y1',
-						(d) =>
-							getYValue(self.constructDatumObj(d)) +
+						({ datum }) =>
+							getYValue(datum) +
 							(isScaleTypeLabels ? scale.step() / 2 : 0)
 					)
 					.attr(
 						'y2',
-						(d) =>
-							getYValue(self.constructDatumObj(d)) +
+						({ datum }) =>
+							getYValue(datum) +
 							(isScaleTypeLabels ? scale.step() / 2 : 0)
 					)
 					.style('stroke', ({ fillColor }) => fillColor);
@@ -223,7 +222,7 @@ export class Threshold extends Component {
 				group
 					.selectAll('rect.threshold-hoverable-area')
 					.attr('x', xScaleStart)
-					.attr('y', (d) => getYValue(self.constructDatumObj(d)))
+					.attr('y', ({ datum }) => getYValue(datum))
 					.attr('width', Math.abs(xScaleEnd - xScaleStart))
 					.classed('rotate', false);
 			}
@@ -339,7 +338,7 @@ export class Threshold extends Component {
 	}
 
 	// Constructs object to pass in scale functions
-	constructDatumObj(d) {
+	constructDatumObj(d, element) {
 		const datum = {};
 
 		// We only need to specify group only if correpsonding dataset is defined
@@ -348,7 +347,7 @@ export class Threshold extends Component {
 		}
 
 		// Add attribute with the mapsTo value as key
-		datum[d['mapsTo']] = d.value;
+		datum[d['mapsTo']] = element.value;
 
 		return datum;
 	}

--- a/packages/core/src/components/essentials/threshold.ts
+++ b/packages/core/src/components/essentials/threshold.ts
@@ -343,7 +343,7 @@ export class Threshold extends Component {
 
 		// We only need to specify group only if correpsonding dataset is defined
 		if (d.correspondingDatasets) {
-			datum['group'] = d.correspondingDatasets[0];
+			datum['group'] = Tools.getProperty(d, 'correspondingDatasets', 0);
 		}
 
 		// Add attribute with the mapsTo value as key


### PR DESCRIPTION
### Updates
- Correctly draw the threshold from all axes regardless the main axes.

fix #1153 

### Demo screenshot or recording
<img width="765" alt="image" src="https://user-images.githubusercontent.com/38994122/134008918-ad1258f2-6fc9-4962-b82e-053628021794.png">
<img width="753" alt="image" src="https://user-images.githubusercontent.com/38994122/134008959-fdb12f80-eeae-4fc5-ad10-63357cfad8b5.png">


### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
