### PR TITLE
docs(svelte): remove Sapper set-up instructions

### DIFF
--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -41,7 +41,6 @@ This is an overview of using Carbon Charts with common Svelte set-ups.
 
 -   [SvelteKit](#sveltekit)
 -   [Vite](#vite)
--   [Sapper](#sapper)
 -   [Rollup](#rollup)
 -   [Webpack](#webpack)
 -   [Snowpack](#snowpack)
@@ -104,15 +103,6 @@ export default defineConfig(({ mode }) => {
 	};
 });
 ```
-
-### Sapper
-
-[sapper](https://github.com/sveltejs/sapper) is another official Svelte
-framework that supports server-side rendering (SSR).
-
-Take care to install `@carbon/charts-svelte` as a development dependency.
-
-No additional configuration should be necessary.
 
 ### Rollup
 


### PR DESCRIPTION
As of June 2022, Sapper is officially [deprecated](https://github.com/sveltejs/sapper/commit/ef01df6f4e891680f2257a646d70c3cdf03fe45b).

### Updates
- docs(svelte): remove Sapper set-up instructions

### Demo screenshot or recording

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
