### PR TITLE
fix(radar): only show active datapoints in tooltips

### DIFF
--- a/packages/core/src/components/graphs/radar.ts
+++ b/packages/core/src/components/graphs/radar.ts
@@ -925,18 +925,7 @@ export class Radar extends Component {
 					`.dots circle.${Tools.kebabCase(datum)}`
 				);
 
-				// Change style
-				axisLine
-					.classed('hovered', true)
-					.attr('stroke-dasharray', '4 4');
-				dots.classed('hovered', true)
-					.attr('opacity', 1)
-					.attr('r', Configuration.radar.dotsRadius);
-
-				// get the items that should be highlighted
-				const itemsToHighlight = self.fullDataNormalized.filter(
-					(d) => d[angle] === datum
-				);
+				const activeDataGroupNames = self.model.getActiveDataGroupNames();
 
 				const options = self.getOptions();
 				const { groupMapsTo } = options.data;
@@ -945,6 +934,20 @@ export class Radar extends Component {
 					'radar',
 					'axes',
 					'value'
+				);
+
+				// Change style
+				axisLine
+					.classed('hovered', true)
+					.attr('stroke-dasharray', '4 4');
+				dots.classed('hovered', true)
+					.attr('opacity', d => activeDataGroupNames.indexOf(d[groupMapsTo]) !== -1 ? 1 : 0)
+					.attr('r', Configuration.radar.dotsRadius);
+
+
+				// get the items that should be highlighted
+				const itemsToHighlight = self.fullDataNormalized.filter(
+					(d) => d[angle] === datum && activeDataGroupNames.indexOf(d[groupMapsTo]) !== -1
 				);
 
 				// Show tooltip


### PR DESCRIPTION
Closes #1288

### Before
![image](https://user-images.githubusercontent.com/14989804/151421818-a46dfb0d-31e4-4342-9a7d-6b5bf4be02b3.png)

### After
![image](https://user-images.githubusercontent.com/14989804/151421934-97f145b3-906c-4428-b903-78c25bfef8a3.png)
