### PR TITLE
fix(core): position bounds correctly in secondary axis of combo chart

### DIFF
--- a/packages/core/src/services/scales-cartesian.ts
+++ b/packages/core/src/services/scales-cartesian.ts
@@ -336,11 +336,12 @@ export class CartesianScales extends Service {
 
 	getBoundedScaledValues(datum: any, index?: number) {
 		const { bounds } = this.model.getOptions();
-		const scale = this.scales[this.rangeAxisPosition];
+		const axisPosition = this.getRangeAxisPosition({ datum });
+		const scale = this.scales[axisPosition];
 
 		const options = this.model.getOptions();
 		const axesOptions = Tools.getProperty(options, 'axes');
-		const axisOptions = axesOptions[this.rangeAxisPosition];
+		const axisOptions = axesOptions[axisPosition];
 		const { mapsTo } = axisOptions;
 		const value = datum[mapsTo] !== undefined ? datum[mapsTo] : datum;
 


### PR DESCRIPTION
### Updates
- Axis position is retrieved by passing in the datum to ensure the coordinates match axis

fix #1253

### Demo screenshot or recording
![image](https://user-images.githubusercontent.com/38994122/151049290-d6b75739-a080-4cec-a8b7-9dde3e88a4c2.png)


### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
