### PR TITLE
docs(readme): add discord link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
 		</a>
 		<img alt="semantic-versioning" src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--ver-e10079.svg" />
 		<img alt="semantic-versioning" src="https://img.shields.io/badge/downloads-+20k%2Fweek-green" />
+		<a href="https://discord.gg/J7JEUEkTRX">
+	    		<img src="https://img.shields.io/discord/689212587170201628?color=5865F2" alt="Chat with us on Discord">
+	  	</a>
 	</p>
 </p>
 


### PR DESCRIPTION
Hey there! Just a small PR to add a link to discord in the readme. I'm opening PRs suggesting we do this for all the top repos in the carbon-design-system org.