### PR TITLE
feat(core): Pass treemap tile data to `getFillColor`

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [Unreleased]
+
+### Added
+
+* **core:** pass treemap data to `getFillColor`
+
+
+
+
+
 # [0.56.0](https://github.com/carbon-design-system/carbon-charts/compare/v0.55.1...v0.56.0) (2022-03-28)
 
 

--- a/packages/core/src/components/graphs/treemap.ts
+++ b/packages/core/src/components/graphs/treemap.ts
@@ -167,8 +167,7 @@ export class Treemap extends Component {
 			.attr('width', (d) => d.x1 - d.x0)
 			.attr('height', (d) => d.y1 - d.y0)
 			.style('fill', (d) => {
-				while (d.depth > 1) d = d.parent;
-				return this.model.getFillColor(d.data.name, undefined, d);
+				return this.model.getFillColor(d.parent.data.name, undefined, d);
 			});
 
 		// Update all clip paths

--- a/packages/core/src/components/graphs/treemap.ts
+++ b/packages/core/src/components/graphs/treemap.ts
@@ -168,7 +168,7 @@ export class Treemap extends Component {
 			.attr('height', (d) => d.y1 - d.y0)
 			.style('fill', (d) => {
 				while (d.depth > 1) d = d.parent;
-				return this.model.getFillColor(d.data.name);
+				return this.model.getFillColor(d.data.name, undefined, d);
 			});
 
 		// Update all clip paths
@@ -220,7 +220,7 @@ export class Treemap extends Component {
 					let parent = d;
 					while (parent.depth > 1) parent = parent.parent;
 					const color = hsl(
-						this.model.getFillColor(parent.data.name)
+						this.model.getFillColor(parent.data.name, undefined, d)
 					);
 					return [
 						{
@@ -285,7 +285,9 @@ export class Treemap extends Component {
 					)
 					.style('fill', (d: any) => {
 						const customColor = self.model.getFillColor(
-							d.parent.data.name
+							d.parent.data.name,
+							undefined,
+							d
 						);
 						if (customColor) {
 							fillColor = customColor;
@@ -361,7 +363,11 @@ export class Treemap extends Component {
 						})
 					)
 					.style('fill', (d: any) =>
-						self.model.getFillColor(d.parent.data.name)
+						self.model.getFillColor(
+							d.parent.data.name,
+							undefined,
+							d
+						)
 					);
 
 				// Dispatch mouse event


### PR DESCRIPTION
### Updates
- passes tile data to the `getFillColor`-function for the treemap component (which is useful for creating [divergent tree maps](https://www.carbondesignsystem.com/data-visualization/complex-charts/))

If you like to try it out yourself you should make a build and try the code in the sandbox below:
https://codesandbox.io/s/carbon-treechart-getfillcolor-for-color-per-tile-fr4f10

### Demo screenshot or recording
_Value in console is the third argument that is passed to `getFillColor`_

https://user-images.githubusercontent.com/89210933/162160812-8ef48369-f1d0-4937-998e-e7ab95cafec7.mov

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
