### PR TITLE
fix(core): wordcloud should not render if `value` is not a number

### DIFF
--- a/packages/core/src/components/graphs/wordcloud.ts
+++ b/packages/core/src/components/graphs/wordcloud.ts
@@ -51,27 +51,26 @@ export class WordCloud extends Component {
 			return;
 		}
 
-		const wordCloudData = [];
-		displayData.map(function (d) {
-			let value = d[fontSizeMapsTo];
-
-			if (typeof d[fontSizeMapsTo] !== 'number') {
-				throw Error(
-					'Badly formatted WordCloud data. `value` should only be an integer or float'
-				);
-			}
-
-			wordCloudData.push({
-				[groupMapsTo]: d[groupMapsTo],
-				text: d[wordMapsTo],
-				size: value,
-				value,
-			});
-		});
-
 		const layout = cloud()
 			.size([width, height])
-			.words(wordCloudData)
+			.words(
+				displayData.map(function (d) {
+					let value = d[fontSizeMapsTo];
+
+					if (typeof d[fontSizeMapsTo] !== 'number') {
+						throw Error(
+							'Badly formatted WordCloud data. `value` should only be an integer or float'
+						);
+					}
+
+					return {
+						[groupMapsTo]: d[groupMapsTo],
+						text: d[wordMapsTo],
+						size: value,
+						value,
+					};
+				})
+			)
 			.padding(5)
 			.rotate(0)
 			.fontSize((d) => fontSizeScale(d.size))

--- a/packages/core/src/components/graphs/wordcloud.ts
+++ b/packages/core/src/components/graphs/wordcloud.ts
@@ -51,18 +51,27 @@ export class WordCloud extends Component {
 			return;
 		}
 
+		const wordCloudData = [];
+		displayData.map(function (d) {
+			let value = d[fontSizeMapsTo];
+
+			if (typeof d[fontSizeMapsTo] !== 'number') {
+				throw Error(
+					'Badly formatted WordCloud data. `value` should only be an integer or float'
+				);
+			}
+
+			wordCloudData.push({
+				[groupMapsTo]: d[groupMapsTo],
+				text: d[wordMapsTo],
+				size: value,
+				value,
+			});
+		});
+
 		const layout = cloud()
 			.size([width, height])
-			.words(
-				displayData.map(function (d) {
-					return {
-						[groupMapsTo]: d[groupMapsTo],
-						text: d[wordMapsTo],
-						size: d[fontSizeMapsTo],
-						value: d[fontSizeMapsTo],
-					};
-				})
-			)
+			.words(wordCloudData)
 			.padding(5)
 			.rotate(0)
 			.fontSize((d) => fontSizeScale(d.size))


### PR DESCRIPTION
this PR adds a check where if the `value` field provided is not a number, it'll stop the rendering and throw an error