### PR TITLE
fix(stacked-bar): set bar width based on number of domain values

### DIFF
--- a/packages/core/src/components/graphs/bar-stacked.ts
+++ b/packages/core/src/components/graphs/bar-stacked.ts
@@ -304,7 +304,7 @@ export class StackedBar extends Bar {
 			useAttrs: true,
 		}).width;
 	
-		const numberOfDomainValues = this.model.getStackKeys({}).length;
+		const numberOfDomainValues = this.model.getStackKeys().length;
 	
 		if (!mainXScale.step) {
 			return Math.min(

--- a/packages/core/src/components/graphs/bar-stacked.ts
+++ b/packages/core/src/components/graphs/bar-stacked.ts
@@ -8,6 +8,8 @@ import {
 	ColorClassNameTypes,
 	RenderTypes,
 } from '../../interfaces';
+import { DOMUtils } from '../../services';
+
 
 // D3 Imports
 import { select } from 'd3-selection';
@@ -292,6 +294,27 @@ export class StackedBar extends Bar {
 			});
 	}
 
+	protected getBarWidth() {
+		const options = this.getOptions();
+		if (options.bars.width) {
+			return options.bars.width;
+		}
+		const mainXScale = this.services.cartesianScales.getMainXScale();
+		const chartWidth = DOMUtils.getSVGElementSize(this.parent, {
+			useAttrs: true,
+		}).width;
+	
+		const numberOfDomainValues = this.model.getStackKeys().length;
+	
+		if (!mainXScale.step) {
+			return Math.min(
+				options.bars.maxWidth,
+				(chartWidth * 0.25) / numberOfDomainValues
+			);
+		}
+		return Math.min(options.bars.maxWidth, mainXScale.step() / 2);
+	}
+	
 	destroy() {
 		// Remove event listeners
 		this.parent

--- a/packages/core/src/components/graphs/bar-stacked.ts
+++ b/packages/core/src/components/graphs/bar-stacked.ts
@@ -8,6 +8,8 @@ import {
 	ColorClassNameTypes,
 	RenderTypes,
 } from '../../interfaces';
+import { DOMUtils } from '../../services';
+
 
 // D3 Imports
 import { select } from 'd3-selection';
@@ -292,6 +294,27 @@ export class StackedBar extends Bar {
 			});
 	}
 
+	protected getBarWidth() {
+		const options = this.getOptions();
+		if (Tools.getProperty(options, "bars", "width")) {
+			return options.bars.width;
+		}
+		const mainXScale = this.services.cartesianScales.getMainXScale();
+		const chartWidth = DOMUtils.getSVGElementSize(this.parent, {
+			useAttrs: true,
+		}).width;
+	
+		const numberOfDomainValues = this.model.getStackKeys().length;
+	
+		if (!mainXScale.step) {
+			return Math.min(
+				options.bars.maxWidth,
+				(chartWidth * 0.25) / numberOfDomainValues
+			);
+		}
+		return Math.min(options.bars.maxWidth, mainXScale.step() / 2);
+	}
+	
 	destroy() {
 		// Remove event listeners
 		this.parent

--- a/packages/core/src/components/graphs/bar-stacked.ts
+++ b/packages/core/src/components/graphs/bar-stacked.ts
@@ -8,8 +8,6 @@ import {
 	ColorClassNameTypes,
 	RenderTypes,
 } from '../../interfaces';
-import { DOMUtils } from '../../services';
-
 
 // D3 Imports
 import { select } from 'd3-selection';
@@ -294,27 +292,6 @@ export class StackedBar extends Bar {
 			});
 	}
 
-	protected getBarWidth() {
-		const options = this.getOptions();
-		if (Tools.getProperty(options, "bars", "width")) {
-			return options.bars.width;
-		}
-		const mainXScale = this.services.cartesianScales.getMainXScale();
-		const chartWidth = DOMUtils.getSVGElementSize(this.parent, {
-			useAttrs: true,
-		}).width;
-	
-		const numberOfDomainValues = this.model.getStackKeys().length;
-	
-		if (!mainXScale.step) {
-			return Math.min(
-				options.bars.maxWidth,
-				(chartWidth * 0.25) / numberOfDomainValues
-			);
-		}
-		return Math.min(options.bars.maxWidth, mainXScale.step() / 2);
-	}
-	
 	destroy() {
 		// Remove event listeners
 		this.parent

--- a/packages/core/src/components/graphs/bar-stacked.ts
+++ b/packages/core/src/components/graphs/bar-stacked.ts
@@ -304,7 +304,7 @@ export class StackedBar extends Bar {
 			useAttrs: true,
 		}).width;
 	
