### PR TITLE
docs(svelte): include `carbon-components` styles in examples

### DIFF
--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -193,6 +193,7 @@ Import chart styles from `@carbon/charts`:
 <script>
   import { BarChartSimple } from "@carbon/charts-svelte";
   import "@carbon/charts/styles.min.css";
+  import "carbon-components/css/carbon-components.min.css";
 </script>
 
 <BarChartSimple
@@ -244,6 +245,7 @@ Dynamically import a chart and instantiate it using the
 <script>
   import { onMount } from "svelte";
   import "@carbon/charts/styles.min.css";
+  import "carbon-components/css/carbon-components.min.css";
 
   let chart;
 
@@ -284,6 +286,7 @@ that fires when hovering over a bar.
   import { onMount } from "svelte";
   import { BarChartSimple } from "@carbon/charts-svelte";
   import "@carbon/charts/styles.min.css";
+  import "carbon-components/css/carbon-components.min.css";
 
   let chart;
 


### PR DESCRIPTION
The chart toolbar will no longer by styled unless the user also imports styles from `carbon-components`.

This PR updates the examples in `README` to import stylesheets for both charts and components.

### Updates

- docs(svelte): include `carbon-components` styles in examples

### Demo screenshot or recording

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
