### PR TITLE
fix(core): prevent chart from breaking if thresholds array is empty 

### DIFF
--- a/packages/core/src/components/graphs/bar-stacked.ts
+++ b/packages/core/src/components/graphs/bar-stacked.ts
@@ -10,7 +10,6 @@ import {
 } from '../../interfaces';
 import { DOMUtils } from '../../services';
 
-
 // D3 Imports
 import { select } from 'd3-selection';
 
@@ -296,16 +295,16 @@ export class StackedBar extends Bar {
 
 	protected getBarWidth() {
 		const options = this.getOptions();
-		if (Tools.getProperty(options, "bars", "width")) {
+		if (Tools.getProperty(options, 'bars', 'width')) {
 			return options.bars.width;
 		}
 		const mainXScale = this.services.cartesianScales.getMainXScale();
 		const chartWidth = DOMUtils.getSVGElementSize(this.parent, {
 			useAttrs: true,
 		}).width;
-	
+
 		const numberOfDomainValues = this.model.getStackKeys().length;
-	
+
 		if (!mainXScale.step) {
 			return Math.min(
 				options.bars.maxWidth,
@@ -314,7 +313,7 @@ export class StackedBar extends Bar {
 		}
 		return Math.min(options.bars.maxWidth, mainXScale.step() / 2);
 	}
-	
+
 	destroy() {
 		// Remove event listeners
 		this.parent

--- a/packages/core/src/services/scales-cartesian.ts
+++ b/packages/core/src/services/scales-cartesian.ts
@@ -754,7 +754,11 @@ export class CartesianScales extends Service {
 
 		const { thresholds } = axesOptions[domainAxisPosition];
 
-		if (!thresholds) {
+		// Check if thresholds exist & is not empty
+		if (
+			!Array.isArray(thresholds) ||
+			(Array.isArray(thresholds) && !thresholds.length)
+		) {
 			return null;
 		}
 
@@ -788,7 +792,11 @@ export class CartesianScales extends Service {
 
 		const { thresholds } = axesOptions[rangeAxisPosition];
 
-		if (!thresholds) {
+		// Check if thresholds exist & is not empty
+		if (
+			!Array.isArray(thresholds) ||
+			(Array.isArray(thresholds) && !thresholds.length)
+		) {
 			return null;
 		}
 

--- a/packages/core/src/styles/_chart-holder.scss
+++ b/packages/core/src/styles/_chart-holder.scss
@@ -4,7 +4,8 @@
 	width: 100%;
 	height: 100%;
 
-	&.filled, &.fullscreen {
+	&.filled,
+	&.fullscreen {
 		background-color: $ui-background;
 
 		.#{$prefix}--#{$charts-prefix}--chart-wrapper {

--- a/packages/core/src/styles/components/_skeleton.scss
+++ b/packages/core/src/styles/components/_skeleton.scss
@@ -38,7 +38,6 @@ $areas-shimmer-color: rgba($carbon--white-0, 0.15);
 		}
 	}
 
-
 	.empty-state-areas {
 		fill: $areas-bg-color;
 	}


### PR DESCRIPTION
### Updates
- Checks to see if thresholds is an array and an additional check to see if it is empty
  - Prevents chart from crashing
- Formats (other) files

fix #1264 

### Demo screenshot or recording
N/A - any cartesian chart with thresholds set to empty array:
```json
options: {
axes: {
  left: { thresholds: [] }
}
}
```

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
