### PR TITLE
fix(core): render only the components that are being used in proportional meter

### DIFF
--- a/packages/core/src/charts/meter.ts
+++ b/packages/core/src/charts/meter.ts
@@ -49,39 +49,61 @@ export class MeterChart extends Chart {
 	}
 
 	getComponents() {
-		// Specify what to render inside the graph only
-		const graph = {
-			id: 'meter-graph',
-			components: [new Meter(this.model, this.services)],
-			growth: LayoutGrowth.STRETCH,
-			renderType: RenderTypes.SVG,
-		};
+		const options = this.model.getOptions();
+		const meterComponents = [
+			// Meter has a unique dataset title within the graph
+			{
+				id: 'meter-title',
+				components: [new MeterTitle(this.model, this.services)],
+				growth: LayoutGrowth.STRETCH,
+				renderType: RenderTypes.SVG,
+			},
+			// Create the title spacer
+			{
+				id: 'spacer',
+				components: [
+					new Spacer(this.model, this.services, { size: 8 }),
+				],
+				growth: LayoutGrowth.STRETCH,
+			},
+			// Specify what to render inside the graph only
+			{
+				id: 'meter-graph',
+				components: [new Meter(this.model, this.services)],
+				growth: LayoutGrowth.STRETCH,
+				renderType: RenderTypes.SVG,
+			},
+		];
 
-		// Meter has an unique dataset title within the graph
-		const titleComponent = {
-			id: 'meter-title',
-			components: [new MeterTitle(this.model, this.services)],
-			growth: LayoutGrowth.STRETCH,
-			renderType: RenderTypes.SVG,
-		};
+		//breakdownFormatter
+		const breakdownFormatter = Tools.getProperty(
+			options,
+			'meter',
+			'proportional',
+			'breakdownFormatter'
+		);
 
-		// create the title spacer
-		const titleSpacerComponent = {
-			id: 'spacer',
-			components: [new Spacer(this.model, this.services, { size: 8 })],
-			growth: LayoutGrowth.STRETCH,
-		};
+		// totalFormatter function
+		const totalFormatter = Tools.getProperty(
+			options,
+			'meter',
+			'proportional',
+			'totalFormatter'
+		);
+
+		// Check to see if the formatter functions exist
+		if (!!breakdownFormatter && !!totalFormatter) {
+			// Check if both formatters return null or empty string, do not render them
+			if (!breakdownFormatter(null) && !totalFormatter(null)) {
+				meterComponents.splice(0, 2);
+			}
+		}
 
 		// the graph frame for meter includes the custom title (and spacer)
 		const graphFrame = [
-			new LayoutComponent(
-				this.model,
-				this.services,
-				[titleComponent, titleSpacerComponent, graph],
-				{
-					direction: LayoutDirection.COLUMN,
-				}
-			),
+			new LayoutComponent(this.model, this.services, meterComponents, {
+				direction: LayoutDirection.COLUMN,
+			}),
 		];
 
 		// add the meter title as a top level component


### PR DESCRIPTION
### Updates
- Add condition to render only the components that are used in proportional meter

**Might be considered a breaking change for the users using formatters?**

fix #1262

### Demo screenshot or recording
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/38994122/149838161-801e5e18-1d4b-4ca0-8f51-97307a4c5881.png">

*Can not be tested in storybook since we are working with functions here. You can see in the image above we are not rendering the total,breakdown or the spacer since they are not being used.

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
