### PR TITLE
docs(svelte): remove Snowpack set-up instructions

### DIFF
--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -43,7 +43,6 @@ This is an overview of using Carbon Charts with common Svelte set-ups.
 -   [Vite](#vite)
 -   [Rollup](#rollup)
 -   [Webpack](#webpack)
--   [Snowpack](#snowpack)
 
 ### SvelteKit
 
@@ -191,26 +190,6 @@ export default {
 bundler used to build Svelte apps.
 
 No additional configuration should be necessary.
-
-### Snowpack
-
-[snowpack](https://github.com/snowpackjs/snowpack) is an ESM-powered frontend
-build tool.
-
-Ensure you have
-[@snowpack/plugin-svelte](https://yarnpkg.com/package/@snowpack/plugin-svelte)
-added as a plugin in `snowpack.config.js`.
-
-No additional configuration should be necessary.
-
-```js
-// snowpack.config.js
-
-/** @type {import("snowpack").SnowpackUserConfig } */
-module.exports = {
-	plugins: ['@snowpack/plugin-svelte'],
-};
-```
 
 ## Usage
 


### PR DESCRIPTION
As of April 2022, Snowpack is [no longer maintained](https://github.com/FredKSchott/snowpack/blob/7f9b5455683a9d7632dbd7f4ed6db9ec2bb7c760/README.md?plain=1#L1-L4). Vite is the recommended alternative.

### Updates
- docs(svelte): remove Snowpack set-up instructions

### Demo screenshot or recording

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
