### PR TITLE
docs(svelte): update CodeSandbox template

### DIFF
--- a/packages/core/demo/create-codesandbox.ts
+++ b/packages/core/demo/create-codesandbox.ts
@@ -350,30 +350,25 @@ export const createSvelteChartApp = (demo: any) => {
 
 	const packageJson = {
 		scripts: {
-			dev: 'vite',
+			dev: 'vite --port 3000',
 			build: 'vite build',
 		},
 		devDependencies: {
 			'@carbon/charts-svelte': libraryVersion,
-			'@sveltejs/vite-plugin-svelte': 'next',
+			'@sveltejs/vite-plugin-svelte': '^1.0.1',
 			d3: D3VERSION,
-			sass: '1.52.1',
-			svelte: '^3.43.1',
-			'svelte-hmr': '^0.14.7',
-			vite: '^2.6.7',
+			svelte: '^3.49.0',
+			vite: '^3.0.4',
 		},
 	};
 
 	const vite = `import { svelte } from "@sveltejs/vite-plugin-svelte";
-import { defineConfig } from "vite";
 
-export default defineConfig(({ mode }) => {
-  return {
-    plugins: [svelte()],
-    build: { minify: mode === "production" },
-    optimizeDeps: { include: ["@carbon/charts"] },
-  };
-});
+/** @type {import('vite').UserConfig} */
+export default {
+	plugins: [svelte()],
+	optimizeDeps: { include: ["@carbon/charts"] }
+};	
 `;
 
 	return {


### PR DESCRIPTION
The generated CodeSandboxes for the Carbon Svelte examples work fine.

This is a housekeeping update that upgrades Vite to the next major version. The official `@sveltejs/vite-plugin-svelte` plugin also reached a stable v1 release. It also simplifies the `vite.config.js` based on [metonym/carbon-charts-svelte-examples](https://github.com/metonym/carbon-charts-svelte-examples/tree/master/vite).

Other changes include:

- update `@sveltejs/vite-plugin-svelte` version from `next` to the latest `semver`
- remove unneeded dependencies in `package.json` (`sass`, `svelte-hmr`)

I tested this by creating a [CodeSandbox](https://codesandbox.io/s/determined-joana-klp6pk-klp6pk?file=/App.svelte) using the simple Bar Chart example.

### Updates
- docs(svelte): update CodeSandbox template

### Demo screenshot or recording

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
