### PR TITLE
fix(core): highlight correct cell when multiple heatmaps exist

### DIFF
--- a/packages/core/src/components/graphs/heatmap.ts
+++ b/packages/core/src/components/graphs/heatmap.ts
@@ -258,7 +258,8 @@ export class Heatmap extends Component {
 						cell.attr('transform')
 					);
 
-					select('g.cell-highlight')
+					self.parent
+						.select('g.cell-highlight')
 						.attr(
 							'transform',
 							`translate(${
@@ -329,7 +330,9 @@ export class Heatmap extends Component {
 				const hoveredElement = cell.select('rect.heat');
 				const nullState = hoveredElement.classed('null-state');
 
-				select('g.cell-highlight').classed('highlighter-hidden', true);
+				self.parent
+					.select('g.cell-highlight')
+					.classed('highlighter-hidden', true);
 
 				// Dispatch event and tooltip only if value exists
 				if (!nullState) {


### PR DESCRIPTION
fix #1439

### Updates
- Highlight cell in the chart that has the cell.
- Select cell from parent

### Demo screenshot or recording
<img width="938" alt="image" src="https://user-images.githubusercontent.com/38994122/189579186-1093c106-490c-4fcc-b5b7-8c3a495c8fe5.png">


### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
