### PR TITLE
docs(svelte): enable inlineDynamicImports in Rollup example

### DIFF
--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -113,8 +113,10 @@ No additional configuration should be necessary.
 
 ### Rollup
 
-If you encounter the error message `ReferenceError: process is not defined`,
-install
+Enable `inlineDynamicImports` in your `rollup.config.js` to avoid the
+`this has been rewritten to undefined` error message.
+
+If you encounter `ReferenceError: process is not defined`, install
 [@rollup/plugin-replace](https://github.com/rollup/plugins/tree/master/packages/replace)
 and add it to `plugins` in `rollup.config.js`.
 
@@ -124,6 +126,7 @@ import replace from '@rollup/plugin-replace';
 
 export default {
 	// ...
+	inlineDynamicImports: true,
 	plugins: [
 		replace({
 			preventAssignment: true,


### PR DESCRIPTION
This PR updates the Rollup example for `@carbon/charts-svelte`.

A [user encountered the `this has been rewritten to undefined`](https://github.com/carbon-design-system/carbon-components-svelte/issues/987) error; the solution is to enable `inlineDynamicImports`.

The [Rollup example here](https://github.com/metonym/carbon-charts-svelte-examples/tree/d9ef417cc16557b1c07499aa1775fcb114193e4f/rollup) has the setting enabled but this was missed in these docs.

### Updates

- docs(svelte): enable `inlineDynamicImports` in Rollup example

### Demo screenshot or recording

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
