### PR TITLE
fix(meter.ts): meter chart no longer have reduce error on empty data

### DIFF
--- a/packages/core/src/model/meter.ts
+++ b/packages/core/src/model/meter.ts
@@ -40,13 +40,10 @@ export class MeterChartModel extends ChartModel {
 		const options = this.getOptions()
 		const dataValues = getProperty(this.getDisplayData())
 
-		const { value: totalValue } =
-			dataValues?.reduce(
-				(previous: any, current: any) => {
-					return { value: previous.value + current.value }
-				},
-				{ value: 0 }
-			) ?? 0
+		const totalValue =
+			dataValues?.reduce((previous: any, current: any) => {
+				return previous + current.value
+			}, 0) ?? 0
 
 		// use max value if the percentage is bigger than 100%
 		const boundedValue = getProperty(options, 'meter', 'proportional')

--- a/packages/core/src/model/meter.ts
+++ b/packages/core/src/model/meter.ts
@@ -40,11 +40,13 @@ export class MeterChartModel extends ChartModel {
 		const options = this.getOptions()
 		const dataValues = getProperty(this.getDisplayData())
 
-		const { value: totalValue } = dataValues
-			? dataValues.reduce((previous: any, current: any) => {
+		const { value: totalValue } =
+			dataValues?.reduce(
+				(previous: any, current: any) => {
 					return { value: previous.value + current.value }
-				})
-			: 0
+				},
+				{ value: 0 }
+			) ?? 0
 
 		// use max value if the percentage is bigger than 100%
 		const boundedValue = getProperty(options, 'meter', 'proportional')


### PR DESCRIPTION
fix #1604

### Updates:

Add an initial value to the `reduce` function so that proportional meter chart doesn't error out when receving an empty array.

### Demo screenshot or recording

#### Before:

https://github.com/carbon-design-system/carbon-charts/assets/38139823/17f32441-8539-4028-9166-fd201009c6ad



#### After:


https://github.com/carbon-design-system/carbon-charts/assets/38139823/30ca1048-ce95-4ecd-9b53-7970dff4f4ab


