### PR TITLE
docs: index compatible design kits

### DIFF
--- a/packages/core/carbon.yml
+++ b/packages/core/carbon.yml
@@ -11,6 +11,9 @@ library:
       name: Storybook
       action: link
       url: https://charts.carbondesignsystem.com
+  designKits:
+    data-viz-sketch:
+      $ref: https://unpkg.com/@carbon-platform/resources/carbon.yml#/designKits/data-viz-sketch
 assets:
   alluvial:
     name: Alluvial


### PR DESCRIPTION
Related: https://github.com/carbon-design-system/carbon-platform/issues/967

### Updates

The Carbon Charts libraries have a design kits page, so you can easily find which design kits are compatible with the libraries.

https://next.carbondesignsystem.com/libraries/carbon-charts/latest/design-kits

There's one data viz Sketch design kit. This PR adds it to the core package, and because the schema `designKits` array is inherited, all 5 Carbon Charts libraries will show the Sketch kit in their design kits page.

### Demo screenshot or recording

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
