### PR TITLE
fix(core): display the correct group when hovering over scatter point

### DIFF
--- a/packages/core/src/components/graphs/scatter-stacked.ts
+++ b/packages/core/src/components/graphs/scatter-stacked.ts
@@ -30,6 +30,9 @@ export class StackedScatter extends Scatter {
 			percentage,
 		});
 
+		// Organize the data based on the active data groups
+		const dGroups = this.model.getDataGroups();
+
 		// Update data on dot groups
 		const circleGroups = svg
 			.selectAll('g.dots')
@@ -49,7 +52,8 @@ export class StackedScatter extends Scatter {
 		const circles = circleGroupsEnter
 			.merge(circleGroups)
 			.selectAll('circle.dot')
-			.data((d) => d);
+			// Render only the circles that should be active
+			.data((d, i) => (dGroups[i].status ? d : []));
 
 		// Remove circles that need to be removed
 		circles.exit().attr('opacity', 0).remove();

--- a/packages/core/src/components/graphs/scatter-stacked.ts
+++ b/packages/core/src/components/graphs/scatter-stacked.ts
@@ -31,7 +31,7 @@ export class StackedScatter extends Scatter {
 		});
 
 		// Organize the data based on the active data groups
-		const dGroups = this.model.getDataGroups();
+		const dataGroups = this.model.getDataGroups();
 
 		// Update data on dot groups
 		const circleGroups = svg
@@ -53,7 +53,7 @@ export class StackedScatter extends Scatter {
 			.merge(circleGroups)
 			.selectAll('circle.dot')
 			// Render only the circles that should be active
-			.data((d, i) => (dGroups[i].status ? d : []));
+			.data((d, i) => (dataGroups[i].status ? d : []));
 
 		// Remove circles that need to be removed
 		circles.exit().attr('opacity', 0).remove();

--- a/packages/core/src/components/graphs/scatter-stacked.ts
+++ b/packages/core/src/components/graphs/scatter-stacked.ts
@@ -30,9 +30,6 @@ export class StackedScatter extends Scatter {
 			percentage,
 		});
 
-		// Organize the data based on the active data groups
-		const dataGroups = this.model.getDataGroups();
-
 		// Update data on dot groups
 		const circleGroups = svg
 			.selectAll('g.dots')
@@ -52,8 +49,7 @@ export class StackedScatter extends Scatter {
 		const circles = circleGroupsEnter
 			.merge(circleGroups)
 			.selectAll('circle.dot')
-			// Render only the circles that should be active
-			.data((d, i) => (dataGroups[i].status ? d : []));
+			.data((d) => d);
 
 		// Remove circles that need to be removed
 		circles.exit().attr('opacity', 0).remove();

--- a/packages/core/src/model/model.ts
+++ b/packages/core/src/model/model.ts
@@ -403,7 +403,9 @@ export class ChartModel {
 		const options = this.getOptions();
 		const { groupMapsTo } = options.data;
 
-		const dataGroupNames = this.getDataGroupNames(groups);
+		// Get only active data groups so non-active data groups are not rendered
+		// on legend item click
+		const dataGroupNames = this.getActiveDataGroupNames(groups);
 		const dataValuesGroupedByKeys = this.getDataValuesGroupedByKeys({
 			groups,
 		});


### PR DESCRIPTION
### Updates
- Render the scatter points only if the status of the data group is true.

fix #1188

### Demo screenshot or recording
<img width="755" alt="image" src="https://user-images.githubusercontent.com/38994122/144260403-a8c472eb-90ea-4631-a51f-508e6aa873a0.png">


### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
