### PR TITLE
fix(core): prevent canvas zooming if depth equals 2 and canvas zoom property is set to false

### DIFF
--- a/packages/core/src/components/graphs/circle-pack.ts
+++ b/packages/core/src/components/graphs/circle-pack.ts
@@ -404,14 +404,13 @@ export class CirclePack extends Component {
 				const hoveredElement = select(this);
 				const disabled = hoveredElement.classed('non-focal');
 
-				const zoomedIn =
-					Tools.getProperty(
-						self.getOptions(),
-						'canvasZoom',
-						'enabled'
-					) && self.model.getHierarchyLevel() > 2;
+				const canvasZoomEnabled = Tools.getProperty(
+					self.model.getOptions(),
+					'canvasZoom',
+					'enabled'
+				);
 
-				if (zoomedIn) {
+				if (canvasZoomEnabled && self.model.getHierarchyLevel() > 2) {
 					const canvasSelection = self.parent.selectAll(
 						'circle.node'
 					);
@@ -427,7 +426,12 @@ export class CirclePack extends Component {
 					);
 				}
 				// zoom if chart has zoom enabled and if its a depth 2 circle that has children
-				else if (datum.depth === 2 && datum.children && !disabled) {
+				else if (
+					datum.depth === 2 &&
+					datum.children &&
+					!disabled &&
+					canvasZoomEnabled
+				) {
 					const canvasSelection = self.parent.selectAll(
 						'circle.node'
 					);


### PR DESCRIPTION
### Updates
- Prevent canvas zoom on click completely if property is set to false

fix #1251

### Demo screenshot or recording
N/A no longer allows zooming when depth is 2 and canvas zoom property is set to false.

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
