### PR TITLE
fix(core): remove mock text from axes

### DIFF
--- a/packages/core/src/components/axes/axis.ts
+++ b/packages/core/src/components/axes/axis.ts
@@ -590,6 +590,9 @@ export class Axis extends Component {
 
 						lastStartPosition = xTransformation;
 					});
+
+					// Cleanup mock text piece
+					mockTextPiece.remove();
 				}
 			}
 


### PR DESCRIPTION
### Updates
Remove mock text element from DOM.

### Demo screenshot or recording
I noticed odd text elements with value A accumulating in the DOM for time-series charts, e.g.
![image](https://user-images.githubusercontent.com/23342726/176300509-190d2122-4dd1-4d60-8022-243615b870e8.png)

Seems there was a mock text element being added to obtain avg letter width but wasn't being removed. 

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
