### PR TITLE
fix(svelte): remove default export in `index.html`

### DIFF
--- a/packages/core/demo/create-codesandbox.ts
+++ b/packages/core/demo/create-codesandbox.ts
@@ -368,8 +368,6 @@ export const createSvelteChartApp = (demo: any) => {
       import App from "./App.svelte";
 
       const app = new App({ target: document.body });
-
-      export default app;
     </script>
   </body>
 </html>


### PR DESCRIPTION
Currently, the Svelte codesandboxes are broken and will not run.

[Example](https://codesandbox.io/s/tv5sg)

![Screen Shot 2021-11-16 at 8 29 14 AM](https://user-images.githubusercontent.com/10718366/142026227-363a1bf3-1796-4f11-940b-3991b2298e00.png)

The error is caused by a breaking change introduced in vite version 2.6.8: https://github.com/vitejs/vite/compare/v2.6.7...v2.6.8#diff-00039b783552b3f2a608918986716e01b1a71996da1a8ad5493a102a1e969d7bR279

The solution is to remove the "export default app" line in the `index.html` file.

Example of the solution in practice: https://codesandbox.io/s/objective-cloud-lp4r5?file=/index.html


### Updates
- fix(svelte): remove default export in `index.html`

### Demo screenshot or recording

![Screen Shot 2021-11-16 at 8 35 05 AM](https://user-images.githubusercontent.com/10718366/142026584-889e0132-0b43-47b7-8c15-084569b7c722.png)


### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
