### PR TITLE
feat(core): bar group time series

### DIFF
--- a/packages/core/demo/data/bar.ts
+++ b/packages/core/demo/data/bar.ts
@@ -23,6 +23,80 @@ export const groupedBarData = [
 	{ group: 'Dataset 4', key: 'Misc', value: 24134 },
 ];
 
+export const groupedBarTimeSeriesData = [
+	{ group: 'Dataset 1', date: new Date(2019, 0, 1), value: 10000 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 2), value: 65000 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 3), value: 30000 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 6), value: 49213 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 7), value: 51213 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 1), value: 8000 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 2), value: 67000 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 3), value: 15000 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 6), value: 51213 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 7), value: 45213 },
+];
+
+export const groupedBarTimeSeriesDenseData = [
+	{ group: 'Dataset 1', date: new Date(2019, 0, 1), value: 10000 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 2), value: 65000 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 3), value: 30000 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 6), value: 49213 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 7), value: 51213 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 8), value: 51213 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 9), value: 51213 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 10), value: 51213 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 11), value: 51213 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 12), value: 51213 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 13), value: 51213 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 14), value: 51213 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 15), value: 51213 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 16), value: 51213 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 17), value: 51213 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 18), value: 51213 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 19), value: 51213 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 20), value: 51213 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 21), value: 51213 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 22), value: 51213 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 23), value: 51213 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 24), value: 51213 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 25), value: 51213 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 26), value: 51213 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 27), value: 51213 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 28), value: 51213 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 29), value: 51213 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 30), value: 51213 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 31), value: 51213 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 1), value: 8000 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 2), value: 67000 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 3), value: 15000 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 6), value: 51213 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 7), value: 45213 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 8), value: 51213 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 9), value: 51213 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 10), value: 51213 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 11), value: 51213 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 12), value: 51213 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 13), value: 51213 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 14), value: 51213 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 15), value: 51213 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 16), value: 51213 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 17), value: 51213 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 18), value: 51213 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 19), value: 51213 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 20), value: 51213 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 21), value: 51213 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 22), value: 51213 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 23), value: 51213 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 24), value: 51213 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 25), value: 51213 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 26), value: 51213 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 27), value: 51213 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 28), value: 51213 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 29), value: 51213 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 30), value: 51213 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 31), value: 51213 },
+];
+
 export const groupedBarOptions = {
 	title: 'Vertical grouped bar (discrete)',
 	axes: {
@@ -67,6 +141,48 @@ export const groupedHorizontalBarOptions = {
 		},
 		bottom: {
 			mapsTo: 'value',
+		},
+	},
+};
+
+// Vertical Grouped Time Series
+export const groupedBarTimeSeriesOptions = {
+	title: 'Vertical grouped bar (time series)',
+	axes: {
+		left: {
+			mapsTo: 'value',
+		},
+		bottom: {
+			mapsTo: 'date',
+			scaleType: 'time',
+		},
+	},
+};
+
+// Horizontal Grouped Time Series
+export const groupedBarHorizontalTimeSeriesOptions = {
+	title: 'Horizontal grouped bar (time series)',
+	axes: {
+		left: {
+			mapsTo: 'date',
+			scaleType: 'time',
+		},
+		bottom: {
+			mapsTo: 'value',
+		},
+	},
+};
+
+// Vertical Grouped time series with dense data
+export const groupedBarTimeSeriesDenseOptions = {
+	title: 'Vertical grouped bar (time series - dense data)',
+	axes: {
+		left: {
+			mapsTo: 'value',
+		},
+		bottom: {
+			mapsTo: 'date',
+			scaleType: 'time',
 		},
 	},
 };

