### PR TITLE
fix: thumbnail hover bugs

### DIFF
--- a/thumbnails/bar-stacked.svg
+++ b/thumbnails/bar-stacked.svg
@@ -1,24 +1,28 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="320px" height="180px" viewBox="0 0 320 180" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <title>stacked_bar</title>
-    <g id="stacked_bar" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <rect id="Rectangle-Copy-12" fill="#005D5D" x="87" y="106" width="6" height="31"></rect>
-        <rect id="Rectangle-Copy-13" fill="#BE95FF" x="87" y="56" width="6" height="48"></rect>
-        <rect id="Rectangle-Copy-17" fill="#BE95FF" x="115" y="80" width="6" height="16"></rect>
-        <rect id="Rectangle-Copy-23" fill="#BE95FF" x="143" y="97" width="6" height="23"></rect>
-        <rect id="Rectangle-Copy-26" fill="#BE95FF" x="227" y="110" width="6" height="12"></rect>
-        <rect id="Rectangle-Copy-24" fill="#BE95FF" x="199" y="111" width="6" height="9"></rect>
-        <rect id="Rectangle-Copy-27" fill="#9F1853" x="227" y="99" width="6" height="9"></rect>
-        <rect id="Rectangle-Copy-15" fill="#9F1853" x="87" y="40" width="6" height="14"></rect>
-        <rect id="Rectangle-Copy-18" fill="#9F1853" x="115" y="58" width="6" height="20"></rect>
-        <rect id="Rectangle-Copy-19" fill="#9F1853" x="143" y="75" width="6" height="20"></rect>
-        <rect id="Rectangle-Copy-14" fill="#9F1853" x="199" y="48" width="6" height="60.925926"></rect>
-        <rect id="Rectangle-Copy-28" fill="#BE95FF" x="171" y="95" width="6" height="23"></rect>
-        <rect id="Rectangle-Copy-29" fill="#9F1853" x="171" y="84" width="6" height="9"></rect>
-        <rect id="Rectangle-Copy-30" fill="#005D5D" x="171" y="120" width="6" height="17.2407407"></rect>
-        <rect id="Rectangle-Copy-16" fill="#005D5D" x="115" y="98" width="6" height="39.0185185"></rect>
-        <rect id="Rectangle-Copy-20" fill="#005D5D" x="143" y="122" width="6" height="15"></rect>
-        <rect id="Rectangle-Copy-25" fill="#005D5D" x="199" y="122" width="6" height="15"></rect>
-        <rect id="Rectangle-Copy-21" fill="#005D5D" x="227" y="124" width="6" height="13.240741"></rect>
-    </g>
+<svg width="640" height="360" viewBox="0 0 640 360" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="bar-stacked">
+<rect id="Rectangle 121" x="174" y="94" width="12" height="150" fill="white"/>
+<rect id="Rectangle 122" x="230" y="114" width="12" height="150" fill="white"/>
+<rect id="Rectangle 123" x="286" y="154" width="12" height="120" fill="white"/>
+<rect id="Rectangle 124" x="342" y="178" width="12" height="96" fill="white"/>
+<rect id="Rectangle 125" x="398" y="178" width="12" height="96" fill="white"/>
+<rect id="Rectangle 126" x="454" y="208" width="12" height="66" fill="white"/>
+<rect id="Rectangle Copy 12" x="174" y="212" width="12" height="62" fill="#005D5D"/>
+<rect id="Rectangle Copy 13" x="174" y="112" width="12" height="96" fill="#BE95FF"/>
+<rect id="Rectangle Copy 17" x="230" y="160" width="12" height="32" fill="#BE95FF"/>
+<rect id="Rectangle Copy 23" x="286" y="194" width="12" height="46" fill="#BE95FF"/>
+<rect id="Rectangle Copy 26" x="454" y="220" width="12" height="24" fill="#BE95FF"/>
+<rect id="Rectangle Copy 24" x="398" y="222" width="12" height="18" fill="#BE95FF"/>
+<rect id="Rectangle Copy 27" x="454" y="198" width="12" height="18" fill="#9F1853"/>
+<rect id="Rectangle Copy 15" x="174" y="80" width="12" height="28" fill="#9F1853"/>
+<rect id="Rectangle Copy 18" x="230" y="116" width="12" height="40" fill="#9F1853"/>
+<rect id="Rectangle Copy 19" x="286" y="150" width="12" height="40" fill="#9F1853"/>
+<rect id="Rectangle Copy 14" x="398" y="96" width="12" height="121.852" fill="#9F1853"/>
+<rect id="Rectangle Copy 28" x="342" y="190" width="12" height="46" fill="#BE95FF"/>
+<rect id="Rectangle Copy 29" x="342" y="168" width="12" height="18" fill="#9F1853"/>
+<rect id="Rectangle Copy 30" x="342" y="240" width="12" height="34.4815" fill="#005D5D"/>
+<rect id="Rectangle Copy 16" x="230" y="196" width="12" height="78.037" fill="#005D5D"/>
+<rect id="Rectangle Copy 20" x="286" y="244" width="12" height="30" fill="#005D5D"/>
+<rect id="Rectangle Copy 25" x="398" y="244" width="12" height="30" fill="#005D5D"/>
+<rect id="Rectangle Copy 21" x="454" y="248" width="12" height="26.4815" fill="#005D5D"/>
+</g>
 </svg>

