### PR TITLE
feat(svelte): add TypeScript definitions for Alluvial, Histogram, and Tree charts

### DIFF
--- a/packages/svelte/tests/AlluvialChart.test.svelte
+++ b/packages/svelte/tests/AlluvialChart.test.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import { AlluvialChart } from '../types';
+	import type { AlluvialChart as AC } from '@carbon/charts';
+	import {
+		alluvialSimpleData as data,
+		alluvialSimpleOptions,
+	} from '@carbon/charts/demo/data';
+
+	let chart: AC = null;
+	let ref = null;
+
+	const options = alluvialSimpleOptions as any;
+</script>
+
+<AlluvialChart
+	bind:chart
+	bind:ref
+	on:load={(e) => {
+		console.log(e.detail);
+	}}
+	on:update={(e) => {
+		console.log(e.detail);
+	}}
+	on:destroy={(e) => {
+		console.log(e.detail);
+	}}
+	{data}
+	{options}
+/>
+
+<svelte:component
+	this={AlluvialChart}
+	on:load={(e) => {
+		console.log(e.detail);
+	}}
+	on:update={(e) => {
+		console.log(e.detail);
+	}}
+	on:destroy={(e) => {
+		console.log(e.detail);
+	}}
+	{data}
+	{options}
+/>

--- a/packages/svelte/tests/HistogramChart.test.svelte
+++ b/packages/svelte/tests/HistogramChart.test.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import { HistogramChart } from '../types';
+	import type { HistogramChart as HC } from '@carbon/charts';
+	import {
+		histogramContinueData as data,
+		histogramContinueWithBinsOptions
+	} from '@carbon/charts/demo/data';
+
+	let chart: HC = null;
+	let ref = null;
+
+	const options = histogramContinueWithBinsOptions as any;
+</script>
+
+<HistogramChart
+	bind:chart
+	bind:ref
+	on:load={(e) => {
+		console.log(e.detail);
+	}}
+	on:update={(e) => {
+		console.log(e.detail);
+	}}
+	on:destroy={(e) => {
+		console.log(e.detail);
+	}}
+	{data}
+	{options}
+/>
+
+<svelte:component
+	this={HistogramChart}
+	on:load={(e) => {
+		console.log(e.detail);
+	}}
+	on:update={(e) => {
+		console.log(e.detail);
+	}}
+	on:destroy={(e) => {
+		console.log(e.detail);
+	}}
+	{data}
+	{options}
+/>

--- a/packages/svelte/tests/TreeChart.test.svelte
+++ b/packages/svelte/tests/TreeChart.test.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+	import { TreeChart } from '../types';
+	import type { TreeChart as TC } from '@carbon/charts';
+
+	let chart: TC = null;
+	let ref = null;
+
+    // copied from packages/core/demo/data/tree.ts
+	const data = {
+		name: 'analytics',
+		children: [
+			{
+				name: 'cluster',
+				children: [
+					{ name: 'AgglomerativeCluster', value: 3938 },
+					{ name: 'CommunityStructure', value: 3812 },
+					{ name: 'HierarchicalCluster', value: 6714 },
+					{ name: 'MergeEdge', value: 743 },
+				],
+			},
+			{
+				name: 'graph',
+				children: [
+					{ name: 'BetweennessCentrality', value: 3534 },
+					{ name: 'LinkDistance', value: 5731 },
+					{ name: 'MaxFlowMinCut', value: 7840 },
+					{ name: 'ShortestPaths', value: 5914 },
+					{ name: 'SpanningTree', value: 3416 },
+				],
+			},
+			{
+				name: 'optimization',
+				children: [{ name: 'AspectRatioBanker', value: 7074 }],
+			},
+		],
+	};
+	const options = {
+		title: 'Tree',
+		height: '2000px',
+		tree: {
+			rootTitle: 'flare',
+		},
+	};
+</script>
+
+<TreeChart
+	bind:chart
+	bind:ref
+	on:load={(e) => {
+		console.log(e.detail);
+	}}
+	on:update={(e) => {
+		console.log(e.detail);
+	}}
+	on:destroy={(e) => {
+		console.log(e.detail);
+	}}
+	{data}
+	{options}
+/>
+
+<svelte:component
+	this={TreeChart}
+	on:load={(e) => {
+		console.log(e.detail);
+	}}
+	on:update={(e) => {
+		console.log(e.detail);
+	}}
+	on:destroy={(e) => {
+		console.log(e.detail);
+	}}
+	{data}
+	{options}
+/>

