### PR TITLE
fix(core): remove circular dependencies inheritance from heatmap legend & canvas zoom files

### DIFF
--- a/packages/core/src/components/essentials/color-scale-legend.ts
+++ b/packages/core/src/components/essentials/color-scale-legend.ts
@@ -1,8 +1,8 @@
 // Internal Imports
 import { Tools } from '../../tools';
-import { ColorLegendType, Events, RenderTypes, Roles } from '../../interfaces';
+import { ColorLegendType, Events, RenderTypes } from '../../interfaces';
 import * as Configuration from '../../configuration';
-import { Legend } from '../';
+import { Legend } from './legend';
 import { DOMUtils } from '../../services';
 
 // D3 imports

--- a/packages/core/src/services/canvas-zoom.ts
+++ b/packages/core/src/services/canvas-zoom.ts
@@ -1,10 +1,9 @@
 // Internal Imports
 import { Service } from './service';
-import { Tools } from '../tools';
 import { Events } from './../interfaces/enums';
 import * as Configuration from '../configuration';
 // Services
-import { DOMUtils } from './index';
+import { DOMUtils } from './essentials/dom-utils';
 import { select } from 'd3-selection';
 
 export class CanvasZoom extends Service {


### PR DESCRIPTION
### Updates
- Remove circular imports from color scale legend and canvas zoom files
- Remove unused imports

### Demo screenshot or recording


### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
