### PR TITLE
fix(core): render chart axis labels correctly when data loads async

### DIFF
--- a/packages/core/src/services/angle-utils.ts
+++ b/packages/core/src/services/angle-utils.ts
@@ -80,8 +80,8 @@ export function polarToCartesianCoords(
 	r: number,
 	t: Point = { x: 0, y: 0 }
 ): Point {
-	let x = r * Math.cos(a) + t.x;
-	let y = r * Math.sin(a) + t.y;
+	const x = r * Math.cos(a) + t.x;
+	const y = r * Math.sin(a) + t.y;
 
 	// NaN is rendered at coordinate 0 in browsers
 	// By setting it to 0, further operations can be performed

--- a/packages/core/src/services/angle-utils.ts
+++ b/packages/core/src/services/angle-utils.ts
@@ -80,16 +80,12 @@ export function polarToCartesianCoords(
 	r: number,
 	t: Point = { x: 0, y: 0 }
 ): Point {
-	const x = r * Math.cos(a) + t.x;
-	const y = r * Math.sin(a) + t.y;
+	let x = r * Math.cos(a) + t.x;
+	let y = r * Math.sin(a) + t.y;
 
 	// NaN is rendered at coordinate 0 in browsers
 	// By setting it to 0, further operations can be performed
-	if (isNaN(x) || isNaN(y)) {
-		return { x: 0, y: 0 };
-	}
-
-	return { x, y };
+	return { x: isNaN(x) ? 0 : x, y: isNaN(y) ? 0 : y };
 }
 
 // Return the distance between a point (described with polar coordinates)

--- a/packages/core/src/services/angle-utils.ts
+++ b/packages/core/src/services/angle-utils.ts
@@ -82,6 +82,13 @@ export function polarToCartesianCoords(
 ): Point {
 	const x = r * Math.cos(a) + t.x;
 	const y = r * Math.sin(a) + t.y;
+
+	// NaN is rendered at coordinate 0 in browsers
+	// By setting it to 0, further operations can be performed
+	if (isNaN(x) || isNaN(y)) {
+		return { x: 0, y: 0 };
+	}
+
 	return { x, y };
 }
 


### PR DESCRIPTION
fix #1135

### Updates
- NaN coordinates are positioned at (0, 0)
  - If value equals NaN, then we reassign it value 0 to allow further operations.


### Demo screenshot or recording
https://user-images.githubusercontent.com/38994122/139632321-8b1de3fe-af4f-463c-87ce-fe6963de5423.mov

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
