### PR TITLE
docs(svelte): remove `kit.target` from SvelteKit set-up

### DIFF
--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -68,7 +68,6 @@ const production = process.env.NODE_ENV === 'production';
 const config = {
 	kit: {
 		adapter: adapter(),
-		target: '#svelte',
 		vite: {
 			optimizeDeps: {
 				include: ['@carbon/charts'],


### PR DESCRIPTION
This updates the documentation for the SvelteKit example.

The `kit.target` option was removed in [v1.0.0-next.257](https://github.com/sveltejs/kit/blob/571831a923fead2a4a8c7d82bc1066a7f61d0221/packages/kit/CHANGELOG.md#100-next257). 

### Updates

- docs(svelte): remove `kit.target` from SvelteKit set-up

I tested this locally with both SvelteKit and SvelteKit + TypeScript set-ups in this repo: https://github.com/metonym/carbon-charts-svelte-examples
