### PR TITLE
fix(core): allow users to assign custom colors to the links of source nodes

### DIFF
--- a/packages/core/demo/data/alluvial.ts
+++ b/packages/core/demo/data/alluvial.ts
@@ -30,9 +30,9 @@ export const alluvialSimpleCustomColorOptions = {
 	title: 'Custom colors (alluvial)',
 	color: {
 		scale: {
-			A: 'red',
-			B: 'yellow',
-			C: 'blue',
+			A: '#d12771',
+			B: '#08bdba',
+			C: '#6fdc8c',
 		},
 	},
 };

--- a/packages/core/demo/data/alluvial.ts
+++ b/packages/core/demo/data/alluvial.ts
@@ -25,6 +25,18 @@ export const alluvialSimpleOptions = {
 	},
 };
 
+export const alluvialSimpleCustomColorOptions = {
+	...alluvialSimpleOptions,
+	title: 'Custom colors (alluvial)',
+	color: {
+		scale: {
+			A: 'red',
+			B: 'yellow',
+			C: 'blue',
+		},
+	},
+};
+
 export const alluvialMultipleCategoryOptions = {
 	title: 'Alluvial (multiple categories)',
 	alluvial: {

--- a/packages/core/demo/data/index.ts
+++ b/packages/core/demo/data/index.ts
@@ -213,6 +213,11 @@ const utilityDemoGroups = [
 				data: circlePackDemos.circlePackTwoLevelData,
 				chartType: chartTypes.CirclePackChart,
 			},
+			{
+				options: alluvialDemos.alluvialSimpleCustomColorOptions,
+				data: alluvialDemos.alluvialSimpleData,
+				chartType: chartTypes.AlluvialChart,
+			},
 		],
 	},
 	{

--- a/packages/core/src/components/graphs/alluvial.ts
+++ b/packages/core/src/components/graphs/alluvial.ts
@@ -137,6 +137,7 @@ export class Alluvial extends Component {
 					originalClassName: 'link',
 				});
 			})
+			.style('stroke', (d) => this.model.getFillColor(d.source.name))
 			.attr('stroke-width', (d) => Math.max(1, d.width))
 			.style('stroke-opacity', Configuration.alluvial.opacity.default)
 			.attr(


### PR DESCRIPTION
### Updates
- Allow users to assign custom colors to node links from source
- Create a demo for it

fix #1175 

### Demo screenshot or recording
<img width="1002" alt="image" src="https://user-images.githubusercontent.com/38994122/136042636-e0d02e72-57e5-4e90-8066-3c4305009e8c.png">


### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