--- a/packages/core/demo/data/index.ts
+++ b/packages/core/demo/data/index.ts
@@ -338,6 +338,11 @@ const utilityDemoGroups = [
 				chartType: chartTypes.SimpleBarChart,
 			},
 			{
+				options: zoomBarDemos.zoomBarGroupedBarTimeSeriesOptions,
+				data: zoomBarDemos.zoomBarGroupedBarTimeSeriesData,
+				chartType: chartTypes.GroupedBarChart,
+			},
+			{
 				options: zoomBarDemos.zoomBarStackedBarTimeSeriesOptions,
 				data: zoomBarDemos.zoomBarStackedBarTimeSeriesData,
 				chartType: chartTypes.StackedBarChart,
@@ -546,6 +551,16 @@ const simpleChartDemos = [
 				mainDemo: true,
 			},
 			{
+				options: barDemos.groupedBarTimeSeriesOptions,
+				data: barDemos.groupedBarTimeSeriesData,
+				chartType: chartTypes.GroupedBarChart,
+			},
+			{
+				options: barDemos.groupedBarTimeSeriesDenseOptions,
+				data: barDemos.groupedBarTimeSeriesDenseData,
+				chartType: chartTypes.GroupedBarChart,
+			},
+			{
 				options: barDemos.groupedBarEmptyStateOptions,
 				data: barDemos.groupedBarEmptyStateData,
 				chartType: chartTypes.GroupedBarChart,
@@ -559,6 +574,11 @@ const simpleChartDemos = [
 			{
 				options: barDemos.groupedHorizontalBarOptions,
 				data: barDemos.groupedHorizontalBarData,
+				chartType: chartTypes.GroupedBarChart,
+			},
+			{
+				options: barDemos.groupedBarHorizontalTimeSeriesOptions,
+				data: barDemos.groupedBarTimeSeriesData,
 				chartType: chartTypes.GroupedBarChart,
 			},
 			{

--- a/packages/core/demo/data/zoom-bar.ts
+++ b/packages/core/demo/data/zoom-bar.ts
@@ -71,6 +71,12 @@ export const zoomBarSimpleBarTimeSeriesOptions = addZoomBarToOptions(
 	{ sliderView: true }
 );
 
+export const zoomBarGroupedBarTimeSeriesData = barChart.groupedBarTimeSeriesData;
+export const zoomBarGroupedBarTimeSeriesOptions = addZoomBarToOptions(
+	Object.assign({}, barChart.groupedBarTimeSeriesOptions),
+	{ sliderView: true }
+);
+
 export const zoomBarStackedBarTimeSeriesData =
 	barChart.stackedBarTimeSeriesData;
 export const zoomBarStackedBarTimeSeriesOptions = addZoomBarToOptions(

--- a/packages/core/src/components/graphs/bar-grouped.ts
+++ b/packages/core/src/components/graphs/bar-grouped.ts
@@ -21,6 +21,9 @@ export class GroupedBar extends Bar {
 
 	padding = 5;
 
+	// A factor to normalize padding between bars regardless of bar group density.
+	readonly defaultStepFactor = 70;
+
 	init() {
 		const eventsFragment = this.services.events;
 
@@ -324,7 +327,7 @@ export class GroupedBar extends Bar {
 		const domainScale = this.services.cartesianScales.getDomainScale();
 		const activeData = this.model.getGroupedData(this.configs.groups);
 
-		let step = 70;
+		let step = this.defaultStepFactor;
 		if (typeof domainScale.step === 'function') {
 			step = domainScale.step();
 		} else if (activeData.length > 0) {
@@ -347,7 +350,7 @@ export class GroupedBar extends Bar {
 			return 0;
 		}
 
-		const padding = Math.min(5, 5 * (this.getDomainScaleStep() / 70));
+		const padding = Math.min(5, 5 * (this.getDomainScaleStep() / this.defaultStepFactor));
 
 		return padding * (activeData.length - 1);
 	}


### PR DESCRIPTION
Extends existing grouped bar support to time series scales. This should address
https://github.com/carbon-design-system/carbon-charts/issues/1396 and
https://github.com/carbon-design-system/carbon-charts/issues/1373

fix #1396, #1373

### Updates
- Grouped bar can now support ```scaleType: 'time'```

### Demo screenshot or recording
[storybook-sm.mov.zip](https://github.com/carbon-design-system/carbon-charts/files/8952483/storybook-sm.mov.zip)

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
