### PR TITLE
fix(react): outdated Carbon prefix being used

### DIFF
--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -1,4 +1,4 @@
-const carbonPrefix = 'bx';
+const carbonPrefix = 'cds';
 const chartsPrefix = 'cc';
 
 export const hasChartBeenInitialized = (chartHolder: HTMLElement) =>


### PR DESCRIPTION
Closes #1500

Seems like react wrappers were still looking for the v10 prefix!