### PR TITLE
chore(svelte): remove old email from package metadata

### DIFF
--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -85,14 +85,12 @@
 	"maintainers": [
 		{
 			"name": "Eric Liu",
-			"email": "eric.young.liu@ibm.com",
 			"url": "https://github.com/metonym"
 		}
 	],
 	"contributors": [
 		{
 			"name": "Eric Liu",
-			"email": "eric.young.liu@ibm.com",
 			"url": "https://github.com/metonym"
 		}
 	]


### PR DESCRIPTION
This removes the `email` field as I am no longer employed by IBM.

### Updates
- chore(svelte): remove old email from package metadata

