### PR TITLE
fix(styles): use `map-get` in `_type.scss`

### DIFF
--- a/packages/core/src/styles/_type.scss
+++ b/packages/core/src/styles/_type.scss
@@ -4,7 +4,7 @@
 
 @import './chart-feature-flags';
 
-@if $chart-feature-flags('enable-font-imports') == true {
+@if map-get($chart-feature-flags, 'enable-font-imports') == true {
 	@include carbon--font-face-sans();
 	@include carbon--font-face-sans-condensed();
 }


### PR DESCRIPTION
### Updates
* Change `_type.scss` to use `map-get` to get values from maps. Part of #1168.

### Demo screenshot or recording

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
