### PR TITLE
fix(core): HCM issues with legend & tooltips

### DIFF
--- a/packages/core/src/styles/components/_legend.scss
+++ b/packages/core/src/styles/components/_legend.scss
@@ -5,7 +5,7 @@ div.#{$prefix}--#{$charts-prefix}--legend {
 	flex-wrap: wrap;
 
 	&[data-name='legend-items'] {
-	    width: 100%;
+		width: 100%;
 		margin: -5px;
 	}
 
@@ -21,6 +21,10 @@ div.#{$prefix}--#{$charts-prefix}--legend {
 			border-radius: 2px;
 			border: solid 1px $ui-background;
 			box-shadow: 0 0 0 2px transparent;
+
+			@media (forced-colors: active) {
+				forced-color-adjust: none;
+			}
 
 			&:not(.active) {
 				border-color: $text-02;

--- a/packages/core/src/styles/components/_tooltip.scss
+++ b/packages/core/src/styles/components/_tooltip.scss
@@ -122,6 +122,10 @@
 		width: 4px;
 		height: 100%;
 
+		@media (forced-colors: active) {
+			forced-color-adjust: none;
+		}
+
 		& + div.label p {
 			margin-left: 4px;
 		}


### PR DESCRIPTION
In HCM legends & tooltips seem to be rendering without fill colors. This should fix that