### PR TITLE
fix(core): keep radar chart alignment after fullscreen exit

### DIFF
--- a/packages/core/src/components/graphs/radar.ts
+++ b/packages/core/src/components/graphs/radar.ts
@@ -444,6 +444,22 @@ export class Radar extends Component {
 									c
 								).y
 						)
+						.end()
+						.finally(() => {
+							// Align chart horizontally after x-axies has finished rendering
+							const alignment = Tools.getProperty(
+								options,
+								'radar',
+								'alignment'
+							);
+
+							const alignmentXOffset = this.getAlignmentXOffset(
+								alignment,
+								svg,
+								this.getParent()
+							);
+							svg.attr('x', alignmentXOffset);
+						})
 				),
 			(exit) =>
 				exit.call((selection) =>
@@ -748,15 +764,6 @@ export class Radar extends Component {
 						.remove()
 				)
 		);
-
-		const alignment = Tools.getProperty(options, 'radar', 'alignment');
-
-		const alignmentXOffset = this.getAlignmentXOffset(
-			alignment,
-			svg,
-			this.getParent()
-		);
-		svg.attr('x', alignmentXOffset);
 
 		// Add event listeners
 		this.addEventListeners();


### PR DESCRIPTION
### Updates
- Align the chart after the transitions are complete, previously alignment was triggered async which caused it to be misaligned after fullscreen exit

fix #1247

### Demo screenshot or recording

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
