### PR TITLE
fix(core): enable heatmap value domain to support small values

### DIFF
--- a/packages/core/demo/data/heatmap.ts
+++ b/packages/core/demo/data/heatmap.ts
@@ -641,6 +641,22 @@ export const heatmapQuantizeLegendOption = {
 	experimental: true,
 };
 
+export const heatmapPositiveNegativeOptions = Object.assign(
+	{},
+	heatmapOptions,
+	{
+		title: 'Heatmap (Divergent)',
+		heatmap: {
+			colorLegend: { title: 'Legend title', type: 'quantize' },
+		},
+	}
+);
+
+export const heatmapPositiveNegativeData = heatmapData.map((element) => ({
+	...element,
+	value: (element.value / 10) * (Math.round(Math.random()) ? -1 : 1),
+}));
+
 export const heatmapDomainOptions = {
 	title: 'Heatmap (Axis order option)',
 	axes: {

--- a/packages/core/demo/data/index.ts
+++ b/packages/core/demo/data/index.ts
@@ -1154,6 +1154,11 @@ const complexChartDemos = [
 				chartType: chartTypes.HeatmapChart,
 			},
 			{
+				options: heatmapDemos.heatmapPositiveNegativeOptions,
+				data: heatmapDemos.heatmapPositiveNegativeData,
+				chartType: chartTypes.HeatmapChart,
+			},
+			{
 				options: heatmapDemos.heatmapMissingDataOptions,
 				data: heatmapDemos.heatmapMissingData,
 				chartType: chartTypes.HeatmapChart,

--- a/packages/core/src/components/essentials/color-scale-legend.ts
+++ b/packages/core/src/components/essentials/color-scale-legend.ts
@@ -8,7 +8,7 @@ import { DOMUtils } from '../../services';
 // D3 imports
 import { axisBottom } from 'd3-axis';
 import { scaleBand, scaleLinear } from 'd3-scale';
-import { interpolateRound, quantize } from 'd3-interpolate';
+import { interpolateNumber, quantize } from 'd3-interpolate';
 
 export class ColorScaleLegend extends Legend {
 	type = 'color-legend';
@@ -23,11 +23,12 @@ export class ColorScaleLegend extends Legend {
 		// Highlight correct circle on legend item hovers
 		eventsFragment.addEventListener(
 			Events.Axis.RENDER_COMPLETE,
-			this.handleAxisComplete
+			this.handleAxisCompleteEvent
 		);
 	}
 
-	handleAxisComplete = (event: CustomEvent) => {
+	// Position legend after axis have rendered
+	handleAxisCompleteEvent = (event: CustomEvent) => {
 		const svg = this.getComponentContainer();
 
 		const { width } = DOMUtils.getSVGElementSize(svg, {
@@ -49,9 +50,9 @@ export class ColorScaleLegend extends Legend {
 			);
 
 			const { cartesianScales } = this.services;
-			// Get available chart area
-			const mainXScale = cartesianScales.getMainXScale();
 
+			// Get axis width & start/end positions
+			const mainXScale = cartesianScales.getMainXScale();
 			const xDimensions = mainXScale.range();
 
 			// Align legend with the axis
@@ -69,10 +70,10 @@ export class ColorScaleLegend extends Legend {
 						{ useBBox: true }
 					);
 
-					// -9 since LEFT y-axis labels are moved towards the left by 9 by d3
+					// D3 moves the LEFT y-axis labels by 9
 					const availableSpace = xDimensions[0] - textWidth - 9;
 
-					// If space is available align the the label with the axis labels
+					// If space is available, align the label with the axis labels
 					if (availableSpace > 1) {
 						svg.select('g.legend-title').attr(
 							'transform',
@@ -93,11 +94,18 @@ export class ColorScaleLegend extends Legend {
 					}
 				}
 			}
+		} else {
+			// Default state
+			svg.select('g.legend-title').attr('transform', `translate(0, 0)`);
 		}
 	};
 
 	render(animate = false) {
 		const options = this.getOptions();
+		const svg = this.getComponentContainer();
+		const { width } = DOMUtils.getSVGElementSize(svg, {
+			useAttrs: true,
+		});
 
 		const customColors = Tools.getProperty(
 			options,
@@ -127,11 +135,6 @@ export class ColorScaleLegend extends Legend {
 			'title'
 		);
 
-		const customColorsEnabled = !Tools.isEmpty(customColors);
-		const domain = this.model.getValueDomain();
-
-		const svg = this.getComponentContainer();
-
 		// Clear DOM if loading
 		const isDataLoading = Tools.getProperty(
 			this.getOptions(),
@@ -144,18 +147,23 @@ export class ColorScaleLegend extends Legend {
 			return;
 		}
 
-		const legend = DOMUtils.appendOrSelect(svg, 'g.legend');
-		const axis = DOMUtils.appendOrSelect(legend, 'g.legend-axis');
+		const customColorsEnabled = !Tools.isEmpty(customColors);
+		const domain = this.model.getValueDomain();
 
-		const { width } = DOMUtils.getSVGElementSize(svg, {
-			useAttrs: true,
-		});
+		const useDefaultBarWidth = !(
+			width <= Configuration.legend.color.barWidth
+		);
+		const barWidth = useDefaultBarWidth
+			? Configuration.legend.color.barWidth
+			: width;
 
-		let barWidth = Configuration.legend.color.barWidth;
-		if (width <= Configuration.legend.color.barWidth) {
-			barWidth = width;
-		}
+		const legendGroupElement = DOMUtils.appendOrSelect(svg, 'g.legend');
+		const axisElement = DOMUtils.appendOrSelect(
+			legendGroupElement,
+			'g.legend-axis'
+		);
 
+		// Render title if it exists
 		if (title) {
 			const legendTitleGroup = DOMUtils.appendOrSelect(
 				svg,
@@ -168,7 +176,7 @@ export class ColorScaleLegend extends Legend {
 			legendTitle.text(title).attr('dy', '0.7em');
 
 			// Move the legend down by 16 pixels to display legend text on top
-			legend.attr('transform', `translate(0, 16)`);
+			legendGroupElement.attr('transform', `translate(0, 16)`);
 		}
 
 		// If domain consists of negative and positive values, use diverging palettes
@@ -207,140 +215,125 @@ export class ColorScaleLegend extends Legend {
 			colorPairing = customColors;
 		}
 
-		if (colorScaleType === ColorLegendType.LINEAR) {
-			const stopLengthPercentage = 100 / (colorPairing.length - 1);
+		// Generate equal chunks between range to act as ticks
+		const interpolator = interpolateNumber(domain[0], domain[1]);
+		const quant = quantize(interpolator, 3);
 
-			// Generate the gradient
-			const linearGradient = DOMUtils.appendOrSelect(
-				legend,
-				'linearGradient'
-			);
-			linearGradient
-				.attr('id', `${this.gradient_id}-legend`)
-				.selectAll('stop')
-				.data(colorPairing)
-				.enter()
-				.append('stop')
-				.attr('offset', (_, i) => `${i * stopLengthPercentage}%`)
-				.attr('class', (_, i) => colorPairing[i])
-				.attr('stop-color', (d) => d);
+		// Create scale & ticks
+		const linearScale = scaleLinear().domain(domain).range([0, barWidth]);
 
-			// Create the legend container
-			const rectangle = DOMUtils.appendOrSelect(legend, 'rect');
-			rectangle
-				.attr('width', barWidth)
-				.attr('height', Configuration.legend.color.barHeight)
-				.style('fill', `url(#${this.gradient_id}-legend)`);
+		const legendAxis = axisBottom(linearScale)
+			.tickSize(0)
+			.tickValues(quant);
 
-			// Create scale & ticks
-			const linearScale = scaleLinear()
-				.domain(domain)
-				.range([0, barWidth]);
-			domain.splice(1, 0, (domain[0] + domain[1]) / 2);
+		switch (colorScaleType) {
+			case ColorLegendType.LINEAR:
+				this.drawLinear(colorPairing, legendGroupElement, barWidth);
+				break;
+			case ColorLegendType.QUANTIZE:
+				const rangeStart = this.drawQuantize(
+					colorPairing,
+					colorScheme,
+					customColorsEnabled,
+					legendGroupElement,
+					barWidth
+				);
+				// Using range provided by drawQuantize for alignment purposes
+				linearScale.range([rangeStart, barWidth]);
+				break;
+			default:
+				throw Error('Entered color legend type is not supported.');
+		}
 
-			const xAxis = axisBottom(linearScale)
-				.tickSize(0)
-				.tickValues(domain);
-
-			// Align axes at the bottom of the rectangle and delete the domain line
-			axis.attr(
+		// Align axes at the bottom of the rectangle and delete the domain line
+		axisElement
+			.attr(
 				'transform',
 				`translate(0,${Configuration.legend.color.axisYTranslation})`
-			).call(xAxis);
+			)
+			.call(legendAxis);
 
-			// Remove domain
-			axis.select('.domain').remove();
+		// Remove auto generated axis bottom line
+		axisElement.select('.domain').remove();
 
-			// Align text to fit in container
-			axis.style('text-anchor', 'start');
-		} else if (colorScaleType === ColorLegendType.QUANTIZE) {
-			// Generate equal chunks between range to act as ticks
-			const interpolator = interpolateRound(domain[0], domain[1]);
-			const quant = quantize(interpolator, colorPairing.length);
+		// Translate first/last axis tick if barWidth equals chart width
+		// Ensures text is not clipped when default bar width (300px) is not used
+		axisElement
+			.select('g.tick:last-of-type text')
+			.style('text-anchor', useDefaultBarWidth ? 'middle' : 'end');
+		axisElement
+			.select('g.tick:first-of-type text')
+			.style('text-anchor', useDefaultBarWidth ? 'middle' : 'start');
+	}
 
-			// If divergent && non-custom color, remove 0/white from being displayed
-			if (!customColorsEnabled && colorScheme === 'diverge') {
-				colorPairing.splice(colorPairing.length / 2, 1);
-			}
+	// Renders gradient legend
+	drawLinear(colorPairing, legendGroupElement, barWidth) {
+		const stopLengthPercentage = 100 / (colorPairing.length - 1);
 
-			const colorScaleBand = scaleBand()
-				.domain(colorPairing)
-				.range([0, barWidth]);
+		// Generate the gradient
+		const linearGradient = DOMUtils.appendOrSelect(
+			legendGroupElement,
+			'linearGradient'
+		);
+		// Rendering gradient
+		linearGradient
+			.attr('id', `${this.gradient_id}-legend`)
+			.selectAll('stop')
+			.data(colorPairing)
+			.enter()
+			.append('stop')
+			.attr('offset', (_, i) => `${i * stopLengthPercentage}%`)
+			.attr('class', (_, i) => colorPairing[i])
+			.attr('stop-color', (d) => d);
 
-			// Render the quantized rectangles
-			const rectangle = DOMUtils.appendOrSelect(
-				legend,
-				'g.quantized-rect'
-			);
+		// Create the legend container
+		const rectangle = DOMUtils.appendOrSelect(legendGroupElement, 'rect');
+		rectangle
+			.attr('width', barWidth)
+			.attr('height', Configuration.legend.color.barHeight)
+			.style('fill', `url(#${this.gradient_id}-legend)`);
+	}
 
-			rectangle
-				.selectAll('rect')
-				.data(colorScaleBand.domain())
-				.join('rect')
-				.attr('x', (d) => colorScaleBand(d))
-				.attr('y', 0)
-				.attr('width', Math.max(0, colorScaleBand.bandwidth()) - 1)
-				.attr('height', Configuration.legend.color.barHeight)
-				.attr('class', (d) => d)
-				.attr('fill', (d) => d);
-
-			const xAxis = axisBottom(colorScaleBand)
-				.tickSize(0)
-				.tickValues(colorPairing)
-				.tickFormat((_, i) => {
-					// Display every other tick to create space
-					if (
-						!customColorsEnabled &&
-						((i + 1) % 2 === 0 || i === colorPairing.length - 1)
-					) {
-						return null;
-					}
-
-					// Use the quant interpolators as ticks
-					return quant[i].toString();
-				});
-
-			// Align axis to match bandwidth start after initial (white)
-			const axisTranslation = colorScaleBand.bandwidth() / 2;
-			axis.attr(
-				'transform',
-				`translate(${
-					!customColorsEnabled && colorScheme === 'diverge' ? '-' : ''
-				}${axisTranslation}, ${
-					Configuration.legend.color.axisYTranslation
-				})`
-			).call(xAxis);
-
-			// Append the last tick
-			const firstTick = axis.select('g.tick').clone(true);
-			firstTick
-				.attr(
-					'transform',
-					`translate(${
-						barWidth +
-						(!customColorsEnabled && colorScheme === 'diverge'
-							? axisTranslation
-							: -axisTranslation)
-					}, 0)`
-				)
-				.classed('final-tick', true)
-				.select('text')
-				.text(quant[quant.length - 1]);
-
-			axis.enter().append(firstTick.node());
-			axis.select('.domain').remove();
-		} else {
-			throw Error('Entered color legend type is not supported.');
+	/**
+	 * Renders quantized legend
+	 * @returns number (range start)
+	 */
+	drawQuantize(
+		colorPairing,
+		colorScheme,
+		customColorsEnabled,
+		legendGroupElement,
+		barWidth
+	) {
+		// If divergent && non-custom color, remove 0/white from being displayed
+		if (!customColorsEnabled && colorScheme === 'diverge') {
+			colorPairing.splice(colorPairing.length / 2, 1);
 		}
 
-		// Translate last axis tick if barWidth equals chart width
-		if (width <= Configuration.legend.color.barWidth) {
-			const lastTick = axis.select('g.tick:last-of-type text');
-			const { width } = DOMUtils.getSVGElementSize(lastTick, {
-				useBBox: true,
-			});
-			lastTick.attr('x', `-${width}`);
-		}
+		const colorScaleBand = scaleBand()
+			.domain(colorPairing)
+			.range([0, barWidth]);
+
+		// Render the quantized rectangles
+		const rectangle = DOMUtils.appendOrSelect(
+			legendGroupElement,
+			'g.quantized-rect'
+		);
+
+		rectangle
+			.selectAll('rect')
+			.data(colorScaleBand.domain())
+			.join('rect')
+			.attr('x', (d) => colorScaleBand(d))
+			.attr('y', 0)
+			.attr('width', Math.max(0, colorScaleBand.bandwidth() - 1))
+			.attr('height', Configuration.legend.color.barHeight)
+			.attr('class', (d) => d)
+			.attr('fill', (d) => d);
+
+		return (!customColorsEnabled && colorScheme) === 'mono'
+			? colorScaleBand.bandwidth() - 1
+			: 0;
 	}
 
 	destroy() {
@@ -348,7 +341,7 @@ export class ColorScaleLegend extends Legend {
 		const eventsFragment = this.services.events;
 		eventsFragment.removeEventListener(
 			Events.Axis.RENDER_COMPLETE,
-			this.handleAxisComplete
+			this.handleAxisCompleteEvent
 		);
 	}
 }


### PR DESCRIPTION
### Updates
- Heatmap domain now supports small values (No user change required)

### Demo screenshot or recording
![image](https://user-images.githubusercontent.com/38994122/157491912-bc31e15f-4cb3-4646-856b-17cda63d3b48.png)

fix #1321

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
