### PR TITLE
fix: set zoom domain if old initial zoom domain is undefined

### DIFF
--- a/packages/core/src/components/axes/zoom-bar.ts
+++ b/packages/core/src/components/axes/zoom-bar.ts
@@ -226,7 +226,7 @@ export class ZoomBar extends Component {
 				);
 			} else if (
 				newInitialZoomDomain === null &&
-				oldInitialZoomDomain != null
+				oldInitialZoomDomain !== null
 			) {
 				// if newInitialZoomDomain is set to null (when oldInitialZoomDomain is not null)
 				// save initialZoomDomain and reset zoom domain to default domain


### PR DESCRIPTION
### Updates
-  if existing initial zoom domain is undefined, we should still reset initial zoom domain (and zoom domain) if new initial zoom domain is null.

### Demo screenshot or recording
No UI/storybook change.

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
