### PR TITLE
feat(core): add alignment option to alluvial 

### DIFF
--- a/packages/core/demo/data/alluvial.ts
+++ b/packages/core/demo/data/alluvial.ts
@@ -281,6 +281,30 @@ export const alluvialMultipleCategoryData = [
 	},
 ];
 
+export const alluvialNodeAlignmentData = [
+	{ source: 'A', target: 'X', value: 3 },
+	{ source: 'A', target: 'Y', value: 7 },
+	{ source: 'B', target: 'X', value: 8 },
+	{ source: 'B', target: 'Y', value: 3 },
+	{ source: 'C', target: 'X', value: 5 },
+	{ source: 'Y', target: 'Z', value: 13 },
+];
+
+export const alluvialNodeAlignmentOptions = {
+	title: 'Alluvial node alignment',
+	alluvial: {
+		nodes: [
+			{ name: 'A', category: 'Start' },
+			{ name: 'B', category: 'Start' },
+			{ name: 'C', category: 'Start' },
+			{ name: 'X', category: 'Middle' },
+			{ name: 'Y', category: 'Middle' },
+			{ name: 'Z', category: 'Finish' },
+		],
+		nodeAlignment: 'left',
+	},
+};
+
 export const alluvialMonochromeData = [
 	{ source: 'A', target: 'X', value: 3 },
 	{ source: 'A', target: 'Y', value: 5 },

--- a/packages/core/demo/data/index.ts
+++ b/packages/core/demo/data/index.ts
@@ -1104,6 +1104,11 @@ const complexChartDemos = [
 				data: alluvialDemos.alluvialMonochromeData,
 				chartType: chartTypes.AlluvialChart,
 			},
+			{
+				options: alluvialDemos.alluvialNodeAlignmentOptions,
+				data: alluvialDemos.alluvialNodeAlignmentData,
+				chartType: chartTypes.AlluvialChart,
+			},
 		],
 	},
 	{

--- a/packages/core/src/components/graphs/alluvial.ts
+++ b/packages/core/src/components/graphs/alluvial.ts
@@ -3,11 +3,22 @@ import { Component } from '../component';
 import { DOMUtils } from '../../services';
 import { Tools } from '../../tools';
 import * as Configuration from '../../configuration';
-import { Events, ColorClassNameTypes, RenderTypes } from '../../interfaces';
+import {
+	Events,
+	ColorClassNameTypes,
+	RenderTypes,
+	Alignments,
+} from '../../interfaces';
 
 // D3 imports
 import { select } from 'd3-selection';
-import { sankey as d3Sankey, sankeyLinkHorizontal } from 'd3-sankey';
+import {
+	sankey as d3Sankey,
+	sankeyLinkHorizontal,
+	sankeyLeft,
+	sankeyRight,
+	sankeyJustify,
+} from 'd3-sankey';
 
 export class Alluvial extends Component {
 	type = 'alluvial';
@@ -50,11 +61,27 @@ export class Alluvial extends Component {
 			nodePadding = options.alluvial.nodePadding;
 		}
 
+		const alignment = Tools.getProperty(
+			options,
+			'alluvial',
+			'nodeAlignment'
+		);
+
+		let nodeAlignment = sankeyJustify;
+
+		if (alignment === Alignments.LEFT) {
+			nodeAlignment = sankeyLeft;
+		} else if (alignment === Alignments.RIGHT) {
+			nodeAlignment = sankeyRight;
+		}
+
 		const sankey = d3Sankey()
 			.nodeId((d) => d.name)
 			.nodeWidth(Configuration.alluvial.nodeWidth)
 			// Distance nodes are apart from each other
 			.nodePadding(nodePadding)
+			// Alignment of nodes within chart
+			.nodeAlign(nodeAlignment)
 			// Size of the chart and its padding
 			// Chart starts at 2 and ends at width - 2 so the outer nodes can expand from center
 			// Chart starts from 30 so node categories can be displayed

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -243,7 +243,7 @@ const axisChart: AxisChartOptions = Tools.merge({}, chart, {
 const baseBarChart: BarChartOptions = Tools.merge({}, axisChart, {
 	bars: {
 		maxWidth: 16,
-		spacingFactor: 0.25
+		spacingFactor: 0.25,
 	},
 	timeScale: Tools.merge(timeScale, {
 		addSpaceOnEdges: 1,
@@ -588,6 +588,7 @@ const alluvialChart: AlluvialChartOptions = Tools.merge({}, chart, {
 		data: Tools.merge(chart.data, {
 			groupMapsTo: 'source',
 		}),
+		nodeAlignment: Alignments.CENTER,
 		nodePadding: 24,
 		monochrome: false,
 		nodes: [],

--- a/packages/core/src/interfaces/charts.ts
+++ b/packages/core/src/interfaces/charts.ts
@@ -511,6 +511,10 @@ export interface AlluvialChartOptions extends BaseChartOptions {
 			category?: string;
 		}>;
 		/**
+		 * Node alignment (Default is center)
+		 */
+		nodeAlignment?: Alignments;
+		/**
 		 * Set the node padding
 		 */
 		nodePadding?: number;


### PR DESCRIPTION
### Updates
- Add alluvial alignment options (Left, Right, Justify)
  - Default is 'Justify' (Center)
- Added demo

### Demo screenshot or recording
**Before**:
![image](https://user-images.githubusercontent.com/38994122/153117593-85369bf7-4974-4607-b49e-cbc10712759c.png)
*Using default alignment - center (justify)

**After**:
![image](https://user-images.githubusercontent.com/38994122/153117454-f88abe94-4316-4c7f-9942-1edfee82f12d.png)
*Using alignment left

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
