### PR TITLE
feat(core): remove overflow menu and modal imports in chart styles 

### DIFF
--- a/packages/core/demo/styles.scss
+++ b/packages/core/demo/styles.scss
@@ -7,6 +7,7 @@
 @import '../src/styles/vendor/carbon-components/scss/components/radio-button/radio-button';
 @import '../src/styles/vendor/carbon-components/scss/components/notification/inline-notification';
 
+@import '../src/styles/vendor/carbon-components/scss/components/overflow-menu/overflow-menu';
 @import '../src/styles/vendor/carbon-components/scss/components/modal/modal';
 @import '../src/styles/vendor/carbon-components/scss/components/data-table-v2/data-table-v2';
 
@@ -52,6 +53,7 @@ div.container {
 		@import '../src/styles/styles-g10.scss';
 
 		@include modal;
+		@include overflow-menu;
 		@include data-table-core;
 
 		@include carbon--theme($carbon--theme--g10) {
@@ -70,6 +72,7 @@ div.container {
 			line-height: 1;
 
 			@include modal;
+			@include overflow-menu;
 			@include data-table-core;
 
 			.bx--radio-button__appearance {
@@ -104,6 +107,7 @@ div.container {
 			line-height: 1;
 
 			@include modal;
+			@include overflow-menu;
 			@include data-table-core;
 
 			.bx--radio-button__appearance {

--- a/packages/core/src/styles/_chart-feature-flags.scss
+++ b/packages/core/src/styles/_chart-feature-flags.scss
@@ -1,0 +1,4 @@
+/// Initialize the feature flag map with default values.
+$chart-feature-flags: (
+	enable-font-imports: true,
+) !default;

--- a/packages/core/src/styles/_type.scss
+++ b/packages/core/src/styles/_type.scss
@@ -1,8 +1,13 @@
 @import './vendor/@carbon/type/scss/type';
 @import './vendor/@carbon/type/scss/font-face/sans';
 @import './vendor/@carbon/type/scss/font-face/sans-condensed';
-@include carbon--font-face-sans();
-@include carbon--font-face-sans-condensed();
+
+@import './chart-feature-flags';
+
+@if $chart-feature-flags('enable-font-imports') == true {
+	@include carbon--font-face-sans();
+	@include carbon--font-face-sans-condensed();
+}
 
 .#{$prefix}--#{$charts-prefix}--chart-wrapper {
 	font-family: carbon--font-family('sans-condensed');

--- a/packages/core/src/styles/components/_modal.scss
+++ b/packages/core/src/styles/components/_modal.scss
@@ -1,8 +1,4 @@
-@import './../vendor/carbon-components/src/components/modal/modal';
-
 .#{$prefix}--chart-holder {
-	@include modal;
-
 	.#{$prefix}--modal {
 		&.is-visible {
 			z-index: 99999;

--- a/packages/core/src/styles/components/_toolbar.scss
+++ b/packages/core/src/styles/components/_toolbar.scss
@@ -1,9 +1,5 @@
 $css--reset: false;
-@import './../vendor/carbon-components/src/components/overflow-menu/overflow-menu';
-
 .#{$prefix}--chart-holder {
-	@include overflow-menu;
-
 	.bx--overflow-menu,
 	.bx--overflow-menu__trigger {
 		width: 2rem;

--- a/packages/core/src/styles/styles.scss
+++ b/packages/core/src/styles/styles.scss
@@ -28,6 +28,7 @@ $css--default-type: false;
 @import './graphs/index.scss';
 @import './type';
 @import './chart-holder';
+@import './chart-feature-flags';
 
 .#{$prefix}--#{$charts-prefix}--chart-wrapper {
 	overflow: visible;

--- a/packages/core/stories/tutorials/feature-flags.ts
+++ b/packages/core/stories/tutorials/feature-flags.ts
@@ -1,0 +1,18 @@
+import marked from 'marked';
+
+export const featureFlagTutorial = {
+	name: 'Style feature flags',
+	content: marked(`
+# Style feature flags
+
+Carbon charts uses carbon components for styling. In order to prevent fonts from loading twice, user's can reduce build times by disabling font importing.
+
+\`\`\`scss
+$chart-feature-flags: (
+	enable-font-imports: false,
+);
+\`\`\`
+
+By default, enable-font-imports is set to true.
+`),
+};

--- a/packages/core/stories/tutorials/index.ts
+++ b/packages/core/stories/tutorials/index.ts
@@ -8,6 +8,7 @@ export * from './getting-started/vanilla';
 export * from './api';
 export * from './tabular-data-format';
 export * from './themes';
+export * from './feature-flags';
 export * from './event-listeners';
 export * from './color-palette';
 export * from './dual-axes';


### PR DESCRIPTION
Closes #1168
Closes #1115

### Updates
- Remove overflow menu and toolbar imports in styles
- Update demo to display overflow menu correctly
- Add feature flags (Similar to carbon) to import fonts

### Demo screenshot or recording

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
