### PR TITLE
docs(core): add demo to change toolbar overflow menu control text for defined types

### DIFF
--- a/packages/core/demo/data/index.ts
+++ b/packages/core/demo/data/index.ts
@@ -307,6 +307,11 @@ const utilityDemoGroups = [
 				data: toolbarDemos.toolbarLineTimeSeriesData,
 				chartType: chartTypes.LineChart,
 			},
+			{
+				options: toolbarDemos.toolbarBarSimpleOptions,
+				data: toolbarDemos.toolbarBarSimpleData,
+				chartType: chartTypes.SimpleBarChart,
+			},
 		],
 	},
 	{

--- a/packages/core/demo/data/toolbar.ts
+++ b/packages/core/demo/data/toolbar.ts
@@ -78,3 +78,26 @@ export const toolbarLineTimeSeriesOptions = addToolbarOptions(
 		],
 	}
 );
+
+export const toolbarBarSimpleData = barChart.simpleBarData;
+export const toolbarBarSimpleOptions = addToolbarOptions(
+	Object.assign({}, barChart.simpleBarOptions),
+	{
+		titleSuffix: ' - overriding export titles',
+		numberOfIcons: 1,
+		controls: [
+			{
+				type: 'Export as CSV',
+				text: 'Export data as CSV',
+			},
+			{
+				type: 'Export as JPG',
+				text: 'Export chart in JPG',
+			},
+			{
+				type: 'Export as PNG',
+				text: 'Export chart in PNG',
+			},
+		],
+	}
+);


### PR DESCRIPTION
### Updates
- Added demo to show users how to overwrite the export titles (text).
- This method can also be used to change text during language changes in applications (Translations/localization)
  - Keep in mind, the library user is responsible for determining the language changes

### Demo screenshot or recording
![image](https://user-images.githubusercontent.com/38994122/152046053-6cc05d38-a360-45b9-9229-4279cba58b34.png)

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