--- a/packages/svelte/types/AlluvialChart.d.ts
+++ b/packages/svelte/types/AlluvialChart.d.ts
@@ -1,0 +1,5 @@
+import { AlluvialChart as AC } from "@carbon/charts";
+import type { AlluvialChartOptions } from "@carbon/charts/interfaces";
+import BaseChart from "./BaseChart";
+
+export default class AlluvialChart extends BaseChart<AC, AlluvialChartOptions> {}

--- a/packages/svelte/types/BaseChart.d.ts
+++ b/packages/svelte/types/BaseChart.d.ts
@@ -6,7 +6,7 @@ import type {
   ChartTabularData,
 } from "@carbon/charts/interfaces";
 
-export interface BaseChartProps<Chart = BC, ChartOptions = BaseChartOptions>
+export interface BaseChartProps<Chart = BC, ChartOptions = BaseChartOptions, ChartData = ChartTabularData>
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
    * Provide a Carbon chart class to instantiate
@@ -24,7 +24,7 @@ export interface BaseChartProps<Chart = BC, ChartOptions = BaseChartOptions>
    * Set the chart data using the tabular data format
    * @default []
    */
-  data?: ChartTabularData;
+  data?: ChartData;
 
   /**
    * Set the chart options
@@ -46,10 +46,11 @@ export interface BaseChartProps<Chart = BC, ChartOptions = BaseChartOptions>
 }
 
 export default class BaseChart<
-  Chart = BaseChart,
-  ChartOptions = BaseChartOptions
+  Chart = BC,
+  ChartOptions = BaseChartOptions,
+  ChartData = ChartTabularData
 > extends SvelteComponentTyped<
-  BaseChartProps<Chart, ChartOptions>,
+  BaseChartProps<Chart, ChartOptions, ChartData>,
   {
     load: CustomEvent<Chart>;
     update: CustomEvent<{

--- a/packages/svelte/types/HistogramChart.d.ts
+++ b/packages/svelte/types/HistogramChart.d.ts
@@ -1,0 +1,5 @@
+import { HistogramChart as HC } from "@carbon/charts";
+import type { HistogramChartOptions } from "@carbon/charts/interfaces";
+import BaseChart from "./BaseChart";
+
+export default class HistogramChart extends BaseChart<HC, HistogramChartOptions> {}

--- a/packages/svelte/types/TreeChart.d.ts
+++ b/packages/svelte/types/TreeChart.d.ts
@@ -1,0 +1,15 @@
+import { TreeChart as TC } from '@carbon/charts';
+import type { TreeChartOptions } from '@carbon/charts/interfaces';
+import BaseChart from './BaseChart';
+
+interface TreeNode {
+	name: string;
+	value?: number;
+	children?: TreeNode[];
+}
+
+export default class TreeChart extends BaseChart<
+	TC,
+	TreeChartOptions,
+	TreeNode
+> {}

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -19,3 +19,4 @@ export { default as MeterChart } from "./MeterChart";
 export { default as TreemapChart } from "./TreemapChart";
 export { default as WordCloudChart } from "./WordCloudChart";
 export { default as AlluvialChart } from "./AlluvialChart";
+export { default as HistogramChart } from "./HistogramChart";

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -18,3 +18,4 @@ export { default as GaugeChart } from "./GaugeChart";
 export { default as MeterChart } from "./MeterChart";
 export { default as TreemapChart } from "./TreemapChart";
 export { default as WordCloudChart } from "./WordCloudChart";
+export { default as AlluvialChart } from "./AlluvialChart";

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -20,3 +20,4 @@ export { default as TreemapChart } from "./TreemapChart";
 export { default as WordCloudChart } from "./WordCloudChart";
 export { default as AlluvialChart } from "./AlluvialChart";
 export { default as HistogramChart } from "./HistogramChart";
+export { default as TreeChart } from "./TreeChart";


### PR DESCRIPTION
This PR is best reviewed by commit.

**Testing locally**

1. Run `yarn; yarn build` at the root of the monorepo
2. In `packages/svelte`, run `yarn test`
3. Validate that no errors or warnings are emitted by `svelte-check`

### Updates
- feat(svelte): add TypeScript definitions for Alluvial, Histogram, and Tree charts

### Demo screenshot or recording

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
