### PR TITLE
docs(svelte): fix codesandbox template issues

### DIFF
--- a/packages/core/demo/create-codesandbox.ts
+++ b/packages/core/demo/create-codesandbox.ts
@@ -393,9 +393,9 @@ export const createSvelteChartApp = (demo: any) => {
 			build: 'vite build',
 		},
 		devDependencies: {
-			'@carbon/charts-svelte': '^0.50.6',
+			'@carbon/charts-svelte': libraryVersion,
 			'@sveltejs/vite-plugin-svelte': 'next',
-			d3: '^7.0.0',
+			d3: D3VERSION,
 			svelte: '^3.43.1',
 			'svelte-hmr': '^0.14.7',
 			vite: '^2.6.7',


### PR DESCRIPTION
This PR updates the Svelte Codesandbox template code to fix the generated Codesandbox demos for Svelte charts.

The template is updated to use `vite` with `@sveltejs/vite-plugin-svelte`.

Working sample: https://codesandbox.io/s/carbon-chart-svelte-vite-forked-jtcqz

### Updates
- fix(svelte): update codesandbox template

### Demo screenshot or recording

I tested this locally by running:

1. `yarn build` at the root of the monorepo
2. `yarn demo:build` in `packages/svelte`
3. `serve demo/bundle` to preview the locally built Storybook
4. Visit the AreaChart story and click "Edit Sandbox"
5. https://codesandbox.io/s/jxtq1?file=/App.svelte

<img width="1374" alt="Screen Shot 2021-10-11 at 4 52 52 PM" src="https://user-images.githubusercontent.com/10718366/136868474-0eec9433-0cb2-4c2b-be33-5fe8b743c6ed.png">


### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
