### PR TITLE
fix(core): optimize transition to not return new transition on root element

### DIFF
--- a/packages/core/src/components/graphs/alluvial.ts
+++ b/packages/core/src/components/graphs/alluvial.ts
@@ -245,11 +245,7 @@ export class Alluvial extends Component {
 			(link, event = 'mouseover') => {
 				const allLinks = self.parent
 					.selectAll('path.link')
-					.transition(
-						self.services.transitions.getTransition(
-							'alluvial-link-mouse-highlight'
-						)
-					);
+					.transition('alluvial-links-mouse-highlight');
 
 				if (event === 'mouseout') {
 					select(link).lower();
@@ -381,11 +377,7 @@ export class Alluvial extends Component {
 				// Highlight all nodes
 				const allLinks = self.parent
 					.selectAll('path.link')
-					.transition(
-						self.services.transitions.getTransition(
-							'alluvial-links-mouse-highlight'
-						)
-					);
+					.transition('alluvial-link-mouse-highlight');
 
 				allLinks.style('stroke-opacity', function (d) {
 					// Raise the links & increase stroke-opacity to selected

--- a/packages/core/src/components/graphs/area-stacked.ts
+++ b/packages/core/src/components/graphs/area-stacked.ts
@@ -119,9 +119,7 @@ export class StackedArea extends Component {
 
 		this.parent
 			.selectAll('path.area')
-			.transition(
-				this.services.transitions.getTransition('legend-hover-area')
-			)
+			.transition('legend-hover-area')
 			.attr('opacity', (d) => {
 				if (
 					Tools.getProperty(d, 0, groupMapsTo) !==
@@ -137,9 +135,7 @@ export class StackedArea extends Component {
 	handleLegendMouseOut = () => {
 		this.parent
 			.selectAll('path.area')
-			.transition(
-				this.services.transitions.getTransition('legend-mouseout-area')
-			)
+			.transition('legend-mouseout-area')
 			.attr('opacity', Configuration.area.opacity.selected);
 	};
 }

--- a/packages/core/src/components/graphs/area.ts
+++ b/packages/core/src/components/graphs/area.ts
@@ -256,9 +256,7 @@ export class Area extends Component {
 
 		this.parent
 			.selectAll('path.area')
-			.transition(
-				this.services.transitions.getTransition('legend-hover-area')
-			)
+			.transition('legend-hover-area')
 			.attr('opacity', (group) => {
 				if (group.name !== hoveredElement.datum()['name']) {
 					return Configuration.area.opacity.unselected;
@@ -271,9 +269,7 @@ export class Area extends Component {
 	handleLegendMouseOut = (event: CustomEvent) => {
 		this.parent
 			.selectAll('path.area')
-			.transition(
-				this.services.transitions.getTransition('legend-mouseout-area')
-			)
+			.transition('legend-mouseout-area')
 			.attr('opacity', Configuration.area.opacity.selected);
 	};
 

--- a/packages/core/src/components/graphs/bar-grouped.ts
+++ b/packages/core/src/components/graphs/bar-grouped.ts
@@ -189,9 +189,7 @@ export class GroupedBar extends Bar {
 
 		this.parent
 			.selectAll('path.bar')
-			.transition(
-				this.services.transitions.getTransition('legend-hover-bar')
-			)
+			.transition('legend-hover-bar')
 			.attr('opacity', (d) =>
 				d[groupMapsTo] !== hoveredElement.datum()['name'] ? 0.3 : 1
 			);
@@ -201,9 +199,7 @@ export class GroupedBar extends Bar {
 	handleLegendMouseOut = (event: CustomEvent) => {
 		this.parent
 			.selectAll('path.bar')
-			.transition(
-				this.services.transitions.getTransition('legend-mouseout-bar')
-			)
+			.transition('legend-mouseout-bar')
 			.attr('opacity', 1);
 	};
 
@@ -215,12 +211,6 @@ export class GroupedBar extends Bar {
 			.on('mouseover', function (event, datum) {
 				const hoveredElement = select(this);
 				hoveredElement.classed('hovered', true);
-
-				hoveredElement.transition(
-					self.services.transitions.getTransition(
-						'graph_element_mouseover_fill_update'
-					)
-				);
 
 				// Dispatch mouse event
 				self.services.events.dispatchEvent(Events.Bar.BAR_MOUSEOVER, {
@@ -261,12 +251,6 @@ export class GroupedBar extends Bar {
 			.on('mouseout', function (event, datum) {
 				const hoveredElement = select(this);
 				hoveredElement.classed('hovered', false);
-
-				hoveredElement.transition(
-					self.services.transitions.getTransition(
-						'graph_element_mouseout_fill_update'
-					)
-				);
 
 				// Dispatch mouse event
 				self.services.events.dispatchEvent(Events.Bar.BAR_MOUSEOUT, {

--- a/packages/core/src/components/graphs/bar-simple.ts
+++ b/packages/core/src/components/graphs/bar-simple.ts
@@ -147,11 +147,7 @@ export class SimpleBar extends Bar {
 
 		this.parent
 			.selectAll('path.bar')
-			.transition(
-				this.services.transitions.getTransition(
-					'legend-hover-simple-bar'
-				)
-			)
+			.transition('legend-hover-simple-bar')
 			.attr('opacity', (d) =>
 				d[groupMapsTo] !== hoveredElement.datum()['name'] ? 0.3 : 1
 			);
@@ -160,11 +156,7 @@ export class SimpleBar extends Bar {
 	handleLegendMouseOut = (event: CustomEvent) => {
 		this.parent
 			.selectAll('path.bar')
-			.transition(
-				this.services.transitions.getTransition(
-					'legend-mouseout-simple-bar'
-				)
-			)
+			.transition('legend-mouseout-simple-bar')
 			.attr('opacity', 1);
 	};
 
@@ -175,11 +167,7 @@ export class SimpleBar extends Bar {
 			.on('mouseover', function (event, datum) {
 				const hoveredElement = select(this);
 				hoveredElement.classed('hovered', true);
-				hoveredElement.transition(
-					self.services.transitions.getTransition(
-						'graph_element_mouseover_fill_update'
-					)
-				);
+
 				// Dispatch mouse event
 				self.services.events.dispatchEvent(Events.Bar.BAR_MOUSEOVER, {
 					event,
@@ -216,12 +204,6 @@ export class SimpleBar extends Bar {
 			.on('mouseout', function (event, datum) {
 				const hoveredElement = select(this);
 				hoveredElement.classed('hovered', false);
-
-				hoveredElement.transition(
-					self.services.transitions.getTransition(
-						'graph_element_mouseout_fill_update'
-					)
-				);
 
 				// Dispatch mouse event
 				self.services.events.dispatchEvent(Events.Bar.BAR_MOUSEOUT, {

--- a/packages/core/src/components/graphs/bar-stacked.ts
+++ b/packages/core/src/components/graphs/bar-stacked.ts
@@ -171,9 +171,7 @@ export class StackedBar extends Bar {
 
 		this.parent
 			.selectAll('path.bar')
-			.transition(
-				this.services.transitions.getTransition('legend-hover-bar')
-			)
+			.transition('legend-hover-bar')
 			.attr('opacity', (d) =>
 				d[groupMapsTo] !== hoveredElement.datum()['name'] ? 0.3 : 1
 			);
@@ -183,9 +181,7 @@ export class StackedBar extends Bar {
 	handleLegendMouseOut = (event: CustomEvent) => {
 		this.parent
 			.selectAll('path.bar')
-			.transition(
-				this.services.transitions.getTransition('legend-mouseout-bar')
-			)
+			.transition('legend-mouseout-bar')
 			.attr('opacity', 1);
 	};
 
@@ -199,12 +195,6 @@ export class StackedBar extends Bar {
 			.on('mouseover', function (event, datum) {
 				const hoveredElement = select(this);
 				hoveredElement.classed('hovered', true);
-
-				hoveredElement.transition(
-					self.services.transitions.getTransition(
-						'graph_element_mouseover_fill_update'
-					)
-				);
 
 				// Dispatch mouse event
 				self.services.events.dispatchEvent(Events.Bar.BAR_MOUSEOVER, {
@@ -239,7 +229,7 @@ export class StackedBar extends Bar {
 					matchingDataPoint = {
 						[domainIdentifier]: datum.data.sharedStackKey,
 						[rangeIdentifier]: datum.data[datum[groupMapsTo]],
-						[groupMapsTo]: datum[groupMapsTo]
+						[groupMapsTo]: datum[groupMapsTo],
 					};
 				}
 

--- a/packages/core/src/components/graphs/bullet.ts
+++ b/packages/core/src/components/graphs/bullet.ts
@@ -344,11 +344,7 @@ export class Bullet extends Component {
 
 		this.parent
 			.selectAll('path.bar')
-			.transition(
-				this.services.transitions.getTransition(
-					'legend-hover-simple-bar'
-				)
-			)
+			.transition('legend-hover-simple-bar')
 			.attr('opacity', (d) =>
 				d[groupMapsTo] !== hoveredElement.datum()['name'] ? 0.3 : 1
 			);
@@ -357,11 +353,7 @@ export class Bullet extends Component {
 	handleLegendMouseOut = (event: CustomEvent) => {
 		this.parent
 			.selectAll('path.bar')
-			.transition(
-				this.services.transitions.getTransition(
-					'legend-mouseout-simple-bar'
-				)
-			)
+			.transition('legend-mouseout-simple-bar')
 			.attr('opacity', 1);
 	};
 
@@ -392,11 +384,6 @@ export class Bullet extends Component {
 			.on('mouseover', function (event, datum) {
 				const hoveredElement = select(this);
 				hoveredElement.classed('hovered', true);
-				hoveredElement.transition(
-					self.services.transitions.getTransition(
-						'graph_element_mouseover_fill_update'
-					)
-				);
 
 				// Dispatch mouse event
 				self.services.events.dispatchEvent(Events.Bar.BAR_MOUSEOVER, {
@@ -470,12 +457,6 @@ export class Bullet extends Component {
 			.on('mouseout', function (event, datum) {
 				const hoveredElement = select(this);
 				hoveredElement.classed('hovered', false);
-
-				hoveredElement.transition(
-					self.services.transitions.getTransition(
-						'graph_element_mouseout_fill_update'
-					)
-				);
 
 				// Dispatch mouse event
 				self.services.events.dispatchEvent(Events.Bar.BAR_MOUSEOUT, {

--- a/packages/core/src/components/graphs/circle-pack.ts
+++ b/packages/core/src/components/graphs/circle-pack.ts
@@ -111,12 +111,7 @@ export class CirclePack extends Component {
 			)
 			.attr('cx', (d) => d.x)
 			.attr('cy', (d) => d.y)
-			.transition(
-				this.services.transitions.getTransition(
-					'circlepack-leaf-update-enter',
-					animate
-				)
-			)
+			.transition('circlepack-leaf-update-enter')
 			.attr('r', (d) => d.r)
 			.attr('opacity', 1)
 			.attr('fill-opacity', Configuration.circlePack.circles.fillOpacity);
@@ -218,11 +213,7 @@ export class CirclePack extends Component {
 
 		this.parent
 			.selectAll('circle.node')
-			.transition(
-				this.services.transitions.getTransition(
-					'legend-hover-circlepack'
-				)
-			)
+			.transition('legend-hover-circlepack')
 			.attr('opacity', (d) => {
 				return d.data.dataGroupName === hoveredElement.datum()['name']
 					? 1
@@ -233,11 +224,7 @@ export class CirclePack extends Component {
 	handleLegendMouseOut = (event: CustomEvent) => {
 		this.parent
 			.selectAll('circle.node')
-			.transition(
-				this.services.transitions.getTransition(
-					'legend-mouseout-circlepack'
-				)
-			)
+			.transition('legend-mouseout-circlepack')
 			.attr('opacity', 1);
 	};
 

--- a/packages/core/src/components/graphs/histogram.ts
+++ b/packages/core/src/components/graphs/histogram.ts
@@ -153,9 +153,7 @@ export class Histogram extends Component {
 
 		this.parent
 			.selectAll('path.bar')
-			.transition(
-				this.services.transitions.getTransition('legend-hover-bar')
-			)
+			.transition('legend-hover-bar')
 			.attr('opacity', (d) =>
 				d[groupMapsTo] !== hoveredElement.datum()['name'] ? 0.3 : 1
 			);
@@ -165,9 +163,7 @@ export class Histogram extends Component {
 	handleLegendMouseOut = (event: CustomEvent) => {
 		this.parent
 			.selectAll('path.bar')
-			.transition(
-				this.services.transitions.getTransition('legend-mouseout-bar')
-			)
+			.transition('legend-mouseout-bar')
 			.attr('opacity', 1);
 	};
 
@@ -182,11 +178,6 @@ export class Histogram extends Component {
 				const hoveredElement = select(this);
 
 				hoveredElement.classed('hovered', true);
-				hoveredElement.transition(
-					self.services.transitions.getTransition(
-						'graph_element_mouseover_fill_update'
-					)
-				);
 
 				const x0 = parseFloat(get(datum, 'data.x0'));
 				const x1 = parseFloat(get(datum, 'data.x1'));

--- a/packages/core/src/components/graphs/line.ts
+++ b/packages/core/src/components/graphs/line.ts
@@ -159,9 +159,7 @@ export class Line extends Component {
 
 		this.parent
 			.selectAll('path.line')
-			.transition(
-				this.services.transitions.getTransition('legend-hover-line')
-			)
+			.transition('legend-hover-line')
 			.attr('opacity', (group) => {
 				if (group.name !== hoveredElement.datum()['name']) {
 					return Configuration.lines.opacity.unselected;
@@ -174,9 +172,7 @@ export class Line extends Component {
 	handleLegendMouseOut = (event: CustomEvent) => {
 		this.parent
 			.selectAll('path.line')
-			.transition(
-				this.services.transitions.getTransition('legend-mouseout-line')
-			)
+			.transition('legend-mouseout-line')
 			.attr('opacity', Configuration.lines.opacity.selected);
 	};
 

--- a/packages/core/src/components/graphs/lollipop.ts
+++ b/packages/core/src/components/graphs/lollipop.ts
@@ -158,9 +158,7 @@ export class Lollipop extends Scatter {
 
 		this.parent
 			.selectAll('line.line')
-			.transition(
-				this.services.transitions.getTransition('legend-hover-line')
-			)
+			.transition('legend-hover-line')
 			.attr('opacity', (d) => {
 				if (d[groupMapsTo] !== hoveredElement.datum()['name']) {
 					return Configuration.lines.opacity.unselected;
@@ -173,9 +171,7 @@ export class Lollipop extends Scatter {
 	handleLegendMouseOut = (event: CustomEvent) => {
 		this.parent
 			.selectAll('line.line')
-			.transition(
-				this.services.transitions.getTransition('legend-mouseout-line')
-			)
+			.transition('legend-mouseout-line')
 			.attr('opacity', Configuration.lines.opacity.selected);
 	};
 

--- a/packages/core/src/components/graphs/meter.ts
+++ b/packages/core/src/components/graphs/meter.ts
@@ -259,12 +259,6 @@ export class Meter extends Component {
 				if (proportional) {
 					hoveredElement.classed('hovered', true);
 
-					hoveredElement.transition(
-						self.services.transitions.getTransition(
-							'graph_element_mouseover_fill_update'
-						)
-					);
-
 					// Show tooltip
 					self.services.events.dispatchEvent(Events.Tooltip.SHOW, {
 						event,

--- a/packages/core/src/components/graphs/pie.ts
+++ b/packages/core/src/components/graphs/pie.ts
@@ -396,9 +396,7 @@ export class Pie extends Component {
 
 		this.parent
 			.selectAll('path.slice')
-			.transition(
-				this.services.transitions.getTransition('legend-hover-bar')
-			)
+			.transition('legend-hover-bar')
 			.attr('opacity', (d) =>
 				d.data[groupMapsTo] !== hoveredElement.datum()['name'] ? 0.3 : 1
 			);
@@ -408,9 +406,7 @@ export class Pie extends Component {
 	handleLegendMouseOut = (event: CustomEvent) => {
 		this.parent
 			.selectAll('path.slice')
-			.transition(
-				this.services.transitions.getTransition('legend-mouseout-bar')
-			)
+			.transition('legend-mouseout-bar')
 			.attr('opacity', 1);
 	};
 
@@ -423,10 +419,12 @@ export class Pie extends Component {
 
 				hoveredElement
 					.classed('hovered', true)
-					.transition(
-						self.services.transitions.getTransition(
-							'pie_slice_mouseover'
-						)
+					.transition()
+					.call((t) =>
+						self.services.transitions.setupTransition({
+							transition: t,
+							name: 'pie_slice_mouseover',
+						})
 					)
 					.attr('d', self.hoverArc);
 
@@ -478,10 +476,12 @@ export class Pie extends Component {
 				const hoveredElement = select(this);
 				hoveredElement
 					.classed('hovered', false)
-					.transition(
-						self.services.transitions.getTransition(
-							'pie_slice_mouseover'
-						)
+					.transition()
+					.call((t) =>
+						self.services.transitions.setupTransition({
+							transition: t,
+							name: 'pie_slice_mouseout',
+						})
 					)
 					.attr('d', self.arc);
 

--- a/packages/core/src/components/graphs/radar.ts
+++ b/packages/core/src/components/graphs/radar.ts
@@ -161,11 +161,13 @@ export class Radar extends Component {
 					.attr('fill', 'none')
 					.call((selection) =>
 						selection
-							.transition(
-								this.services.transitions.getTransition(
-									'radar_y_axes_enter',
-									animate
-								)
+							.transition()
+							.call((t) =>
+								this.services.transitions.setupTransition({
+									transition: t,
+									name: 'radar_y_axes_enter',
+									animate,
+								})
 							)
 							.attr('opacity', 1)
 							.attr('d', (tick) =>
@@ -175,11 +177,13 @@ export class Radar extends Component {
 			(update) =>
 				update.call((selection) =>
 					selection
-						.transition(
-							this.services.transitions.getTransition(
-								'radar_y_axes_update',
-								animate
-							)
+						.transition()
+						.call((t) =>
+							this.services.transitions.setupTransition({
+								transition: t,
+								name: 'radar_y_axes_update',
+								animate,
+							})
 						)
 						.attr('opacity', 1)
 						.attr('transform', `translate(${c.x}, ${c.y})`)
@@ -190,11 +194,13 @@ export class Radar extends Component {
 			(exit) =>
 				exit.call((selection) =>
 					selection
-						.transition(
-							this.services.transitions.getTransition(
-								'radar_y_axes_exit',
-								animate
-							)
+						.transition()
+						.call((t) =>
+							this.services.transitions.setupTransition({
+								transition: t,
+								name: 'radar_y_axes_exit',
+								animate,
+							})
 						)
 						.attr('d', (tick) =>
 							radialLineGenerator(shapeData(tick))
@@ -238,11 +244,13 @@ export class Radar extends Component {
 					)
 					.call((selection) =>
 						selection
-							.transition(
-								this.services.transitions.getTransition(
-									'radar_x_axes_enter',
-									animate
-								)
+							.transition()
+							.call((t) =>
+								this.services.transitions.setupTransition({
+									transition: t,
+									name: 'radar_x_axes_enter',
+									animate,
+								})
 							)
 							.attr('opacity', 1)
 							.attr(
@@ -285,11 +293,13 @@ export class Radar extends Component {
 			(update) =>
 				update.call((selection) =>
 					selection
-						.transition(
-							this.services.transitions.getTransition(
-								'radar_x_axes_update',
-								animate
-							)
+						.transition()
+						.call((t) =>
+							this.services.transitions.setupTransition({
+								transition: t,
+								name: 'radar_x_axes_update',
+								animate,
+							})
 						)
 						.attr('opacity', 1)
 						.attr(
@@ -332,11 +342,13 @@ export class Radar extends Component {
 			(exit) =>
 				exit.call((selection) =>
 					selection
-						.transition(
-							this.services.transitions.getTransition(
-								'radar_x_axes_exit',
-								animate
-							)
+						.transition()
+						.call((t) =>
+							this.services.transitions.setupTransition({
+								transition: t,
+								name: 'radar_x_axes_exit',
+								animate,
+							})
 						)
 						.attr('opacity', 0)
 						.remove()
@@ -384,22 +396,26 @@ export class Radar extends Component {
 					)
 					.call((selection) =>
 						selection
-							.transition(
-								this.services.transitions.getTransition(
-									'radar_x_labels_enter',
-									animate
-								)
+							.transition()
+							.call((t) =>
+								this.services.transitions.setupTransition({
+									transition: t,
+									name: 'radar_x_labels_enter',
+									animate,
+								})
 							)
 							.attr('opacity', 1)
 					),
 			(update) =>
 				update.call((selection) =>
 					selection
-						.transition(
-							this.services.transitions.getTransition(
-								'radar_x_labels_update',
-								animate
-							)
+						.transition()
+						.call((t) =>
+							this.services.transitions.setupTransition({
+								transition: t,
+								name: 'radar_x_labels_update',
+								animate,
+							})
 						)
 						.attr('opacity', 1)
 						.attr(
@@ -424,11 +440,13 @@ export class Radar extends Component {
 			(exit) =>
 				exit.call((selection) =>
 					selection
-						.transition(
-							this.services.transitions.getTransition(
-								'radar_x_labels_exit',
-								animate
-							)
+						.transition()
+						.call((t) =>
+							this.services.transitions.setupTransition({
+								transition: t,
+								name: 'radar_x_labels_exit',
+								animate,
+							})
 						)
 						.attr('opacity', 0)
 						.remove()
@@ -474,12 +492,15 @@ export class Radar extends Component {
 					.style('stroke', (group) => colorScale(group.name))
 
 					.call((selection) => {
-						const selectionUpdate = selection.transition(
-							this.services.transitions.getTransition(
-								'radar_blobs_enter',
-								animate
-							)
-						);
+						const selectionUpdate = selection
+							.transition()
+							.call((t) =>
+								this.services.transitions.setupTransition({
+									transition: t,
+									name: 'radar_blobs_enter',
+									animate,
+								})
+							);
 
 						if (animate) {
 							selectionUpdate
@@ -509,11 +530,13 @@ export class Radar extends Component {
 					.style('stroke', (group) => colorScale(group.name));
 				update.call((selection) =>
 					selection
-						.transition(
-							this.services.transitions.getTransition(
-								'radar_blobs_update',
-								animate
-							)
+						.transition()
+						.call((t) =>
+							this.services.transitions.setupTransition({
+								transition: t,
+								name: 'radar_blobs_update',
+								animate,
+							})
 						)
 						.attr('opacity', 1)
 						.attr('transform', `translate(${c.x}, ${c.y})`)
@@ -522,11 +545,12 @@ export class Radar extends Component {
 			},
 			(exit) =>
 				exit.call((selection) => {
-					const selectionUpdate = selection.transition(
-						this.services.transitions.getTransition(
-							'radar_blobs_exit',
-							animate
-						)
+					const selectionUpdate = selection.transition().call((t) =>
+						this.services.transitions.setupTransition({
+							transition: t,
+							name: 'radar_blobs_exit',
+							animate,
+						})
 					);
 
 					if (animate) {
@@ -656,22 +680,26 @@ export class Radar extends Component {
 					.style('dominant-baseline', 'middle')
 					.call((selection) =>
 						selection
-							.transition(
-								this.services.transitions.getTransition(
-									'radar_y_labels_enter',
-									animate
-								)
+							.transition()
+							.call((t) =>
+								this.services.transitions.setupTransition({
+									transition: t,
+									name: 'radar_y_labels_enter',
+									animate,
+								})
 							)
 							.attr('opacity', 1)
 					),
 			(update) =>
 				update.call((selection) =>
 					selection
-						.transition(
-							this.services.transitions.getTransition(
-								'radar_y_labels_update',
-								animate
-							)
+						.transition()
+						.call((t) =>
+							this.services.transitions.setupTransition({
+								transition: t,
+								name: 'radar_y_labels_update',
+								animate,
+							})
 						)
 						.text((tick) => tick)
 						.attr('opacity', 1)
@@ -697,11 +725,13 @@ export class Radar extends Component {
 			(exit) =>
 				exit.call((selection) =>
 					selection
-						.transition(
-							this.services.transitions.getTransition(
-								'radar_y_labels_exit',
-								animate
-							)
+						.transition()
+						.call((t) =>
+							this.services.transitions.setupTransition({
+								transition: t,
+								name: 'radar_y_labels_exit',
+								animate,
+							})
 						)
 						.attr('opacity', 0)
 						.remove()
@@ -792,9 +822,7 @@ export class Radar extends Component {
 		const { hoveredElement } = event.detail;
 		this.parent
 			.selectAll('g.blobs path')
-			.transition(
-				this.services.transitions.getTransition('legend-hover-blob')
-			)
+			.transition('legend-hover-blob')
 			.style('fill-opacity', (group) => {
 				if (group.name !== hoveredElement.datum().name) {
 					return Configuration.radar.opacity.unselected;
@@ -812,9 +840,7 @@ export class Radar extends Component {
 	handleLegendMouseOut = (event: CustomEvent) => {
 		this.parent
 			.selectAll('g.blobs path')
-			.transition(
-				this.services.transitions.getTransition('legend-mouseout-blob')
-			)
+			.transition('legend-mouseout-blob')
 			.style('fill-opacity', Configuration.radar.opacity.selected)
 			.style('stroke-opacity', 1);
 	};

--- a/packages/core/src/components/graphs/scatter.ts
+++ b/packages/core/src/components/graphs/scatter.ts
@@ -302,22 +302,14 @@ export class Scatter extends Component {
 	handleChartHolderOnHover = (event: CustomEvent) => {
 		this.parent
 			.selectAll('circle.dot')
-			.transition(
-				this.services.transitions.getTransition(
-					'chart-holder-hover-scatter'
-				)
-			)
+			.transition('chart-holder-hover-scatter')
 			.attr('opacity', 1);
 	};
 
 	handleChartHolderOnMouseOut = (event: CustomEvent) => {
 		this.parent
 			.selectAll('circle.dot')
-			.transition(
-				this.services.transitions.getTransition(
-					'chart-holder-mouseout-scatter'
-				)
-			)
+			.transition('chart-holder-mouseout-scatter')
 			.attr('opacity', 0);
 	};
 
@@ -328,9 +320,7 @@ export class Scatter extends Component {
 
 		this.parent
 			.selectAll('circle.dot')
-			.transition(
-				this.services.transitions.getTransition('legend-hover-scatter')
-			)
+			.transition('legend-hover-scatter')
 			.attr('opacity', (d) =>
 				d[groupMapsTo] !== hoveredElement.datum()['name'] ? 0.3 : 1
 			);
@@ -339,11 +329,7 @@ export class Scatter extends Component {
 	handleLegendMouseOut = (event: CustomEvent) => {
 		this.parent
 			.selectAll('circle.dot')
-			.transition(
-				this.services.transitions.getTransition(
-					'legend-mouseout-scatter'
-				)
-			)
+			.transition('legend-mouseout-scatter')
 			.attr('opacity', 1);
 	};
 

--- a/packages/core/src/components/graphs/treemap.ts
+++ b/packages/core/src/components/graphs/treemap.ts
@@ -280,10 +280,12 @@ export class Treemap extends Component {
 				while (parent.depth > 1) parent = parent.parent;
 
 				hoveredElement
-					.transition(
-						self.services.transitions.getTransition(
-							'graph_element_mouseover_fill_update'
-						)
+					.transition('graph_element_mouseover_fill_update')
+					.call((t) =>
+						self.services.transitions.setupTransition({
+							transition: t,
+							name: 'graph_element_mouseover_fill_update',
+						})
 					)
 					.style('fill', (d: any) => {
 						const customColor = self.model.getFillColor(
@@ -355,10 +357,12 @@ export class Treemap extends Component {
 				while (parent.depth > 1) parent = parent.parent;
 
 				hoveredElement
-					.transition(
-						self.services.transitions.getTransition(
-							'graph_element_mouseout_fill_update'
-						)
+					.transition()
+					.call((t) =>
+						self.services.transitions.setupTransition({
+							transition: t,
+							name: 'graph_element_mouseout_fill_update',
+						})
 					)
 					.style('fill', (d: any) =>
 						self.model.getFillColor(d.parent.data.name)
@@ -386,9 +390,7 @@ export class Treemap extends Component {
 
 		this.parent
 			.selectAll("g[data-name='leaf']")
-			.transition(
-				this.services.transitions.getTransition('legend-hover-treemap')
-			)
+			.transition('legend-hover-treemap')
 			.attr('opacity', (d) =>
 				d.parent.data.name === hoveredElement.datum()['name'] ? 1 : 0.3
 			);
@@ -397,11 +399,7 @@ export class Treemap extends Component {
 	handleLegendMouseOut = (event: CustomEvent) => {
 		this.parent
 			.selectAll("g[data-name='leaf']")
-			.transition(
-				this.services.transitions.getTransition(
-					'legend-mouseout-treemap'
-				)
-			)
+			.transition('legend-mouseout-treemap')
 			.attr('opacity', 1);
 	};
 }

--- a/packages/core/src/components/graphs/wordcloud.ts
+++ b/packages/core/src/components/graphs/wordcloud.ts
@@ -106,11 +106,13 @@ export class WordCloud extends Component {
 					return self.model.getFillColor(d[groupMapsTo], d.text, d);
 				})
 				.attr('text-anchor', 'middle')
-				.transition(
-					self.services.transitions.getTransition(
-						'wordcloud-text-update-enter',
-						animate
-					)
+				.transition()
+				.call((t) =>
+					self.services.transitions.setupTransition({
+						transition: t,
+						name: 'wordcloud-text-update-enter',
+						animate,
+					})
 				)
 				.attr('transform', (d) => `translate(${d.x}, ${d.y})`)
 				.attr('opacity', 1);
@@ -152,11 +154,7 @@ export class WordCloud extends Component {
 
 		this.parent
 			.selectAll('text.word')
-			.transition(
-				this.services.transitions.getTransition(
-					'legend-hover-wordcloud'
-				)
-			)
+			.transition('legend-hover-wordcloud')
 			.attr('opacity', (d) =>
 				d[groupMapsTo] !== hoveredElement.datum()['name'] ? 0.3 : 1
 			);
@@ -166,11 +164,7 @@ export class WordCloud extends Component {
 	handleLegendMouseOut = (event: CustomEvent) => {
 		this.parent
 			.selectAll('text.word')
-			.transition(
-				this.services.transitions.getTransition(
-					'legend-mouseout-wordcloud'
-				)
-			)
+			.transition('legend-mouseout-wordcloud')
 			.attr('opacity', 1);
 	};
 
@@ -182,11 +176,7 @@ export class WordCloud extends Component {
 		const debouncedHighlight = Tools.debounce((word) => {
 			const allWords = self.parent
 				.selectAll('text.word')
-				.transition(
-					self.services.transitions.getTransition(
-						'wordcloud-word-mouse-highlight'
-					)
-				);
+				.transition('wordcloud-word-mouse-highlight');
 
 			if (word === null) {
 				allWords.attr('opacity', 1);

--- a/packages/core/src/services/essentials/transitions.ts
+++ b/packages/core/src/services/essentials/transitions.ts
@@ -22,38 +22,6 @@ export class Transitions extends Service {
 		});
 	}
 
-	getTransition(
-		name: string,
-		animate?: boolean
-	): Transition<any, any, any, any> {
-		if (this.model.getOptions().animations === false || animate === false) {
-			return this.getInstantTransition(name);
-		}
-
-		const t: any = transition(name).duration(
-			Tools.getProperty(Configuration.transitions, name, 'duration') ||
-				Configuration.transitions.default.duration
-		);
-
-		this.pendingTransitions[t._id] = t;
-		t.on('end interrupt cancel', () => {
-			delete this.pendingTransitions[t._id];
-		});
-
-		return t;
-	}
-
-	getInstantTransition(name?: string): Transition<any, any, any, any> {
-		const t: any = transition(name).duration(0);
-
-		this.pendingTransitions[t._id] = t;
-		t.on('end interrupt cancel', () => {
-			delete this.pendingTransitions[t._id];
-		});
-
-		return t;
-	}
-
 	setupTransition({ transition: t, name, animate }: setupTransitionConfigs) {
 		this.pendingTransitions[t._id] = t;
 		t.on('end interrupt cancel', () => {


### PR DESCRIPTION
fix #1143

### Updates
- Remove all getTransition calls
- Remove all tarnsition functions that creates a new transition on the root element
- I've used concurrent transitions instead of asynchronous transitions (call) where the same transition behavior (as live) was not happening to fix the issues
  - Ex. All of the legends, circlepack, wordcloud

### Demo screenshot or recording

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
