### PR TITLE
docs(svelte): update rollup set-up instructions

### DIFF
--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -114,22 +114,6 @@ No additional configuration should be necessary.
 
 ### Rollup
 
-When using this library with [rollup](https://github.com/rollup/rollup), set
-`context` to `"window"` in the exported configuration in `rollup.config.js`.
-
-```js
-// rollup.config.js
-
-export default {
-	context: 'window',
-	// ...
-};
-```
-
-#### Troubleshooting
-
-##### "process is not defined"
-
 If you encounter the error message `ReferenceError: process is not defined`,
 install
 [@rollup/plugin-replace](https://github.com/rollup/plugins/tree/master/packages/replace)


### PR DESCRIPTION
Using the latest `@carbon/charts-svelte` and `d3` versions no longer require setting the `context` option for Rollup set-ups.

Tested here: https://github.com/metonym/carbon-charts-svelte-examples/tree/master/rollup

### Updates
- docs(svelte): update rollup set-up instructions
