### PR TITLE
fix(core): set pointer events of highlight elements to none

### DIFF
--- a/packages/core/demo/data/hightlight.ts
+++ b/packages/core/demo/data/hightlight.ts
@@ -23,7 +23,7 @@ export const boundedAreaTimeSeriesWithHighlightsOptions = {
 				labelMapsTo: 'label',
 				data: [
 					{
-						startHighlight: new Date(2019, 0, 7),
+						startHighlight: new Date(2019, 0, 3),
 						label: 'Custom formatter',
 						endHighlight: new Date(2019, 0, 8),
 					},

--- a/packages/core/src/axis-chart.ts
+++ b/packages/core/src/axis-chart.ts
@@ -125,7 +125,15 @@ export class AxisChart extends Chart {
 		}
 
 		graphFrameComponents.push(new Threshold(this.model, this.services));
-		graphFrameComponents.push(new Highlight(this.model, this.services));
+		// Insert Highlight right after Axes is created so user's can still hover over datapoints
+		const insertIndex = graphFrameComponents.findIndex(
+			({ type }) => type === '2D-axes'
+		);
+		graphFrameComponents.splice(
+			insertIndex + 1,
+			0,
+			new Highlight(this.model, this.services)
+		);
 
 		const graphFrameComponent = {
 			id: 'graph-frame',

--- a/packages/core/src/axis-chart.ts
+++ b/packages/core/src/axis-chart.ts
@@ -125,15 +125,7 @@ export class AxisChart extends Chart {
 		}
 
 		graphFrameComponents.push(new Threshold(this.model, this.services));
-		// Insert Highlight right after Axes is created so user's can still hover over datapoints
-		const insertIndex = graphFrameComponents.findIndex(
-			({ type }) => type === '2D-axes'
-		);
-		graphFrameComponents.splice(
-			insertIndex + 1,
-			0,
-			new Highlight(this.model, this.services)
-		);
+		graphFrameComponents.push(new Highlight(this.model, this.services));
 
 		const graphFrameComponent = {
 			id: 'graph-frame',

--- a/packages/core/src/styles/components/_highlights.scss
+++ b/packages/core/src/styles/components/_highlights.scss
@@ -1,5 +1,6 @@
 .#{$prefix}--#{$charts-prefix}--highlight {
 	rect.highlight-bar {
+		pointer-events: none;
 		fill: $magenta-50;
 		stroke: $magenta-50;
 	}


### PR DESCRIPTION
### Updates
- Sets pointer events of highlight element to none so users can use the ruler & hover over the chart elements.

### Demo screenshot or recording
<img width="780" alt="image" src="https://user-images.githubusercontent.com/38994122/142272886-954afda5-16e6-4d8b-8e11-de580af75c68.png">


### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
