### PR TITLE
feat(svelte): add `theme` prop

### DIFF
--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -224,20 +224,20 @@ module.exports = {
 
 ## Usage
 
-Import chart styles from `@carbon/charts`:
+Styles must be imported from both `@carbon/charts` and `@carbon/styles`.
 
--   `@carbon/charts/styles.css`: White theme
--   `@carbon/charts/styles-g10.css`: Gray 10 theme
--   `@carbon/charts/styles-g90.css`: Gray 90 theme
--   `@carbon/charts/styles-g100.css`: Gray 100 theme
+```js
+import '@carbon/styles/css/styles.css';
+import '@carbon/charts/styles.css';
+```
 
 ### Basic
 
 ```svelte
 <script>
+  import "@carbon/styles/css/styles.css";
+  import "@carbon/charts/styles.css";
   import { BarChartSimple } from "@carbon/charts-svelte";
-  import "@carbon/charts/styles.min.css";
-  import "carbon-components/css/carbon-components.min.css";
 </script>
 
 <BarChartSimple
@@ -258,6 +258,30 @@ Import chart styles from `@carbon/charts`:
   }}
 />
 
+```
+
+### Theming
+
+`@carbon/styles` uses
+[CSS custom properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties)
+for dynamic, client-side theming. Update the Carbon theme using the `theme`
+prop.
+
+Supported themes include:
+
+-   `"white"`
+-   `"g10"` (Gray 10)
+-   `"g90"` (Gray 90)
+-   `"g100"` (Gray 100)
+
+The default theme is `"white"`.
+
+```svelte
+<BarChartSimple
+  theme="g90"
+  data={/* ... */}
+  options={/* ... */}
+/>
 ```
 
 ### Dispatched events
@@ -287,9 +311,9 @@ Dynamically import a chart and instantiate it using the
 
 ```svelte
 <script>
+  import "@carbon/styles/css/styles.css";
+  import "@carbon/charts/styles.css";
   import { onMount } from "svelte";
-  import "@carbon/charts/styles.min.css";
-  import "carbon-components/css/carbon-components.min.css";
 
   let chart;
 
@@ -327,10 +351,10 @@ that fires when hovering over a bar.
 
 ```svelte
 <script>
+  import "@carbon/styles/css/styles.css";
+  import "@carbon/charts/styles.css";
   import { onMount } from "svelte";
   import { BarChartSimple } from "@carbon/charts-svelte";
-  import "@carbon/charts/styles.min.css";
-  import "carbon-components/css/carbon-components.min.css";
 
   let chart;
 

--- a/packages/svelte/src/BaseChart.svelte
+++ b/packages/svelte/src/BaseChart.svelte
@@ -24,6 +24,12 @@
 	 */
 	export let options = {};
 
+  /**
+	 * Specify the Carbon theme
+	 * @type {"white" | "g10" | "g90" | "g100"}
+	 */
+	export let theme = "white";
+
 	/** Specify the id for the chart holder element */
 	export let id = "chart-" + Math.random().toString(36);
 
@@ -70,4 +76,4 @@
 	}
 </script>
 
-<div {...$$restProps} bind:this={ref} {id} />
+<div {...$$restProps} data-carbon-theme={theme} bind:this={ref} {id} />

--- a/packages/svelte/types/BaseChart.d.ts
+++ b/packages/svelte/types/BaseChart.d.ts
@@ -33,6 +33,12 @@ export interface BaseChartProps<Chart = BC, ChartOptions = BaseChartOptions, Cha
   options?: ChartOptions;
 
   /**
+   * Specify the Carbon theme
+   * @default "white"
+   */
+  theme?: "white" | "g10" | "g90" | "g100";
+
+  /**
    * Specify the id for the chart holder element
    * @default "chart-" + Math.random().toString(36)
    */


### PR DESCRIPTION
This PR adds a `theme` prop to the Svelte base chart to make theming easier. It also updates the documentation on using the v1 Svelte charts based on the process of updating [metonym/carbon-charts-svelte-examples](https://github.com/metonym/carbon-charts-svelte-examples/commit/8ec690a83a0778c6a60fede22d8a01a9ad4459b5).

### Updates

- feat(svelte): add `theme` prop to chart wrappers
- docs(svelte): update docs on v1 usage
- docs(svelte): update docs on theming

### Demo screenshot or recording

I've tested the updated type definitions locally.

<img width="490" alt="Screen Shot 2022-06-12 at 7 06 16 AM" src="https://user-images.githubusercontent.com/10718366/173237135-d82a623d-f11e-4d18-8b0f-fa84edd70f7e.png">


### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
