### PR TITLE
feat(core): Show milliseconds in axis labels if necessary

### DIFF
--- a/packages/core/demo/data/bar.ts
+++ b/packages/core/demo/data/bar.ts
@@ -656,6 +656,43 @@ export const stackedBarTimeSeriesOptions = {
 	},
 };
 
+export const stackedBarShortIntervalTimeSeriesData = [
+	{ group: 'Dataset 1', date: new Date(2019, 0, 1, 8, 15, 20, 111), value: 0 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 1, 8, 15, 20, 222), value: 65000 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 1, 8, 15, 20, 333), value: 10000 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 1, 8, 15, 20, 444), value: 49213 },
+	{ group: 'Dataset 1', date: new Date(2019, 0, 1, 8, 15, 20, 555), value: 0 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 1, 8, 15, 20, 111), value: 0 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 1, 8, 15, 20, 222), value: 57312 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 1, 8, 15, 20, 333), value: 21432 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 1, 8, 15, 20, 444), value: 70323 },
+	{ group: 'Dataset 2', date: new Date(2019, 0, 1, 8, 15, 20, 555), value: 0 },
+	{ group: 'Dataset 3', date: new Date(2019, 0, 1, 8, 15, 20, 111), value: 0 },
+	{ group: 'Dataset 3', date: new Date(2019, 0, 1, 8, 15, 20, 222), value: 15000 },
+	{ group: 'Dataset 3', date: new Date(2019, 0, 1, 8, 15, 20, 333), value: 20000 },
+	{ group: 'Dataset 3', date: new Date(2019, 0, 1, 8, 15, 20, 444), value: 39213 },
+	{ group: 'Dataset 3', date: new Date(2019, 0, 1, 8, 15, 20, 555), value: 0 },
+	{ group: 'Dataset 4', date: new Date(2019, 0, 1, 8, 15, 20, 111), value: 0 },
+	{ group: 'Dataset 4', date: new Date(2019, 0, 1, 8, 15, 20, 222), value: 37312 },
+	{ group: 'Dataset 4', date: new Date(2019, 0, 1, 8, 15, 20, 333), value: 51432 },
+	{ group: 'Dataset 4', date: new Date(2019, 0, 1, 8, 15, 20, 444), value: 40323 },
+	{ group: 'Dataset 4', date: new Date(2019, 0, 1, 8, 15, 20, 555), value: 0 },
+];
+
+export const stackedBarShortIntervalTimeSeriesOptions = {
+	title: 'Vertical stacked bar (short interval time series)',
+	axes: {
+		left: {
+			mapsTo: 'value',
+			stacked: true,
+		},
+		bottom: {
+			mapsTo: 'date',
+			scaleType: 'time',
+		},
+	},
+};
+
 // demo with custom ticks
 export const stackedBarTimeSeriesDataCustomTicks = stackedBarTimeSeriesData;
 

--- a/packages/core/demo/data/index.ts
+++ b/packages/core/demo/data/index.ts
@@ -614,6 +614,11 @@ const simpleChartDemos = [
 				chartType: chartTypes.StackedBarChart,
 			},
 			{
+				options: barDemos.stackedBarShortIntervalTimeSeriesOptions,
+				data: barDemos.stackedBarShortIntervalTimeSeriesData,
+				chartType: chartTypes.StackedBarChart,
+			},
+			{
 				options: barDemos.stackedBarEmptyStateOptions,
 				data: barDemos.stackedBarEmptyStateData,
 				chartType: chartTypes.StackedBarChart,

--- a/packages/core/src/components/essentials/tooltip.ts
+++ b/packages/core/src/components/essentials/tooltip.ts
@@ -253,6 +253,13 @@ export class Tooltip extends Component {
 			return format(value, 'MMM d, yyyy');
 		}
 
+		try {
+			// it's a correct ISO format Date string
+			return format(Date.parse(value), 'MMM d, yyyy');
+		} catch (e){
+			// not a valid ISO format string
+		}
+
 		return value.toLocaleString();
 	}
 

--- a/packages/core/src/model/model.ts
+++ b/packages/core/src/model/model.ts
@@ -9,6 +9,7 @@ import { Events, ScaleTypes, ColorClassNameTypes } from '../interfaces';
 import { scaleOrdinal } from 'd3-scale';
 import { stack, stackOffsetDiverging } from 'd3-shape';
 import { histogram } from 'd3-array';
+import { formatDateTillMilliSeconds } from "../services/time-series";
 
 /** The charting model layer which includes mainly the chart data and options,
  * as well as some misc. information to be shared among components */
@@ -316,6 +317,11 @@ export class ChartModel {
 						datum
 					);
 
+					// Use time value as key for Date object to avoid multiple data in the same second
+					if (datum[domainIdentifier] instanceof Date) {
+						return formatDateTillMilliSeconds(datum[domainIdentifier]);
+					}
+
 					return datum[domainIdentifier] &&
 						typeof datum[domainIdentifier].toString === 'function'
 						? datum[domainIdentifier].toString()
@@ -385,7 +391,9 @@ export class ChartModel {
 					return (
 						datum[groupMapsTo] === dataGroupName &&
 						datum.hasOwnProperty(domainIdentifier) &&
-						datum[domainIdentifier].toString() === key
+						(datum[domainIdentifier] instanceof Date
+							? formatDateTillMilliSeconds(datum[domainIdentifier]) === key
+					    	: datum[domainIdentifier].toString() === key)
 					);
 				});
 

--- a/packages/core/src/services/time-series.ts
+++ b/packages/core/src/services/time-series.ts
@@ -97,9 +97,16 @@ export function formatTick(
 	];
 	const primary = Tools.getProperty(formats, 'primary');
 	const secondary = Tools.getProperty(formats, 'secondary');
-	const formatString = isTickPrimary(tick, i, allTicks, interval, showDayName)
+	let formatString = isTickPrimary(tick, i, allTicks, interval, showDayName)
 		? primary
 		: secondary;
+
+	// if the interval, and the timestamp includes milliseconds value
+	if (interval === '15seconds' && date.getMilliseconds() !== 0){
+		// show milliseconds in tick
+		formatString = formatString.replace('pp', 'h:m:s.SSS a');
+	}
+
 	const locale = timeScaleOptions.localeObject;
 
 	return format(date, formatString, { locale });

--- a/packages/core/src/services/time-series.ts
+++ b/packages/core/src/services/time-series.ts
@@ -173,3 +173,13 @@ function isYearChanged(timestamp: number): boolean {
 	const { M, d, s, m, H } = getTimeformats(timestamp);
 	return M === 1 && d === 1 && H === 0 && m === 0 && s === 0;
 }
+
+// Return string value of Date with milliseconds
+export function formatDateTillMilliSeconds(date: Date) {
+	if (date === undefined) {
+		return '';
+	}
+
+	// The only valid format with millisecond is ISO 8601
+	return date.toISOString();
+}


### PR DESCRIPTION
### Issue
If there are multiple data set in the same second (different millisecond) in time-serious stacked bar chart, only one data is displayed, and the other data will be ignored due to stacked key conflicts.

### Updates

- Include millisecond as part of time serious stacked keys to avoid conflicts

- Add a new short time interval stacked bar (all data are in the same second)
  -- http://localhost:9006/?path=/story/simple-charts-bar-stacked--vertical-stacked-bar-short-interval-time-series


### Demo screenshot or recording
![image](https://user-images.githubusercontent.com/59426533/178187631-48bcb434-403d-484c-8735-9d6cbb0eddcc.png)


### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