--- a/thumbnails/gauge.svg
+++ b/thumbnails/gauge.svg
@@ -13,5 +13,6 @@
             <g id="Mask"></g>
             <path d="M22,43 C22,12.072054 -3.07205401,-13 -34,-13 C-64.927946,-13 -90,12.072054 -90,43" stroke="#E0E0E0" stroke-width="12" mask="url(#mask-2)"></path>
         </g>
+        <line x1="205.5" y1="76" x2="197.278497" y2="83.3080022" id="Line" stroke="#FFFFFF" stroke-width="2" stroke-linecap="square"></line>
     </g>
 </svg>

--- a/thumbnails/heat-map.svg
+++ b/thumbnails/heat-map.svg
@@ -1,62 +1,61 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="320px" height="180px" viewBox="0 0 320 180" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <title>heat-map</title>
-    <g id="heat-map" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="Group" transform="translate(85.000000, 40.000000)">
-            <rect id="Rectangle-2-Copy-25" fill="#FFD6E8" x="0" y="0" width="16" height="16"></rect>
-            <rect id="Rectangle-2-Copy-71" fill="#FFD6E8" x="0" y="33" width="16" height="16"></rect>
-            <rect id="Rectangle-2-Copy-26" fill="#FF7EB6" x="0" y="17" width="16" height="15"></rect>
-            <rect id="Rectangle-2-Copy-84" fill="#FFD6E8" x="0" y="50" width="16" height="16"></rect>
-            <rect id="Rectangle-2-Copy-30" fill="#FFD6E8" x="67" y="0" width="15" height="16"></rect>
-            <rect id="Rectangle-2-Copy-85" fill="#EE5396" x="67" y="33" width="15" height="16"></rect>
-            <rect id="Rectangle-2-Copy-31" fill="#EE5396" x="67" y="17" width="15" height="15"></rect>
-            <rect id="Rectangle-2-Copy-86" fill="#EE5396" x="67" y="50" width="15" height="16"></rect>
-            <rect id="Rectangle-2-Copy-34" fill="#FF7EB6" x="17" y="0" width="15" height="16"></rect>
-            <rect id="Rectangle-2-Copy-87" fill="#FF7EB6" x="17" y="33" width="15" height="16"></rect>
-            <rect id="Rectangle-2-Copy-35" fill="#EE5396" x="17" y="17" width="15" height="15"></rect>
-            <rect id="Rectangle-2-Copy-88" fill="#FF7EB6" x="17" y="50" width="15" height="16"></rect>
-            <rect id="Rectangle-2-Copy-36" fill="#FFD6E8" x="83" y="0" width="16" height="16"></rect>
-            <rect id="Rectangle-2-Copy-89" fill="#EE5396" x="83" y="33" width="16" height="16"></rect>
-            <rect id="Rectangle-2-Copy-37" fill="#FFAFD2" x="83" y="17" width="16" height="15"></rect>
-            <rect id="Rectangle-2-Copy-90" fill="#FF7EB6" x="83" y="50" width="16" height="16"></rect>
-            <rect id="Rectangle-2-Copy-42" fill="#EE5396" x="33" y="0" width="16" height="16"></rect>
-            <rect id="Rectangle-2-Copy-91" fill="#EE5396" x="33" y="33" width="16" height="16"></rect>
-            <rect id="Rectangle-2-Copy-43" fill="#D12771" x="33" y="17" width="16" height="15"></rect>
-            <rect id="Rectangle-2-Copy-92" fill="#FF7EB6" x="33" y="50" width="16" height="16"></rect>
-            <rect id="Rectangle-2-Copy-44" fill="#EE5396" x="50" y="0" width="16" height="16"></rect>
-            <rect id="Rectangle-2-Copy-93" fill="#D12771" x="50" y="33" width="16" height="16"></rect>
-            <rect id="Rectangle-2-Copy-46" fill="#D12771" x="50" y="17" width="16" height="15"></rect>
-            <rect id="Rectangle-2-Copy-94" fill="#EE5396" x="50" y="50" width="16" height="16"></rect>
-            <rect id="Rectangle-2-Copy-95" fill="#FFD6E8" x="0" y="67" width="16" height="15"></rect>
-            <rect id="Rectangle-2-Copy-96" fill="#FFD6E8" x="0" y="83" width="16" height="16"></rect>
-            <rect id="Rectangle-2-Copy-97" fill="#FF7EB6" x="67" y="67" width="15" height="15"></rect>
-            <rect id="Rectangle-2-Copy-98" fill="#FFD6E8" x="67" y="83" width="15" height="16"></rect>
-            <rect id="Rectangle-2-Copy-99" fill="#FFD6E8" x="17" y="67" width="15" height="15"></rect>
-            <rect id="Rectangle-2-Copy-100" fill="#FF7EB6" x="17" y="83" width="15" height="16"></rect>
-            <rect id="Rectangle-2-Copy-101" fill="#FFD6E8" x="83" y="67" width="16" height="15"></rect>
-            <rect id="Rectangle-2-Copy-102" fill="#FFD6E8" x="83" y="83" width="16" height="16"></rect>
-            <rect id="Rectangle-2-Copy-103" fill="#FFD6E8" x="33" y="67" width="16" height="15"></rect>
-            <rect id="Rectangle-2-Copy-104" fill="#FF7EB6" x="33" y="83" width="16" height="16"></rect>
-            <rect id="Rectangle-2-Copy-105" fill="#FF7EB6" x="50" y="67" width="16" height="15"></rect>
-            <rect id="Rectangle-2-Copy-106" fill="#FF7EB6" x="50" y="83" width="16" height="16"></rect>
-            <rect id="Rectangle-2-Copy-107" fill="#FFD6E8" x="100" y="0" width="16" height="16"></rect>
-            <rect id="Rectangle-2-Copy-108" fill="#EE5396" x="100" y="33" width="16" height="16"></rect>
-            <rect id="Rectangle-2-Copy-109" fill="#FF7EB6" x="100" y="17" width="16" height="15"></rect>
-            <rect id="Rectangle-2-Copy-110" fill="#EE5396" x="100" y="50" width="16" height="16"></rect>
-            <rect id="Rectangle-2-Copy-111" fill="#FFAFD2" x="117" y="0" width="15" height="16"></rect>
-            <rect id="Rectangle-2-Copy-112" fill="#EE5396" x="117" y="33" width="15" height="16"></rect>
-            <rect id="Rectangle-2-Copy-113" fill="#EE5396" x="117" y="17" width="15" height="15"></rect>
-            <rect id="Rectangle-2-Copy-114" fill="#EE5396" x="117" y="50" width="15" height="16"></rect>
-            <rect id="Rectangle-2-Copy-115" fill="#FFD6E8" x="133" y="0" width="16" height="16"></rect>
-            <rect id="Rectangle-2-Copy-123" fill="#FFD6E8" x="133" y="33" width="16" height="16"></rect>
-            <rect id="Rectangle-2-Copy-127" fill="#FFD6E8" x="133" y="17" width="16" height="15"></rect>
-            <rect id="Rectangle-2-Copy-129" fill="#FFD6E8" x="133" y="50" width="16" height="16"></rect>
-            <rect id="Rectangle-2-Copy-130" fill="#FFAFD2" x="100" y="67" width="16" height="15"></rect>
-            <rect id="Rectangle-2-Copy-131" fill="#FFD6E8" x="100" y="83" width="16" height="16"></rect>
-            <rect id="Rectangle-2-Copy-132" fill="#FF7EB6" x="117" y="67" width="15" height="15"></rect>
-            <rect id="Rectangle-2-Copy-133" fill="#FFD6E8" x="117" y="83" width="15" height="16"></rect>
-            <rect id="Rectangle-2-Copy-135" fill="#FFD6E8" x="133" y="67" width="16" height="15"></rect>
-            <rect id="Rectangle-2-Copy-136" fill="#FFD6E8" x="133" y="83" width="16" height="16"></rect>
-        </g>
-    </g>
+<svg width="640" height="360" viewBox="0 0 640 360" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="heat-map">
+<g id="Group">
+<rect id="bkg" x="170" y="80" width="298" height="198" fill="white"/>
+<rect id="Rectangle 2 Copy 25" x="170" y="80" width="32" height="32" fill="#FFD6E8"/>
+<rect id="Rectangle 2 Copy 71" x="170" y="146" width="32" height="32" fill="#FFD6E8"/>
+<rect id="Rectangle 2 Copy 26" x="170" y="114" width="32" height="30" fill="#FF7EB6"/>
+<rect id="Rectangle 2 Copy 84" x="170" y="180" width="32" height="32" fill="#FFD6E8"/>
+<rect id="Rectangle 2 Copy 30" x="304" y="80" width="30" height="32" fill="#FFD6E8"/>
+<rect id="Rectangle 2 Copy 85" x="304" y="146" width="30" height="32" fill="#EE5396"/>
+<rect id="Rectangle 2 Copy 31" x="304" y="114" width="30" height="30" fill="#EE5396"/>
+<rect id="Rectangle 2 Copy 86" x="304" y="180" width="30" height="32" fill="#EE5396"/>
+<rect id="Rectangle 2 Copy 34" x="204" y="80" width="30" height="32" fill="#FF7EB6"/>
+<rect id="Rectangle 2 Copy 87" x="204" y="146" width="30" height="32" fill="#FF7EB6"/>
+<rect id="Rectangle 2 Copy 35" x="204" y="114" width="30" height="30" fill="#EE5396"/>
+<rect id="Rectangle 2 Copy 88" x="204" y="180" width="30" height="32" fill="#FF7EB6"/>
+<rect id="Rectangle 2 Copy 36" x="336" y="80" width="32" height="32" fill="#FFD6E8"/>
+<rect id="Rectangle 2 Copy 89" x="336" y="146" width="32" height="32" fill="#EE5396"/>
+<rect id="Rectangle 2 Copy 37" x="336" y="114" width="32" height="30" fill="#FFAFD2"/>
+<rect id="Rectangle 2 Copy 90" x="336" y="180" width="32" height="32" fill="#FF7EB6"/>
+<rect id="Rectangle 2 Copy 42" x="236" y="80" width="32" height="32" fill="#EE5396"/>
+<rect id="Rectangle 2 Copy 91" x="236" y="146" width="32" height="32" fill="#EE5396"/>
+<rect id="Rectangle 2 Copy 43" x="236" y="114" width="32" height="30" fill="#D12771"/>
+<rect id="Rectangle 2 Copy 92" x="236" y="180" width="32" height="32" fill="#FF7EB6"/>
+<rect id="Rectangle 2 Copy 44" x="270" y="80" width="32" height="32" fill="#EE5396"/>
+<rect id="Rectangle 2 Copy 93" x="270" y="146" width="32" height="32" fill="#D12771"/>
+<rect id="Rectangle 2 Copy 46" x="270" y="114" width="32" height="30" fill="#D12771"/>
+<rect id="Rectangle 2 Copy 94" x="270" y="180" width="32" height="32" fill="#EE5396"/>
+<rect id="Rectangle 2 Copy 95" x="170" y="214" width="32" height="30" fill="#FFD6E8"/>
+<rect id="Rectangle 2 Copy 96" x="170" y="246" width="32" height="32" fill="#FFD6E8"/>
+<rect id="Rectangle 2 Copy 97" x="304" y="214" width="30" height="30" fill="#FF7EB6"/>
+<rect id="Rectangle 2 Copy 98" x="304" y="246" width="30" height="32" fill="#FFD6E8"/>
+<rect id="Rectangle 2 Copy 99" x="204" y="214" width="30" height="30" fill="#FFD6E8"/>
+<rect id="Rectangle 2 Copy 100" x="204" y="246" width="30" height="32" fill="#FF7EB6"/>
+<rect id="Rectangle 2 Copy 101" x="336" y="214" width="32" height="30" fill="#FFD6E8"/>
+<rect id="Rectangle 2 Copy 102" x="336" y="246" width="32" height="32" fill="#FFD6E8"/>
+<rect id="Rectangle 2 Copy 103" x="236" y="214" width="32" height="30" fill="#FFD6E8"/>
+<rect id="Rectangle 2 Copy 104" x="236" y="246" width="32" height="32" fill="#FF7EB6"/>
+<rect id="Rectangle 2 Copy 105" x="270" y="214" width="32" height="30" fill="#FF7EB6"/>
+<rect id="Rectangle 2 Copy 106" x="270" y="246" width="32" height="32" fill="#FF7EB6"/>
+<rect id="Rectangle 2 Copy 107" x="370" y="80" width="32" height="32" fill="#FFD6E8"/>
+<rect id="Rectangle 2 Copy 108" x="370" y="146" width="32" height="32" fill="#EE5396"/>
+<rect id="Rectangle 2 Copy 109" x="370" y="114" width="32" height="30" fill="#FF7EB6"/>
+<rect id="Rectangle 2 Copy 110" x="370" y="180" width="32" height="32" fill="#EE5396"/>
+<rect id="Rectangle 2 Copy 111" x="404" y="80" width="30" height="32" fill="#FFAFD2"/>
+<rect id="Rectangle 2 Copy 112" x="404" y="146" width="30" height="32" fill="#EE5396"/>
+<rect id="Rectangle 2 Copy 113" x="404" y="114" width="30" height="30" fill="#EE5396"/>
+<rect id="Rectangle 2 Copy 114" x="404" y="180" width="30" height="32" fill="#EE5396"/>
+<rect id="Rectangle 2 Copy 115" x="436" y="80" width="32" height="32" fill="#FFD6E8"/>
+<rect id="Rectangle 2 Copy 123" x="436" y="146" width="32" height="32" fill="#FFD6E8"/>
+<rect id="Rectangle 2 Copy 127" x="436" y="114" width="32" height="30" fill="#FFD6E8"/>
+<rect id="Rectangle 2 Copy 129" x="436" y="180" width="32" height="32" fill="#FFD6E8"/>
+<rect id="Rectangle 2 Copy 130" x="370" y="214" width="32" height="30" fill="#FFAFD2"/>
+<rect id="Rectangle 2 Copy 131" x="370" y="246" width="32" height="32" fill="#FFD6E8"/>
+<rect id="Rectangle 2 Copy 132" x="404" y="214" width="30" height="30" fill="#FF7EB6"/>
+<rect id="Rectangle 2 Copy 133" x="404" y="246" width="30" height="32" fill="#FFD6E8"/>
+<rect id="Rectangle 2 Copy 135" x="436" y="214" width="32" height="30" fill="#FFD6E8"/>
+<rect id="Rectangle 2 Copy 136" x="436" y="246" width="32" height="32" fill="#FFD6E8"/>
+</g>
+</g>
 </svg>

