### PR TITLE
fix(core): prevent toolbar buttons from being clicked if shouldBeDisabled returns true

### DIFF
--- a/packages/core/src/components/axes/toolbar.ts
+++ b/packages/core/src/components/axes/toolbar.ts
@@ -401,6 +401,12 @@ export class Toolbar extends Component {
 
 	// Calls passed function && dispatches event
 	triggerFunctionAndEvent(control, event, element?) {
+		// Check if trigger is disabled
+		if (typeof control.shouldBeDisabled === 'function') {
+			if (control.shouldBeDisabled()) {
+				return;
+			}
+		}
 		// Call custom function only if it exists
 		if (typeof control.clickFunction === 'function') {
 			control.clickFunction(event);

--- a/packages/core/src/components/axes/toolbar.ts
+++ b/packages/core/src/components/axes/toolbar.ts
@@ -402,11 +402,13 @@ export class Toolbar extends Component {
 	// Calls passed function && dispatches event
 	triggerFunctionAndEvent(control, event, element?) {
 		// Check if trigger is disabled
-		if (typeof control.shouldBeDisabled === 'function') {
-			if (control.shouldBeDisabled()) {
-				return;
-			}
+		if (
+			typeof control.shouldBeDisabled === 'function' &&
+			control.shouldBeDisabled()
+		) {
+			return;
 		}
+
 		// Call custom function only if it exists
 		if (typeof control.clickFunction === 'function') {
 			control.clickFunction(event);


### PR DESCRIPTION
fix #1424

### Updates
- Checks to see if shouldBeDisabled exists
- If it exists, runs the function
- If it doesn't exist, we automatically assume the toolbar button click function should execute

### Demo screenshot or recording


### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
