### PR TITLE
feat(core): allow theme to be set via options prop

### DIFF
--- a/packages/core/demo/styles.scss
+++ b/packages/core/demo/styles.scss
@@ -3,28 +3,28 @@
 @use "@carbon/styles/scss/theme";
 @use "@carbon/styles/scss/type" as *;
 
-@import "../src/styles/styles.scss";
+@import '../src/styles/styles.scss';
 
 html {
 	@include styles.theme(styles.$white);
 }
 
-html[data-carbon-theme="g10"] {
+html[data-carbon-theme='g10'] {
 	@include styles.theme(styles.$g10);
 }
 
-html[data-carbon-theme="g90"] {
+html[data-carbon-theme='g90'] {
 	@include styles.theme(styles.$g90);
 }
 
-html[data-carbon-theme="g100"] {
+html[data-carbon-theme='g100'] {
 	@include styles.theme(styles.$g100);
 }
 
 div.container {
 	color: theme.$text-primary;
 	background-color: theme.$background;
-	font-family: "IBM Plex Sans", Arial, sans-serif;
+	font-family: 'IBM Plex Sans', Arial, sans-serif;
 	padding: 30px;
 
 	div.v10-banner {
@@ -51,19 +51,6 @@ div.container {
 
 	#chart-demo {
 		max-width: 700px;
-		@include styles.theme(styles.$white);
-
-		&[data-carbon-theme="g10"] {
-			@include styles.theme(styles.$g10);
-		}
-
-		&[data-carbon-theme="g90"] {
-			@include styles.theme(styles.$g90);
-		}
-
-		&[data-carbon-theme="g100"] {
-			@include styles.theme(styles.$g100);
-		}
 	}
 
 	.cds--grid {
@@ -145,7 +132,7 @@ div.container {
 			overflow: hidden;
 
 			&:before {
-				content: " ";
+				content: ' ';
 				display: block;
 				position: absolute;
 				z-index: 2;
@@ -196,7 +183,7 @@ div.container {
 					width: 100%;
 					height: 100%;
 					background: rgba(0, 0, 0, 0.45);
-					content: " ";
+					content: ' ';
 					z-index: 1;
 				}
 			}
@@ -208,7 +195,7 @@ div.container {
 		}
 
 		.welcome__heading {
-			@include type-style("productive-heading-07");
+			@include type-style('productive-heading-07');
 
 			color: theme.$text-inverse;
 		}
@@ -218,7 +205,7 @@ div.container {
 		}
 
 		.welcome__heading--other {
-			@include type-style("productive-heading-04");
+			@include type-style('productive-heading-04');
 
 			font-weight: 600;
 			color: #4587fd;
@@ -248,7 +235,7 @@ div.container {
 	}
 
 	&.tutorial {
-		@import "~highlight.js/styles/sunburst.css";
+		@import '~highlight.js/styles/sunburst.css';
 
 		h1,
 		h2,
@@ -382,13 +369,13 @@ div.container {
 }
 
 .#{$prefix}--resource-card__title {
-	@include type-style("productive-heading-03");
+	@include type-style('productive-heading-03');
 	text-decoration: none;
 	color: theme.$text-primary;
 }
 
 .#{$prefix}--resource-card__subtitle {
-	@include type-style("heading-01");
+	@include type-style('heading-01');
 	font-weight: 400;
 	text-decoration: none;
 	color: theme.$text-primary;
@@ -405,8 +392,8 @@ div.container {
 }
 
 .#{$prefix}--resource-card__icon--img .gatsby-resp-image-wrapper,
-.#{$prefix}--resource-card__icon--img img[src*="gif"],
-.#{$prefix}--resource-card__icon--img img[src*="svg"] {
+.#{$prefix}--resource-card__icon--img img[src*='gif'],
+.#{$prefix}--resource-card__icon--img img[src*='svg'] {
 	margin-bottom: 0;
 }
 
@@ -455,7 +442,9 @@ div.container {
 	color: theme.$icon-on-color-disabled;
 }
 
-.#{$prefix}--resource-card--disabled .#{$prefix}--resource-card__icon--action svg {
+.#{$prefix}--resource-card--disabled
+	.#{$prefix}--resource-card__icon--action
+	svg {
 	fill: theme.$icon-disabled;
 }
 
@@ -465,15 +454,20 @@ div.container {
 }
 
 // Disabled dark
-.#{$prefix}--resource-card--disabled.#{$prefix}--resource-card--dark .#{$prefix}--tile:hover {
+.#{$prefix}--resource-card--disabled.#{$prefix}--resource-card--dark
+	.#{$prefix}--tile:hover {
 	background: $gray-90; //$background for gray 90 theme
 }
 
-.#{$prefix}--resource-card--disabled.#{$prefix}--resource-card--dark .#{$prefix}--resource-card__title,
-.#{$prefix}--resource-card--disabled.#{$prefix}--resource-card--dark .#{$prefix}--resource-card__subtitle {
+.#{$prefix}--resource-card--disabled.#{$prefix}--resource-card--dark
+	.#{$prefix}--resource-card__title,
+.#{$prefix}--resource-card--disabled.#{$prefix}--resource-card--dark
+	.#{$prefix}--resource-card__subtitle {
 	color: $gray-50; //$icon-on-color-disabled for gray 90
 }
 
-.#{$prefix}--resource-card--disabled.#{$prefix}--resource-card--dark .#{$prefix}--resource-card__icon--action svg {
+.#{$prefix}--resource-card--disabled.#{$prefix}--resource-card--dark
+	.#{$prefix}--resource-card__icon--action
+	svg {
 	fill: $gray-70; //$disabled-02 for gray 90
 }

--- a/packages/core/demo/utils.ts
+++ b/packages/core/demo/utils.ts
@@ -188,8 +188,6 @@ export const addRadioButtonEventListeners = (container, chart, configs) => {
 			document.documentElement.setAttribute('data-carbon-theme', theme);
 			// Set selected theme to options
 			chart.model.setOptions({ ...chart.model.getOptions(), theme });
-
-			chart.update();
 		});
 	});
 };

--- a/packages/core/demo/utils.ts
+++ b/packages/core/demo/utils.ts
@@ -157,7 +157,7 @@ export const addControls = (
 	chart,
 	configs = { colorPairingOptions: null }
 ) => {
-	generateThemePickerHTML(container, configs);
+	generateThemePickerHTML(container, chart);
 
 	if (demoGroup?.configs?.excludeColorPaletteControl !== true) {
 		generateColorPalettePickerHTML(container, chart, configs);
@@ -186,9 +186,8 @@ export const addRadioButtonEventListeners = (container, chart, configs) => {
 			const theme = e.target.value;
 
 			document.documentElement.setAttribute('data-carbon-theme', theme);
-			chart.services.domUtils
-				.getHolder()
-				.setAttribute('data-carbon-theme', theme);
+			// Set selected theme to options
+			chart.model.setOptions({ ...chart.model.getOptions(), theme });
 
 			chart.update();
 		});

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -47,6 +47,7 @@ import {
 	TreeTypes,
 	HeatmapChartOptions,
 	DividerStatus,
+	ChartTheme,
 } from './interfaces';
 import enUSLocaleObject from 'date-fns/locale/en-US/index';
 import { circlePack } from './configuration-non-customizable';
@@ -172,6 +173,7 @@ const chart: BaseChartOptions = {
 	width: null,
 	height: null,
 	resizable: true,
+	theme: ChartTheme.WHITE,
 	tooltip: baseTooltip,
 	legend,
 	style: {

--- a/packages/core/src/interfaces/charts.ts
+++ b/packages/core/src/interfaces/charts.ts
@@ -48,7 +48,7 @@ export interface BaseChartOptions {
 	 */
 	height?: string;
 	/**
-	 * Optionally specify the theme of the chart
+	 * Optionally specify a theme for the chart
 	 */
 	theme?: ChartTheme;
 	/**

--- a/packages/core/src/interfaces/charts.ts
+++ b/packages/core/src/interfaces/charts.ts
@@ -7,6 +7,7 @@ import {
 	TreeTypes,
 	DividerStatus,
 	ColorLegendType,
+	ChartTheme,
 } from './enums';
 import {
 	LegendOptions,
@@ -46,6 +47,10 @@ export interface BaseChartOptions {
 	 * Optionally specify a height for the chart
 	 */
 	height?: string;
+	/**
+	 * Optionally specify the theme of the chart
+	 */
+	theme?: ChartTheme;
 	/**
 	 * tooltip configuration
 	 */
@@ -281,11 +286,7 @@ export interface LineChartOptions extends ScatterChartOptions {
 	/**
 	 * options for the curve of the line
 	 */
-	curve?:
-		| string
-		| {
-				name: string;
-		  };
+	curve?: string | { name: string };
 }
 
 /**
@@ -295,11 +296,7 @@ export interface AreaChartOptions extends AxisChartOptions {
 	/**
 	 * options for the curve of the line
 	 */
-	curve?:
-		| string
-		| {
-				name: string;
-		  };
+	curve?: string | { name: string };
 	/**
 	 * options to bound the area of the chart
 	 */
@@ -316,11 +313,7 @@ export interface StackedAreaChartOptions extends ScatterChartOptions {
 	/**
 	 * options for the curve of the line
 	 */
-	curve?:
-		| string
-		| {
-				name: string;
-		  };
+	curve?: string | { name: string };
 }
 
 /**

--- a/packages/core/src/interfaces/enums.ts
+++ b/packages/core/src/interfaces/enums.ts
@@ -10,7 +10,7 @@ export enum RenderTypes {
  * enum of all supported chart themes
  */
 export enum ChartTheme {
-	DEFAULT = 'default',
+	WHITE = 'white',
 	G100 = 'g100',
 	G90 = 'g90',
 	G10 = 'g10',

--- a/packages/core/src/services/essentials/dom-utils.ts
+++ b/packages/core/src/services/essentials/dom-utils.ts
@@ -255,13 +255,10 @@ export class DOMUtils extends Service {
 	styleHolderElement() {
 		const holderElement = this.getHolder() as HTMLElement;
 
-		// Add class to chart holder
-		select(this.getHolder()).classed(`${carbonPrefix}--chart-holder`, true);
-
 		// In order for resize events to not clash with these updates
 		// We'll check if the width & height values passed in options
 		// Have changed, before setting them to the holder
-		const { width, height } = this.model.getOptions();
+		const { width, height, theme } = this.model.getOptions();
 		if (width !== this.width) {
 			// Apply formatted width attribute to chart
 			holderElement.style.width = width;
@@ -275,6 +272,11 @@ export class DOMUtils extends Service {
 
 			this.height = height;
 		}
+
+		// Add class to chart holder
+		select(this.getHolder())
+			.classed(`${carbonPrefix}--chart-holder`, true)
+			.attr('data-carbon-theme', theme);
 	}
 
 	getHolder() {

--- a/packages/core/stories/tutorials/themes.ts
+++ b/packages/core/stories/tutorials/themes.ts
@@ -5,6 +5,7 @@ export const themesTutorial = {
 	content: marked(`
 # Themes
 We support all 4 Carbon themes (white, g10, g90 & g100), which are all included inside the main CSS bundle.
+After importing the carbon styles, pass in one of the four Carbon themes in options like in the examples below.
 
 **If using CSS:**
 
@@ -15,13 +16,13 @@ Now all you need is to add a \`data-carbon-theme\` attribute to your chart holde
 e.g.
 
 \`\`\`html
-<div id="my-sample-chart" data-carbon-theme="g100">
-</div>
+<div id="my-sample-chart"></div>
 \`\`\`
 
 \`\`\`js
 const chartHolder = document.getElementById("my-sample-chart");
 new SimpleBarChart(chartHolder, {
+	theme: "g100", // Pass theme in options
 	data,
 	options
 });
@@ -34,22 +35,15 @@ new SimpleBarChart(chartHolder, {
 @use "@carbon/styles/scss/themes";
 
 @import "@carbon/charts/styles/styles.scss";
+\`\`\`
 
-div.my-sample-chart.theme__white {
-	@include styles.theme(styles.$white);
-}
-
-div.my-sample-chart.theme__g10 {
-	@include styles.theme(styles.$g10);
-}
-
-div.my-sample-chart.theme__g90 {
-	@include styles.theme(styles.$g90);
-}
-
-div.my-sample-chart.theme__g100 {
-	@include styles.theme(styles.$g100);
-}
+\`\`\`js
+const chartHolder = document.getElementById("my-sample-chart");
+new SimpleBarChart(chartHolder, {
+	theme: "g100", // Pass theme in options
+	data,
+	options
+});
 \`\`\`
 
 ## Things to keep in mind

--- a/packages/core/stories/tutorials/themes.ts
+++ b/packages/core/stories/tutorials/themes.ts
@@ -11,8 +11,6 @@ After importing the carbon styles, pass in one of the four Carbon themes in opti
 
 You'd need to import our **CSS bundle** \`@carbon/charts/styles.css\`
 
-Now all you need is to add a \`data-carbon-theme\` attribute to your chart holder element.
-
 e.g.
 
 \`\`\`html
@@ -22,32 +20,32 @@ e.g.
 \`\`\`js
 const chartHolder = document.getElementById("my-sample-chart");
 new SimpleBarChart(chartHolder, {
-	theme: "g100", // Pass theme in options
 	data,
-	options
+	options: {
+		...myChartOptions,
+		theme: "g100", // Pass theme in options
+	}
 });
 \`\`\`
 
 **If using SCSS:**
 
 \`\`\`scss
-@use "@carbon/styles/scss/theme" as *;
-@use "@carbon/styles/scss/themes";
-
 @import "@carbon/charts/styles/styles.scss";
 \`\`\`
 
 \`\`\`js
 const chartHolder = document.getElementById("my-sample-chart");
 new SimpleBarChart(chartHolder, {
-	theme: "g100", // Pass theme in options
 	data,
-	options
+	options: {
+		...myChartOptions,
+		theme: "g100", // Pass theme in options
+	}
 });
 \`\`\`
 
-## Things to keep in mind
+## Color palette
 - Our color palette udpates automatically on theme switches
-- In some chart types such as **Treemap**, you'd need to update the chart after swapping out the themes (this is if you are updating the theme on a chart that's already been rendered). In order to do this you would call \`myChart.update()\` on your charting object instance.
 `),
 };

--- a/packages/svelte/src/BaseChart.svelte
+++ b/packages/svelte/src/BaseChart.svelte
@@ -27,7 +27,7 @@
   	/**
 	 * Specify the Carbon theme
 	 * @type {"white" | "g10" | "g90" | "g100"}
-	 * @deprecated as of V1, pass theme into options
+	 * @deprecated as of v1, pass theme into options
 	 */
 	export let theme = "white";
 
@@ -72,7 +72,7 @@
 
 	$: if (chart) {
 		chart.model.setData(data);
-		chart.model.setOptions(options);
+		chart.model.setOptions({theme, ...options });
 		dispatch("update", { data, options });
 	}
 </script>

--- a/packages/svelte/src/BaseChart.svelte
+++ b/packages/svelte/src/BaseChart.svelte
@@ -24,9 +24,10 @@
 	 */
 	export let options = {};
 
-  /**
+  	/**
 	 * Specify the Carbon theme
 	 * @type {"white" | "g10" | "g90" | "g100"}
+	 * @deprecated as of V1, pass theme into options
 	 */
 	export let theme = "white";
 


### PR DESCRIPTION
fix #1411

### Updates
- Updates docs to use `theme` option when `theme` radio value is selected.
- Marks svelte _additional_ `theme` as deprecated since V1
  - In next major version, should be removed
- Creates a new option called `theme` set to `white` by default. Accepts  `white`, `g10`, `g90`, `g100` as values, where `white` is default value.

### Demo screenshot or recording

### **Theme updates as you set change radio button**
![image](https://user-images.githubusercontent.com/38994122/179149221-aac3e75a-9794-4490-8599-c0a6d8403ae2.png)
### **Use `g100` chart theme in `g90` active theme**
![image](https://user-images.githubusercontent.com/38994122/179149271-d60e81b1-a7e7-44e1-8837-e1cb7d286e72.png)


### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