-		const numberOfDomainValues = this.model.getStackKeys().length;
+		const numberOfDomainValues = this.model.getStackKeys({}).length;
 	
 		if (!mainXScale.step) {
 			return Math.min(

--- a/packages/core/src/components/graphs/bar-stacked.ts
+++ b/packages/core/src/components/graphs/bar-stacked.ts
@@ -296,7 +296,7 @@ export class StackedBar extends Bar {
 
 	protected getBarWidth() {
 		const options = this.getOptions();
-		if (options.bars.width) {
+		if (Tools.getProperty(options, "bars", "width")) {
 			return options.bars.width;
 		}
 		const mainXScale = this.services.cartesianScales.getMainXScale();

--- a/packages/core/src/components/graphs/bar.ts
+++ b/packages/core/src/components/graphs/bar.ts
@@ -10,7 +10,7 @@ export class Bar extends Component {
 			return options.bars.width;
 		}
 
-		const numberOfDatapoints = this.model.getDisplayData().length;
+		const numberOfDomainValues = this.model.getStackKeys().length;
 		const mainXScale = this.services.cartesianScales.getMainXScale();
 		const chartWidth = DOMUtils.getSVGElementSize(this.parent, {
 			useAttrs: true,
@@ -19,7 +19,7 @@ export class Bar extends Component {
 		if (!mainXScale.step) {
 			return Math.min(
 				options.bars.maxWidth,
-				(chartWidth * 0.25) / numberOfDatapoints
+				(chartWidth * 0.25) / numberOfDomainValues
 			);
 		}
 

--- a/packages/core/src/components/graphs/bar.ts
+++ b/packages/core/src/components/graphs/bar.ts
@@ -10,7 +10,7 @@ export class Bar extends Component {
 			return options.bars.width;
 		}
 
-		const numberOfDomainValues = this.model.getStackKeys().length;
+		const numberOfDatapoints = this.model.getDisplayData().length;
 		const mainXScale = this.services.cartesianScales.getMainXScale();
 		const chartWidth = DOMUtils.getSVGElementSize(this.parent, {
 			useAttrs: true,
@@ -19,7 +19,7 @@ export class Bar extends Component {
 		if (!mainXScale.step) {
 			return Math.min(
 				options.bars.maxWidth,
-				(chartWidth * 0.25) / numberOfDomainValues
+				(chartWidth * 0.25) / numberOfDatapoints
 			);
 		}
 

--- a/packages/core/src/model/model.ts
+++ b/packages/core/src/model/model.ts
@@ -299,7 +299,9 @@ export class ChartModel {
 		}));
 	}
 
-	getStackKeys({ bins = null, groups = null }) {
+	getStackKeys(
+		{ bins = null, groups = null } = { bins: null, groups: null }
+	) {
 		const options = this.getOptions();
 
 		const displayData = this.getDisplayData(groups);


### PR DESCRIPTION
This fixes the #1232 issue:

The solution is to override the default method for getting width of the bar width for the  `StackedBar` :
https://github.com/carbon-design-system/carbon-charts/blob/b11873b24c3ca19ef07381b1647be70be33b4baf/packages/core/src/components/graphs/bar.ts#L7-L27

with the analogous method which uses `this.model.getStackKeys().length;` as the count of data points on domain we divide in line 22 of default method: https://github.com/carbon-design-system/carbon-charts/blob/b11873b24c3ca19ef07381b1647be70be33b4baf/packages/core/src/components/graphs/bar.ts#L22
instead of using `this.model.getDisplayData().length;` which just gets length of whole visible data, thus for charts with many series, the greater the number of series is, the thinner the bars are.


### Demo screenshot or recording
before fix:
<img width="1154" alt="obraz" src="https://user-images.githubusercontent.com/92912677/144468123-baa04f82-10c5-4e13-8337-5fe557f26185.png">

after fix:
<img width="1154" alt="obraz" src="https://user-images.githubusercontent.com/92912677/144468194-e00f14ce-f385-41a3-8ee3-d914c0824d52.png">

for the single serie chart we see lack of difference:

before fix:
<img width="1154" alt="obraz" src="https://user-images.githubusercontent.com/92912677/144469249-cc51d9ff-ffbe-4c0b-86c5-79d8f40bea97.png">

after fix:
<img width="1154" alt="obraz" src="https://user-images.githubusercontent.com/92912677/144469349-b4023521-fe3e-4176-aab5-78a4ad1e3b6d.png">


### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
