### PR TITLE
fix(core): add aria-label attribute to toolbar container

### DIFF
--- a/packages/core/src/components/axes/toolbar.ts
+++ b/packages/core/src/components/axes/toolbar.ts
@@ -42,7 +42,12 @@ export class Toolbar extends Component {
 	}
 
 	render(animate = true) {
-		const container = this.getComponentContainer().attr('role', 'toolbar');
+		const container = this.getComponentContainer()
+			.attr('role', 'toolbar')
+			.attr(
+				'aria-label',
+				`chart-${this.services.domUtils.getChartID()} toolbar`
+			);
 
 		const isDataLoading = Tools.getProperty(
 			this.getOptions(),

--- a/packages/core/src/services/essentials/dom-utils.ts
+++ b/packages/core/src/services/essentials/dom-utils.ts
@@ -24,9 +24,8 @@ interface getSVGElementSizeOptions {
 }
 
 export class DOMUtils extends Service {
-	private chartID = Math.floor(
-		(1 + Math.random()) * 0x1000000000000
-	).toString(16);
+	// Initialized in init
+	private chartID;
 
 	constructor(model: any, services: any) {
 		super(model, services);
@@ -204,6 +203,9 @@ export class DOMUtils extends Service {
 		// Add width & height to the chart holder if necessary, and add a classname
 		this.styleHolderElement();
 
+		// Initialize chart ID
+		this.initializeID();
+
 		this.addMainContainer();
 		this.verifyCSSStylesBeingApplied();
 
@@ -224,6 +226,12 @@ export class DOMUtils extends Service {
 		return `chart-${this.chartID}-${originalID}`;
 	}
 
+	private initializeID() {
+		this.chartID = Math.floor(
+			(1 + Math.random()) * 0x1000000000000
+		).toString(16);
+	}
+
 	addMainContainer() {
 		const options = this.model.getOptions();
 		const chartsprefix = Tools.getProperty(options, 'style', 'prefix');
@@ -231,6 +239,7 @@ export class DOMUtils extends Service {
 		const mainContainer = select(this.getHolder())
 			.append('div')
 			.classed(`${carbonPrefix}--${chartsprefix}--chart-wrapper`, true)
+			.attr('id', `chart-${this.getChartID()}`)
 			.style('height', '100%')
 			.style('width', '100%');
 


### PR DESCRIPTION
closes #1390

### Updates
- Each `chart` now has an id element
- Initializing chart id in init function (it is called before constructor is called 🤔)
- Decided to add `id` to the chart to clarify what the toolbar aria-label is referring too
- Added aria-label attribute to toolbar container
  - Aria label has the following label: `chart-${id} toolbar`
  - Using aria-label instead of aria-labelledby since we do not have text within container (only icon)

### Demo screenshot or recording
![image](https://user-images.githubusercontent.com/38994122/173472792-29559318-ffe9-4525-bf8a-bba0d318aa6b.png)
- 4.1.2 Name, Role, Value is no longer reported by the checker

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
