### PR TITLE
fix(core): allow users to 'escape' axis tooltip in heatmap

### DIFF
--- a/packages/core/src/components/axes/hover-axis.ts
+++ b/packages/core/src/components/axes/hover-axis.ts
@@ -86,27 +86,6 @@ export class HoverAxis extends Axis {
 				)
 				.attr('height', height)
 				.lower();
-
-			// Add keyboard event listeners to each group element
-			g.on('keydown', function (event: KeyboardEvent) {
-				// Choose specific arrow key depending on the axis
-				if (
-					axisPosition === AxisPositions.LEFT ||
-					axisPosition === AxisPositions.RIGHT
-				) {
-					if (event.key && event.key === 'ArrowUp') {
-						self.goNext(this as HTMLElement, event);
-					} else if (event.key && event.key === 'ArrowDown') {
-						self.goPrevious(this as HTMLElement, event);
-					}
-				} else {
-					if (event.key && event.key === 'ArrowLeft') {
-						self.goPrevious(this as HTMLElement, event);
-					} else if (event.key && event.key === 'ArrowRight') {
-						self.goNext(this as HTMLElement, event);
-					}
-				}
-			});
 		});
 
 		// Add event listeners to element group
@@ -219,6 +198,35 @@ export class HoverAxis extends Axis {
 					element: select(this),
 					datum: select(this).select('text').datum(),
 				});
+			})
+			.on('keydown', function (event) {
+				// Hide the tooltip when `Escape` is pressed, but keep focus
+				if (event.key && event.key === 'Escape') {
+					self.services.events.dispatchEvent(Events.Tooltip.HIDE);
+					self.services.events.dispatchEvent(Events.Axis.LABEL_BLUR, {
+						event,
+						element: select(this),
+						datum: select(this).select('text').datum(),
+					});
+				}
+
+				// Choose specific arrow key depending on the axis
+				if (
+					axisPosition === AxisPositions.LEFT ||
+					axisPosition === AxisPositions.RIGHT
+				) {
+					if (event.key && event.key === 'ArrowUp') {
+						self.goNext(this as HTMLElement, event);
+					} else if (event.key && event.key === 'ArrowDown') {
+						self.goPrevious(this as HTMLElement, event);
+					}
+				} else {
+					if (event.key && event.key === 'ArrowLeft') {
+						self.goPrevious(this as HTMLElement, event);
+					} else if (event.key && event.key === 'ArrowRight') {
+						self.goNext(this as HTMLElement, event);
+					}
+				}
 			});
 	}
 


### PR DESCRIPTION
fix #1453

### Updates
- Accessibility fix, allows users to escape (hide) the tooltip for HEATMAP axis
- When tooltip is hidden, the axis tick will remain highlighted
  - Going to the next or previous tick will show the tooltip again

### Demo screenshot or recording
![image](https://user-images.githubusercontent.com/38994122/197029091-562f1e45-5c22-4339-bbf4-e1e7ff062041.png)


### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
