### PR TITLE
fix(core): fix overflow menu caused by data loading option change

### DIFF
--- a/packages/core/src/components/axes/toolbar.ts
+++ b/packages/core/src/components/axes/toolbar.ts
@@ -51,6 +51,9 @@ export class Toolbar extends Component {
 
 		if (isDataLoading) {
 			container.html('');
+			// Set overflow menu to null if data is loading
+			// This will render in a new overflow menu when data is done loading
+			this.overflowMenu = null;
 		} else {
 			if (!this.overflowMenu) {
 				this.overflowMenu = container
@@ -190,6 +193,9 @@ export class Toolbar extends Component {
 
 	// show/hide overflow menu
 	updateOverflowMenu(show: boolean) {
+		if (!this.overflowMenu) {
+			return;
+		}
 		this.overflowMenu.classed('is-open', show);
 
 		// update overflow button background


### PR DESCRIPTION
fix #1229

### Updates
- When data is loading, we set the overflow menu to null since the DOM Element no longer exists
  - This will force a re render of the overflow menu and it's list

### Demo screenshot or recording
https://user-images.githubusercontent.com/38994122/145088761-b53e65c4-3121-4ffa-9a16-8543b9015eee.mov



### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
