### PR TITLE
fix(core): display correct minimum in heatmap axis tooltip when there is missing data

### DIFF
--- a/packages/core/src/components/graphs/heatmap.ts
+++ b/packages/core/src/components/graphs/heatmap.ts
@@ -367,27 +367,43 @@ export class Heatmap extends Component {
 		const mainYScale = this.services.cartesianScales.getMainYScale();
 
 		let label = '',
-			sum = 0,
-			minimum = 0,
-			maximum = 0;
+			sum = null,
+			minimum = null,
+			maximum = null;
 
 		// Check to see where datum belongs
 		if (this.matrix[datum] !== undefined) {
 			label = domainLabel;
 			// Iterate through Object and get sum, min, and max
 			ranges.forEach((element) => {
-				let value = this.matrix[datum][element].value || 0;
-				sum += value;
-				minimum = value < minimum ? value : minimum;
-				maximum = value > maximum ? value : maximum;
+				if (typeof this.matrix[datum][element].value === 'number') {
+					let value = this.matrix[datum][element].value;
+					if (sum === null) {
+						sum = value;
+						minimum = value;
+						maximum = value;
+						return;
+					}
+					sum += value;
+					minimum = value < minimum ? value : minimum;
+					maximum = value > maximum ? value : maximum;
+				}
 			});
 		} else {
 			label = rangeLabel;
 			domains.forEach((element) => {
-				let value = this.matrix[element][datum].value || 0;
-				sum += value;
-				minimum = value < minimum ? value : minimum;
-				maximum = value > maximum ? value : maximum;
+				if (typeof this.matrix[element][datum].value === 'number') {
+					let value = this.matrix[element][datum].value;
+					if (sum === null) {
+						sum = value;
+						minimum = value;
+						maximum = value;
+						return;
+					}
+					sum += value;
+					minimum = value < minimum ? value : minimum;
+					maximum = value > maximum ? value : maximum;
+				}
 			});
 		}
 
@@ -423,15 +439,15 @@ export class Heatmap extends Component {
 				},
 				{
 					label: 'Min',
-					value: minimum,
+					value: minimum !== null ? minimum : '-',
 				},
 				{
 					label: 'Max',
-					value: maximum,
+					value: maximum !== null ? maximum : '-',
 				},
 				{
 					label: 'Average',
-					value: sum / domains.length,
+					value: sum !== null ? sum / domains.length : '-',
 				},
 			],
 		});


### PR DESCRIPTION
fix #1423

### Updates
- Display correct minimum in heatmap axis tooltip
- If entire column or row consists of missing data, display `-` (dash)
  - This is possible by passing in custom domain

### Demo screenshot or recording
![image](https://user-images.githubusercontent.com/38994122/185946637-3b9a8b7c-6be2-4c3f-8959-9613dd29cc83.png)
![image](https://user-images.githubusercontent.com/38994122/185947004-ee0cbbbd-f66d-49e7-bf1c-385f978e81c7.png)


### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
