### PR TITLE
feat: boolean option for turn on and off rect fill color

### DIFF
--- a/packages/core/demo/data/area.ts
+++ b/packages/core/demo/data/area.ts
@@ -138,6 +138,7 @@ export const sparklineOptions = {
 		y: {
 			enabled: false,
 		},
+		hasFillColor: false,
 	},
 	axes: {
 		bottom: {

--- a/packages/core/src/components/axes/grid.ts
+++ b/packages/core/src/components/axes/grid.ts
@@ -29,8 +29,16 @@ export class Grid extends Component {
 			'enabled'
 		);
 
+		const hasFillColor = Tools.getProperty(
+			this.getOptions(),
+			'grid',
+			'hasFillColor'
+		);
+
+		console.log('!!! hasfillColor: ', hasFillColor);
+
 		// Draw the backdrop
-		this.drawBackdrop(isXGridEnabled, isYGridEnabled);
+		this.drawBackdrop(isXGridEnabled, isYGridEnabled, hasFillColor);
 
 		if (!isXGridEnabled && !isYGridEnabled) {
 			return;
@@ -272,7 +280,7 @@ export class Grid extends Component {
 		return xGridlines;
 	}
 
-	drawBackdrop(isXGridEnabled, isYGridEnabled) {
+	drawBackdrop(isXGridEnabled, isYGridEnabled, hasFillColor) {
 		const svg = this.parent;
 
 		const mainXScale = this.services.cartesianScales.getMainXScale();
@@ -287,7 +295,7 @@ export class Grid extends Component {
 			this.backdrop,
 			isXGridEnabled || isYGridEnabled
 				? 'rect.chart-grid-backdrop.stroked'
-				: 'rect.chart-grid-backdrop'
+				: hasFillColor? 'rect.chart-grid-backdrop' : 'rect.chart-grid-backdrop.noFillColor'
 		);
 
 		this.backdrop

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -93,6 +93,7 @@ export const grid: GridOptions = {
 		numberOfTicks: 5,
 		alignWithAxisTicks: false,
 	},
+	hasFillColor: true,
 };
 
 /**

--- a/packages/core/src/interfaces/components.ts
+++ b/packages/core/src/interfaces/components.ts
@@ -118,6 +118,10 @@ export interface GridOptions {
 		numberOfTicks?: number;
 		alignWithAxisTicks?: boolean;
 	};
+	/**
+	 * has rect fill color or not
+	 */
+	hasFillColor?: boolean;
 }
 
 /**

--- a/packages/core/src/styles/components/_grid.scss
+++ b/packages/core/src/styles/components/_grid.scss
@@ -8,6 +8,9 @@
 			fill: $ui-background;
 		}
 	}
+	rect.chart-grid-backdrop.noFillColor {
+		fill: none !important;
+	}
 	rect.chart-grid-backdrop.stroked {
 		stroke: $ui-03;
 	}


### PR DESCRIPTION
### Updates
- Provide an boolean option within grid for user to turn on and off the rect fill color

### Demo screenshot or recording
<img width="732" alt="image" src="https://user-images.githubusercontent.com/23396970/146899961-01b23375-6fc9-43c3-820e-55a8ef638d23.png">


### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
