### PR TITLE
docs(svelte): update SvelteKit/Vite set-up instructions

### DIFF
--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -47,61 +47,40 @@ This is an overview of using Carbon Charts with common Svelte set-ups.
 
 ### SvelteKit
 
-[SvelteKit](https://github.com/sveltejs/kit) is fast becoming the de facto
-framework for building Svelte apps that supports both client-side rendering
-(CSR) and server-side rendering (SSR).
+[SvelteKit](https://github.com/sveltejs/kit) is the official framework for
+building apps that support client-side rendering (CSR) and server-side rendering
+(SSR). SvelteKit is powered by [Vite](https://github.com/vitest-dev/vitest).
 
-For set-ups powered by [vite](https://github.com/vitejs/vite), add
-`@carbon/charts` to the list of dependencies for `vite` to optimize.
-
-If using a [SvelteKit adapter](https://kit.svelte.dev/docs#adapters), instruct
-`vite` to avoid externalizing `@carbon/charts` when building for production.
+In your `vite.config.js`, add `@carbon/charts` and `carbon-components` to
+`ssr.noExternal` to avoid externalizing the dependencies for SSR.
 
 ```js
-// svelte.config.js
-import adapter from '@sveltejs/adapter-node';
+// vite.config.js
+import { sveltekit } from '@sveltejs/kit/vite';
 
-const production = process.env.NODE_ENV === 'production';
-
-/** @type {import('@sveltejs/kit').Config} */
-const config = {
-	kit: {
-		adapter: adapter(),
-		vite: {
-			optimizeDeps: {
-				include: ['@carbon/charts'],
-			},
-			ssr: {
-				noExternal: [production && '@carbon/charts'].filter(Boolean),
-			},
-		},
+/** @type {import('vite').UserConfig} */
+export default {
+	plugins: [sveltekit()],
+	ssr: {
+		noExternal: ['@carbon/charts', 'carbon-components'],
 	},
 };
-
-export default config;
 ```
 
 ### Vite
 
-[vite-plugin-svelte](https://github.com/sveltejs/vite-plugin-svelte) is an
-alternative to using SvelteKit. Similarly, instruct `vite` to optimize
-`@carbon/charts` in vite.config.js.
-
-Note that `@sveltejs/vite-plugin-svelte` is the official vite/svelte integration
-not to be confused with [svite](https://github.com/svitejs/svite).
+You can also use Vite without SvelteKit. Instruct `vite` to optimize
+`@carbon/charts` in `vite.config.js`.
 
 ```js
 // vite.config.js
 import { svelte } from '@sveltejs/vite-plugin-svelte';
-import { defineConfig } from 'vite';
 
-export default defineConfig(({ mode }) => {
-	return {
-		plugins: [svelte()],
-		build: { minify: mode === 'production' },
-		optimizeDeps: { include: ['@carbon/charts'] },
-	};
-});
+/** @type {import('vite').UserConfig} */
+export default {
+	plugins: [svelte()],
+	optimizeDeps: { include: ['@carbon/charts'] },
+};
 ```
 
 ### Rollup
@@ -187,7 +166,7 @@ export default {
 
 ### Webpack
 
-[webpack](https://github.com/webpack/webpack) is another popular application
+[Webpack](https://github.com/webpack/webpack) is another popular application
 bundler used to build Svelte apps.
 
 No additional configuration should be necessary.


### PR DESCRIPTION
I've noticed that the set-up instructions for SvelteKit are out of date as it will no longer build properly when using the latest SvelteKit version. SvelteKit recently updated to use Vite version 3.

The gist of the change is that both `@carbon/charts` and `carbon-components` should *not* be externalized for SSR if using SvelteKit. This isn't needed for the Vite standalone set-up. `@carbon/charts` no longer needs to be optimized for SvelteKit, but is still required if using Vite standalone.

Grammatical changes include capitalizing "Webpack" and "Vite."

### Updates
- docs(svelte): update SvelteKit/Vite set-up instructions

### Testing

I've tested the updated set-ups in [metonym/carbon-charts-svelte-examples](https://github.com/metonym/carbon-charts-svelte-examples). I've ensured that the config works in both development and when building for production.

### Demo screenshot or recording

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
