### PR TITLE
fix(core): display respective combochart tooltips range label

### DIFF
--- a/packages/core/src/components/essentials/tooltip-axis.ts
+++ b/packages/core/src/components/essentials/tooltip-axis.ts
@@ -18,17 +18,26 @@ export class AxisChartsTooltip extends Tooltip {
 		const options = this.getOptions();
 		const { cartesianScales } = this.services;
 		const domainIdentifier = cartesianScales.getDomainIdentifier();
+		const dualAxes = cartesianScales.isDualAxes();
 
 		// Generate default tooltip
 		const { groupMapsTo } = options.data;
 		const domainLabel = cartesianScales.getDomainLabel();
-		const rangeLabel = cartesianScales.getRangeLabel();
+		let rangeLabel = cartesianScales.getRangeLabel();
 
 		let domainValue = data[0][domainIdentifier];
 		let items: any[];
 		if (data.length === 1) {
 			const datum = data[0];
 			const rangeIdentifier = cartesianScales.getRangeIdentifier(datum);
+
+			if (dualAxes) {
+				const position = cartesianScales.getRangeAxisPosition({
+					datum,
+					groups: [datum[groupMapsTo]],
+				});
+				rangeLabel = cartesianScales.getScaleLabel(position);
+			}
 			const value = datum[rangeIdentifier];
 
 			items = [
@@ -95,7 +104,6 @@ export class AxisChartsTooltip extends Tooltip {
 					.sort((a, b) => b.value - a.value)
 			);
 
-			const dualAxes = cartesianScales.isDualAxes();
 			if (
 				!dualAxes &&
 				Tools.getProperty(options, 'tooltip', 'showTotal') === true


### PR DESCRIPTION
### Updates
- All charts with dual axes & combo charts were displaying incorrect range label on secondary axes data set
- Check to see what type of chart it is (dual axes or not) and determine the correct range label.

fix #1085 

### Demo screenshot or recording
<img width="313" alt="image" src="https://user-images.githubusercontent.com/38994122/144865544-d906f5ec-373e-4e75-b89e-5b1dd67856d7.png">

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
