### PR TITLE
docs(svelte): remove unnecessary exclusion for @carbon/telemetry

### DIFF
--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -68,7 +68,6 @@ const config = {
 		vite: {
 			optimizeDeps: {
 				include: ['@carbon/charts'],
-				exclude: ['@carbon/telemetry']
 			},
 			ssr: {
 				noExternal: [production && '@carbon/charts'].filter(Boolean),


### PR DESCRIPTION
This PR updates the SvelteKit usage example by removing the line instructing vite to exclude `@carbon/telemetry`.

The issue in #1130 was fixed 4 days after it was reported in `@sveltejs/vite-plugin-svelte@1.0.0-next.22` (https://github.com/sveltejs/vite-plugin-svelte/pull/163), which is used by SvelteKit.

It's no longer necessary to manually exclude `@carbon/telemetry`.

Tested locally here: https://github.com/metonym/carbon-charts-svelte-examples/tree/master/sveltekit

### Updates
- docs(svelte): remove unnecessary exclusion for @carbon/telemetry

### Demo screenshot or recording

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
