### PR TITLE
ci(actions): add carbon-dco workflow to repo

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -145,6 +145,17 @@ yarn run storybook
 
 ## Legal
 
+Each source file must include a license header for the Apache
+Software License 2.0. Using the SPDX format is the simplest approach.
+For example:
+
+```javascript
+/*
+Copyright <holder> All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+```
+
 We have tried to make it as easy as possible to make contributions. This
 applies to how we handle the legal aspects of contribution. We use the
 same approach - the [Developer's Certificate of Origin 1.1 (DCO)](https://developercertificate.org/) - that the Linux® Kernel [community](https://elinux.org/Developer_Certificate_Of_Origin)

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,6 +15,7 @@ Please take a moment to review this document in order to make the contribution p
   - [Contribution process](#contribution-process)
 - [Code guidelines](#code-guidelines)
   - [Philosophy](#philosophy)
+- [Legal](#legal)
 
 
 ## IBMer Contributions
@@ -140,3 +141,28 @@ yarn run storybook
 
 - Components should be fully equipped with _all_ features and interactions defined in the latest Design Guide and UX Specifications.
 - Components should be _pixel perfect_ when compared to the latest Design Guide.
+
+
+## Legal
+
+We have tried to make it as easy as possible to make contributions. This
+applies to how we handle the legal aspects of contribution. We use the
+same approach - the [Developer's Certificate of Origin 1.1 (DCO)](https://developercertificate.org/) - that the Linux® Kernel [community](https://elinux.org/Developer_Certificate_Of_Origin)
+uses to manage code contributions.
+
+We simply ask that when submitting a patch for review, the developer
+must include a sign-off statement in the commit message.
+
+Here is an example Signed-off-by line, which indicates that the
+submitter accepts the DCO:
+
+```text
+Signed-off-by: John Doe <john.doe@example.com>
+```
+
+You can include this automatically when you commit a change to your
+local git repository using the following command:
+
+```bash
+git commit -s
+```

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,37 @@
+name: 'DCO Assistant'
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+jobs:
+  DCO:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'DCO Assistant'
+        if:
+          (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the
+          DCO document and I hereby sign the DCO.') || github.event_name == 'pull_request_target'
+        uses: cla-assistant/github-action@v2.2.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CARBON_BOT_DCO }}
+        with:
+          path-to-signatures: 'dco-signatures.json'
+          path-to-document: 'https://github.com/carbon-design-system/carbon-dco/blob/main/dco.md'
+          branch: 'main'
+          allowlist: bot*
+          remote-organization-name: carbon-design-system
+          remote-repository-name: carbon-dco
+          create-file-commit-message: 'chore: create file to store dco signatures'
+          signed-commit-message: 'chore: $contributorName has signed the dco in #$pullRequestNo'
+          custom-notsigned-prcomment:
+            'Thanks for your submission! We ask that $you sign our [Developer Certificate of
+            Origin](https://github.com/carbon-design-system/carbon-dco/blob/main/dco.md) before we
+            can accept your contribution. You can sign the DCO by adding a comment below using this
+            text:'
+          custom-pr-sign-comment: 'I have read the DCO document and I hereby sign the DCO.'
+          custom-allsigned-prcomment: 'All contributors have signed the DCO.'
+          lock-pullrequest-aftermerge: false
+          use-dco-flag: true


### PR DESCRIPTION
### Updates
- Adds carbon-dco workflow
- Adds legal notice to `contribution.md`

`GITHUB_TOKEN` is auto-generated for each action, but we will need the `carbon-bot` PAT (`CARBON_BOT_DCO`) with repo scope permissions.