### PR TITLE
fix(core): use domain in zoom bar if defined in axes

### DIFF
--- a/packages/core/src/services/zoom.ts
+++ b/packages/core/src/services/zoom.ts
@@ -67,11 +67,21 @@ export class Zoom extends Service {
 		const mainXAxisPosition = cartesianScales.getMainXAxisPosition();
 		const domainIdentifier = cartesianScales.getDomainIdentifier();
 
-		// default to full range with extended domain
-		return cartesianScales.extendsDomain(
+		const customDomain = Tools.getProperty(
+			this.model.getOptions(),
+			'axes',
 			mainXAxisPosition,
-			extent(allZoomBarData, (d: any) => d[domainIdentifier])
+			'domain'
 		);
+
+		// Return custom domain if defined
+		// default to full range with extended domain
+		return customDomain
+			? customDomain
+			: cartesianScales.extendsDomain(
+					mainXAxisPosition,
+					extent(allZoomBarData, (d: any) => d[domainIdentifier])
+			  );
 	}
 
 	handleDomainChange(newDomain, configs = { dispatchEvent: true }) {

--- a/packages/core/src/services/zoom.ts
+++ b/packages/core/src/services/zoom.ts
@@ -74,14 +74,16 @@ export class Zoom extends Service {
 			'domain'
 		);
 
-		// Return custom domain if defined
+		// return custom domain if exists && valid
+		if (Array.isArray(customDomain) && customDomain.length === 2) {
+			return customDomain;
+		}
+
 		// default to full range with extended domain
-		return customDomain
-			? customDomain
-			: cartesianScales.extendsDomain(
-					mainXAxisPosition,
-					extent(allZoomBarData, (d: any) => d[domainIdentifier])
-			  );
+		return cartesianScales.extendsDomain(
+			mainXAxisPosition,
+			extent(allZoomBarData, (d: any) => d[domainIdentifier])
+		);
 	}
 
 	handleDomainChange(newDomain, configs = { dispatchEvent: true }) {


### PR DESCRIPTION
### Updates
- Set zoom bar domain to the initial domain defined in axes
- User can use initialDomain in zoom bar options to zoom in into min/max value. T
  - User must calculate extent

fix #1228 

### Demo screenshot or recording
<img width="768" alt="image" src="https://user-images.githubusercontent.com/38994122/145836648-72f157aa-c04d-4aa6-86fa-92ddcde1909a.png">


### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
