### PR TITLE
chore: make sass an optional peer dependency of charts

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -124,6 +124,11 @@
 		"webpack-cli": "3.3.11",
 		"webpack-dev-server": "3.7.0"
 	},
+	"peerDependenciesMeta": {
+		"sass": {
+			"optional": true
+		}
+	},
 	"publishConfig": {
 		"directory": "dist",
 		"access": "public"


### PR DESCRIPTION
### Updates

- adds `sass` as an optional peer dep of `@carbon/charts`. The real peer dep is in `@carbon/styles` and rightfully so, therefore I'm not 100% certain this will work the way I expect it to, but it appears optional per the findings in #1440 

### Demo screenshot or recording

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