--- a/thumbnails/tree-map.svg
+++ b/thumbnails/tree-map.svg
@@ -1,11 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="320px" height="180px" viewBox="0 0 320 180" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <title>tree-map</title>
-    <g id="tree-map" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <polygon id="Rectangle-2-Copy" fill="#9F1853" points="154 77 234 77 234 141 154 141"></polygon>
-        <polygon id="Rectangle-2-Copy-2" fill="#520408" points="154 41 234 41 234 76 154 76"></polygon>
-        <rect id="Rectangle-2-Copy-4" fill="#A56EFF" x="86" y="41" width="67" height="49"></rect>
-        <polygon id="Rectangle-2-Copy-5" fill="#002D9C" points="86 91 135 91 135 141 86 141"></polygon>
-        <polygon id="Rectangle-2-Copy-84" fill="#08BDBA" points="136 91 153 91 153 141 136 141"></polygon>
-    </g>
+<svg width="640" height="360" viewBox="0 0 640 360" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="tree-map">
+<rect id="Rectangle 120" x="172" y="82" width="296" height="200" fill="white"/>
+<path id="Rectangle 2 Copy" fill-rule="evenodd" clip-rule="evenodd" d="M308 154H468V282H308V154Z" fill="#9F1853"/>
+<path id="Rectangle 2 Copy 2" fill-rule="evenodd" clip-rule="evenodd" d="M308 82H468V152H308V82Z" fill="#520408"/>
+<rect id="Rectangle 2 Copy 4" x="172" y="82" width="134" height="98" fill="#A56EFF"/>
+<path id="Rectangle 2 Copy 5" fill-rule="evenodd" clip-rule="evenodd" d="M172 182H270V282H172V182Z" fill="#002D9C"/>
+<path id="Rectangle 2 Copy 84" fill-rule="evenodd" clip-rule="evenodd" d="M272 182H306V282H272V182Z" fill="#08BDBA"/>
+</g>
 </svg>


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-platform/issues/1432

Reported https://github.com/carbon-design-system/carbon-platform/issues/1315

### Updates

- Makes sure white divider lines show up on hover for bar stacked, gauge, heat map, and tree map thumbnails

### Demo screenshot or recording

Hovering:

<img width="321" alt="image" src="https://user-images.githubusercontent.com/1691245/197578638-cac1a236-ca26-4596-a9eb-d36ed7662d71.png">

<img width="320" alt="image" src="https://user-images.githubusercontent.com/1691245/197578687-abaae047-fe18-4129-953e-aa44ae3e9822.png">

<img width="315" alt="image" src="https://user-images.githubusercontent.com/1691245/197578726-ad42ff46-bad0-4739-ae42-f859e7ad6a22.png">

<img width="316" alt="image" src="https://user-images.githubusercontent.com/1691245/197578768-4e12bd6a-0fa3-4f57-b09d-a0cc0954a5a9.png">

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
