### PR TITLE
fix(model): d3-array histogram deprecated / replaced by bin

### DIFF
--- a/packages/core/src/model/model.ts
+++ b/packages/core/src/model/model.ts
@@ -8,7 +8,7 @@ import { Events, ScaleTypes, ColorClassNameTypes } from '../interfaces';
 // D3
 import { scaleOrdinal } from 'd3-scale';
 import { stack, stackOffsetDiverging } from 'd3-shape';
-import { histogram } from 'd3-array';
+import { bin } from 'd3-array';
 import { formatDateTillMilliSeconds } from '../services/time-series';
 
 /** The charting model layer which includes mainly the chart data and options,
@@ -205,7 +205,7 @@ export class ChartModel {
 		const areBinsDefined = Array.isArray(axisBins);
 
 		// Get Histogram bins
-		const bins = histogram()
+		const bins = bin()
 			.value((d) => d[domainIdentifier])
 			.thresholds(axisBins)(data);
 


### PR DESCRIPTION
### Updates
Two lines changed in core/src/model/model.ts to replace use of deprecated histogram function in d3-array with bin. Functionality remains the same but modification prevents break in future release.

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
