### PR TITLE
fix(core): add missing properties to AxisOptions interface

### DIFF
--- a/packages/core/src/interfaces/axis-scales.ts
+++ b/packages/core/src/interfaces/axis-scales.ts
@@ -126,6 +126,18 @@ export interface AxisOptions extends BasedAxisOptions {
 	percentage?: boolean;
 }
 
+export interface ComboChartAxisOptions extends AxisOptions {
+	/**
+	 * should be set to `true` for the
+	 * left axis to be the primary axis
+	 */
+ 	main?: boolean;
+ 	/**
+  	 * used to map data on the secondary axis
+  	 */
+ 	correspondingDatasets?: Array<string>;
+}
+
 export interface BinnedAxisOptions {
 	/**
 	 * should be set to `true` on the domain

--- a/packages/core/src/interfaces/axis-scales.ts
+++ b/packages/core/src/interfaces/axis-scales.ts
@@ -131,11 +131,11 @@ export interface ComboChartAxisOptions extends AxisOptions {
 	 * should be set to `true` for the
 	 * left axis to be the primary axis
 	 */
- 	main?: boolean;
- 	/**
-  	 * used to map data on the secondary axis
-  	 */
- 	correspondingDatasets?: Array<string>;
+	main?: boolean;
+	/**
+	 * used to map data on the secondary axis
+	 */
+	correspondingDatasets?: Array<string>;
 }
 
 export interface BinnedAxisOptions {

--- a/packages/core/src/interfaces/charts.ts
+++ b/packages/core/src/interfaces/charts.ts
@@ -20,6 +20,7 @@ import { BarOptions, StackedBarOptions, ToolbarOptions } from './components';
 import {
 	AxisOptions,
 	BinnedAxisOptions,
+	ComboChartAxisOptions,
 	TimeScaleOptions,
 } from './axis-scales';
 
@@ -451,6 +452,7 @@ export interface RadarChartOptions extends BaseChartOptions {
  * options specific to combo charts
  */
 export interface ComboChartOptions extends AxisChartOptions {
+	axes?: AxesOptions<ComboChartAxisOptions>;
 	comboChartTypes: Array<{
 		type: ChartTypes | any;
 		options?: object;


### PR DESCRIPTION
Fixes #1413

The `AxisOptions` interface is missing `main` and `correspondingDatasets` properties to support dual-axes charts.

### Updates
- add missing properties to AxisOptions interface

### Demo screenshot or recording

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
