### PR TITLE
Stop re-exporting lodash from tools.

### DIFF
--- a/packages/core/src/charts/area.ts
+++ b/packages/core/src/charts/area.ts
@@ -1,4 +1,4 @@
-import { cloneDeep } from "lodash-es";
+import { cloneDeep } from 'lodash-es'
 import { AxisChart } from '@/axis-chart'
 import { options } from '@/configuration'
 import { mergeDefaultChartOptions } from '@/tools'

--- a/packages/core/src/charts/area.ts
+++ b/packages/core/src/charts/area.ts
@@ -1,6 +1,7 @@
+import { cloneDeep } from "lodash-es";
 import { AxisChart } from '@/axis-chart'
 import { options } from '@/configuration'
-import { clone, mergeDefaultChartOptions } from '@/tools'
+import { mergeDefaultChartOptions } from '@/tools'
 import type { ChartConfig } from '@/interfaces/model'
 import type { AreaChartOptions } from '@/interfaces/charts'
 import { Skeletons } from '@/interfaces/enums'
@@ -19,7 +20,7 @@ export class AreaChart extends AxisChart {
 
 		// Merge the default options for this chart
 		// With the user provided options
-		this.model.setOptions(mergeDefaultChartOptions(clone(options.areaChart), chartConfigs.options))
+		this.model.setOptions(mergeDefaultChartOptions(cloneDeep(options.areaChart), chartConfigs.options))
 
 		// Initialize data, services, components etc.
 		this.init(holder, chartConfigs)

--- a/packages/core/src/charts/combo.ts
+++ b/packages/core/src/charts/combo.ts
@@ -1,6 +1,7 @@
+import { camelCase, flatten, merge } from 'lodash-es'
 import { AxisChart } from '@/axis-chart'
 import { options as configOptions } from '@/configuration'
-import { camelCase, flatten, merge, mergeDefaultChartOptions } from '@/tools'
+import { mergeDefaultChartOptions } from '@/tools'
 import type { ChartConfig } from '@/interfaces/model'
 import { ChartTypes, Skeletons } from '@/interfaces/enums'
 import type { ComboChartOptions } from '@/interfaces/charts'

--- a/packages/core/src/charts/meter.ts
+++ b/packages/core/src/charts/meter.ts
@@ -1,6 +1,7 @@
+import { cloneDeep } from "lodash-es";
 import { Chart } from '@/chart'
 import { options as configOptions } from '@/configuration'
-import { clone, getProperty, merge } from '@/tools'
+import { getProperty, merge } from '@/tools'
 import { MeterChartModel } from '@/model/meter'
 import type { ChartConfig } from '@/interfaces/model'
 import type { MeterChartOptions } from '@/interfaces/charts'
@@ -23,8 +24,8 @@ export class MeterChart extends Chart {
 
 		// use prop meter options or regular meter options
 		const options = chartConfigs.options.meter?.proportional
-			? merge(clone(configOptions.proportionalMeterChart), chartConfigs.options)
-			: merge(clone(configOptions.meterChart), chartConfigs.options)
+			? merge(cloneDeep(configOptions.proportionalMeterChart), chartConfigs.options)
+			: merge(cloneDeep(configOptions.meterChart), chartConfigs.options)
 
 		// Merge the default options for this chart
 		// With the user provided options

--- a/packages/core/src/charts/meter.ts
+++ b/packages/core/src/charts/meter.ts
@@ -1,7 +1,7 @@
-import { cloneDeep } from "lodash-es";
+import { cloneDeep, merge } from 'lodash-es'
 import { Chart } from '@/chart'
 import { options as configOptions } from '@/configuration'
-import { getProperty, merge } from '@/tools'
+import { getProperty } from '@/tools'
 import { MeterChartModel } from '@/model/meter'
 import type { ChartConfig } from '@/interfaces/model'
 import type { MeterChartOptions } from '@/interfaces/charts'

--- a/packages/core/src/components/axes/axis.ts
+++ b/packages/core/src/components/axes/axis.ts
@@ -7,8 +7,9 @@ import {
     select,
     type Selection as D3Selection
 } from 'd3'
+import { clamp } from 'lodash-es'
 import { axis as axisConfigs } from '@/configuration'
-import { clamp, getProperty, getTranslationValues, truncateLabel } from '@/tools'
+import { getProperty, getTranslationValues, truncateLabel } from '@/tools'
 import { Component } from '@/components/component'
 import {
     AxisPositions,

--- a/packages/core/src/components/axes/ruler-binned.ts
+++ b/packages/core/src/components/axes/ruler-binned.ts
@@ -1,6 +1,6 @@
 import { select, type Selection } from 'd3'
-import { get } from 'lodash-es'
-import { isEqual, getProperty } from '@/tools'
+import { get, isEqual } from 'lodash-es'
+import { getProperty } from '@/tools'
 import { Ruler } from './ruler'
 import { DOMUtils } from '@/services/essentials/dom-utils'
 import { CartesianOrientations, ColorClassNameTypes, Events, RenderTypes } from '@/interfaces/enums'

--- a/packages/core/src/components/axes/ruler.ts
+++ b/packages/core/src/components/axes/ruler.ts
@@ -1,5 +1,6 @@
 import { Selection, pointer } from 'd3'
-import { debounceWithD3MousePosition, getProperty, isEqual } from '@/tools'
+import { isEqual } from 'lodash-es'
+import { debounceWithD3MousePosition, getProperty } from '@/tools'
 import { Component } from '@/components/component'
 import { DOMUtils } from '@/services/essentials/dom-utils'
 import { CartesianOrientations, Events, RenderTypes } from '@/interfaces/enums'

--- a/packages/core/src/components/axes/zoom-bar.ts
+++ b/packages/core/src/components/axes/zoom-bar.ts
@@ -1,5 +1,6 @@
+import { cloneDeep } from "lodash-es";
 import { area, brushX, extent, line } from 'd3'
-import { clone, getProperty, isEmpty, merge } from '@/tools'
+import { getProperty, isEmpty, merge } from '@/tools'
 import { zoomBar as zoomBarConfigs } from '@/configuration'
 import { Component } from '@/components/component'
 import type { ChartModelCartesian } from '@/model/cartesian-charts'
@@ -500,7 +501,7 @@ export class ZoomBar extends Component {
 		if (!data || data.length < 2) {
 			return
 		}
-		const zoomBarData = clone(data)
+		const zoomBarData = cloneDeep(data)
 
 		const domainIdentifier = this.services.cartesianScales.getDomainIdentifier()
 		const rangeIdentifier = this.services.cartesianScales.getRangeIdentifier()

--- a/packages/core/src/components/axes/zoom-bar.ts
+++ b/packages/core/src/components/axes/zoom-bar.ts
@@ -1,6 +1,6 @@
-import { cloneDeep } from "lodash-es";
+import { cloneDeep, isEmpty, merge } from 'lodash-es'
 import { area, brushX, extent, line } from 'd3'
-import { getProperty, isEmpty, merge } from '@/tools'
+import { getProperty } from '@/tools'
 import { zoomBar as zoomBarConfigs } from '@/configuration'
 import { Component } from '@/components/component'
 import type { ChartModelCartesian } from '@/model/cartesian-charts'

--- a/packages/core/src/components/component.ts
+++ b/packages/core/src/components/component.ts
@@ -1,5 +1,6 @@
 import { select, type Selection as D3Selection } from 'd3'
-import { getProperty, merge } from '@/tools'
+import { merge } from 'lodash-es'
+import { getProperty } from '@/tools'
 import { carbonPrefix } from '@/configuration-non-customizable' // CSS prefix
 import type { ChartModel } from '@/model/model'
 import { DOMUtils } from '@/services/essentials/dom-utils'

--- a/packages/core/src/components/essentials/color-scale-legend.ts
+++ b/packages/core/src/components/essentials/color-scale-legend.ts
@@ -1,5 +1,6 @@
 import { axisBottom, interpolateNumber, quantize, scaleBand, scaleLinear } from 'd3'
-import { getProperty, isEmpty } from '@/tools'
+import { isEmpty } from 'lodash-es'
+import { getProperty } from '@/tools'
 import { legend as legendConfigs } from '@/configuration'
 import { ColorLegendType, Events, RenderTypes } from '@/interfaces/enums'
 import { Legend } from './legend'

--- a/packages/core/src/components/graphs/alluvial.ts
+++ b/packages/core/src/components/graphs/alluvial.ts
@@ -6,7 +6,8 @@ import {
 	sankeyRight,
 	sankeyJustify
 } from 'd3-sankey'
-import { debounce, getProperty, getTransformOffsets } from '@/tools'
+import { debounce } from 'lodash-es'
+import { getProperty, getTransformOffsets } from '@/tools'
 import { alluvial as alluvialConfigs } from '@/configuration'
 import { Component } from '@/components/component'
 import { DOMUtils } from '@/services/essentials/dom-utils'

--- a/packages/core/src/components/graphs/bar-grouped.ts
+++ b/packages/core/src/components/graphs/bar-grouped.ts
@@ -1,5 +1,6 @@
 import { ScaleBand, scaleBand, select } from 'd3'
-import { generateSVGPathString, getProperty, uniq } from '@/tools'
+import { uniq } from 'lodash-es'
+import { generateSVGPathString, getProperty } from '@/tools'
 import { Bar } from './bar'
 import {
 	CartesianOrientations,

--- a/packages/core/src/components/graphs/bar-grouped.ts
+++ b/packages/core/src/components/graphs/bar-grouped.ts
@@ -1,5 +1,5 @@
 import { ScaleBand, scaleBand, select } from 'd3'
-import { generateSVGPathString, getProperty, removeArrayDuplicates } from '@/tools'
+import { generateSVGPathString, getProperty, uniq } from '@/tools'
 import { Bar } from './bar'
 import {
 	CartesianOrientations,
@@ -42,7 +42,7 @@ export class GroupedBar extends Bar {
 		// Grab container SVG
 		const svg = this.getComponentContainer({ withinChartClip: true })
 
-		const allDataLabels = removeArrayDuplicates(
+		const allDataLabels = uniq(
 			displayData.map((datum: any) => {
 				const domainIdentifier = this.services.cartesianScales.getDomainIdentifier(datum)
 

--- a/packages/core/src/components/graphs/gauge.ts
+++ b/packages/core/src/components/graphs/gauge.ts
@@ -1,5 +1,6 @@
 import { arc, select } from 'd3'
-import { clamp, getProperty } from '@/tools'
+import { clamp } from 'lodash-es'
+import { getProperty } from '@/tools'
 import { Component } from '@/components/component'
 import { DOMUtils } from '@/services/essentials/dom-utils'
 import {

--- a/packages/core/src/components/graphs/line.ts
+++ b/packages/core/src/components/graphs/line.ts
@@ -1,5 +1,6 @@
 import { line } from 'd3'
-import { flipDomainAndRangeBasedOnOrientation, getProperty, some } from '@/tools'
+import { some } from 'lodash-es'
+import { flipDomainAndRangeBasedOnOrientation, getProperty } from '@/tools'
 import { lines as lineConfigs } from '@/configuration'
 import { Component } from '@/components/component'
 import { Events, ColorClassNameTypes, RenderTypes } from '@/interfaces/enums'

--- a/packages/core/src/components/graphs/radar.ts
+++ b/packages/core/src/components/graphs/radar.ts
@@ -10,7 +10,8 @@ import {
 	type Selection as D3Selection,
 	type Transition
 } from 'd3'
-import { flatMapDeep, getProperty, kebabCase, merge } from '@/tools'
+import { flatMapDeep, kebabCase, merge } from 'lodash-es'
+import { getProperty } from '@/tools'
 import { radar as radarConfigs } from '@/configuration'
 import { Component } from '@/components/component'
 import { DOMUtils } from '@/services/essentials/dom-utils'

--- a/packages/core/src/components/graphs/wordcloud.ts
+++ b/packages/core/src/components/graphs/wordcloud.ts
@@ -1,6 +1,6 @@
 import { extent, scaleLinear, select } from 'd3'
 import cloud from 'd3-cloud'
-import { debounce } from '@/tools'
+import { debounce } from 'lodash-es'
 import { Component } from '@/components/component'
 import { DOMUtils } from '@/services/essentials/dom-utils'
 import { Events, ColorClassNameTypes, RenderTypes } from '@/interfaces/enums'

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -1,6 +1,6 @@
 import { enUS as localeObject } from 'date-fns/locale'
+import { merge } from 'lodash-es'
 import { circlePack } from './configuration-non-customizable'
-import { merge } from './tools'
 import {
 	AlluvialChartOptions,
 	AreaChartOptions,

--- a/packages/core/src/model/cartesian-charts.ts
+++ b/packages/core/src/model/cartesian-charts.ts
@@ -1,6 +1,6 @@
-import { cloneDeep } from "lodash-es";
 import { format } from 'date-fns'
-import { getProperty, uniq } from '@/tools'
+import { cloneDeep, uniq } from 'lodash-es'
+import { getProperty } from '@/tools'
 import { ChartModel } from './model'
 import { ScaleTypes, AxisPositions, AxisFlavor } from '@/interfaces/enums'
 

--- a/packages/core/src/model/cartesian-charts.ts
+++ b/packages/core/src/model/cartesian-charts.ts
@@ -1,6 +1,6 @@
 import { cloneDeep } from "lodash-es";
 import { format } from 'date-fns'
-import { getProperty, removeArrayDuplicates } from '@/tools'
+import { getProperty, uniq } from '@/tools'
 import { ChartModel } from './model'
 import { ScaleTypes, AxisPositions, AxisFlavor } from '@/interfaces/enums'
 
@@ -138,7 +138,7 @@ export class ChartModelCartesian extends ChartModel {
 			const rangeIdentifier = cartesianScales.getRangeIdentifier()
 			// get all dates (Number) in displayData
 			let allDates = sanitizedData.map((datum: any) => datum[domainIdentifier].getTime())
-			allDates = removeArrayDuplicates(allDates).sort()
+			allDates = uniq(allDates).sort()
 
 			// Go through all date values
 			// And get corresponding data from each dataset

--- a/packages/core/src/model/cartesian-charts.ts
+++ b/packages/core/src/model/cartesian-charts.ts
@@ -1,5 +1,6 @@
+import { cloneDeep } from "lodash-es";
 import { format } from 'date-fns'
-import { clone, getProperty, removeArrayDuplicates } from '@/tools'
+import { getProperty, removeArrayDuplicates } from '@/tools'
 import { ChartModel } from './model'
 import { ScaleTypes, AxisPositions, AxisFlavor } from '@/interfaces/enums'
 
@@ -126,7 +127,7 @@ export class ChartModelCartesian extends ChartModel {
 	 */
 	setZoomBarData(newZoomBarData?: any) {
 		const sanitizedData = newZoomBarData
-			? this.sanitize(clone(newZoomBarData))
+			? this.sanitize(cloneDeep(newZoomBarData))
 			: this.getDisplayData() // if we're not passed explicit zoom data use the model
 
 		let zoomBarNormalizedValues = sanitizedData

--- a/packages/core/src/model/choropleth.ts
+++ b/packages/core/src/model/choropleth.ts
@@ -1,6 +1,9 @@
+// External Imports
+import { isEmpty } from 'lodash-es'
+
 // Internal Imports
 import { ChartModel } from './model'
-import { getProperty, isEmpty } from '@/tools'
+import { getProperty } from '@/tools'
 import { getColorScale } from '@/services/color-scale-utils'
 
 /**

--- a/packages/core/src/model/circle-pack.ts
+++ b/packages/core/src/model/circle-pack.ts
@@ -1,4 +1,5 @@
-import { getProperty, merge, updateLegendAdditionalItems } from '@/tools'
+import { merge } from 'lodash-es'
+import { getProperty, updateLegendAdditionalItems } from '@/tools'
 import { ChartModel } from './model'
 import { LegendItemType } from '@/interfaces/enums'
 

--- a/packages/core/src/model/heatmap.ts
+++ b/packages/core/src/model/heatmap.ts
@@ -1,6 +1,6 @@
-import { cloneDeep } from "lodash-es";
 import { extent, scaleQuantize, scaleLinear } from 'd3'
-import { getProperty, isEmpty } from '@/tools'
+import { cloneDeep, isEmpty } from 'lodash-es'
+import { getProperty } from '@/tools'
 import { AxisFlavor, ScaleTypes } from '@/interfaces/enums'
 import { getColorScale } from '@/services'
 import { ChartModelCartesian } from './cartesian-charts'

--- a/packages/core/src/model/heatmap.ts
+++ b/packages/core/src/model/heatmap.ts
@@ -1,5 +1,6 @@
+import { cloneDeep } from "lodash-es";
 import { extent, scaleQuantize, scaleLinear } from 'd3'
-import { clone, getProperty, isEmpty } from '@/tools'
+import { getProperty, isEmpty } from '@/tools'
 import { AxisFlavor, ScaleTypes } from '@/interfaces/enums'
 import { getColorScale } from '@/services'
 import { ChartModelCartesian } from './cartesian-charts'
@@ -163,7 +164,7 @@ export class HeatmapModel extends ChartModelCartesian {
 
 			// Complete the matrix by cloning the column to all domains
 			uniqueDomain.forEach((dom: any) => {
-				this._matrix[dom] = clone(range)
+				this._matrix[dom] = cloneDeep(range)
 			})
 
 			// Fill in user passed data
@@ -183,7 +184,7 @@ export class HeatmapModel extends ChartModelCartesian {
 	 * @param newData The new raw data to be set
 	 */
 	setData(newData: any) {
-		const sanitizedData = this.sanitize(clone(newData))
+		const sanitizedData = this.sanitize(cloneDeep(newData))
 		const dataGroups = this.generateDataGroups(sanitizedData)
 
 		this.set({

--- a/packages/core/src/model/model.ts
+++ b/packages/core/src/model/model.ts
@@ -5,7 +5,7 @@ import {
 	getProperty,
 	groupBy,
 	merge,
-	removeArrayDuplicates,
+	uniq,
 	updateLegendAdditionalItems
 } from '@/tools'
 import { color as colorConfigs, legend as legendConfigs } from '@/configuration'
@@ -294,7 +294,7 @@ export class ChartModel {
 		if (bins) {
 			stackKeys = bins.map((bin: any) => `${bin.x0}-${bin.x1}`)
 		} else {
-			stackKeys = removeArrayDuplicates(
+			stackKeys = uniq(
 				displayData.map((datum: any) => {
 					const domainIdentifier = this.services.cartesianScales.getDomainIdentifier(datum)
 
@@ -734,7 +734,7 @@ export class ChartModel {
 		const { ACTIVE, DISABLED } = legendConfigs.items.status
 		const options = this.getOptions()
 
-		const uniqueDataGroups = removeArrayDuplicates(data.map((datum: any) => datum[groupMapsTo]))
+		const uniqueDataGroups = uniq(data.map((datum: any) => datum[groupMapsTo]))
 
 		// check if selectedGroups can be applied to chart with current data groups
 		if (options.data.selectedGroups.length) {

--- a/packages/core/src/model/model.ts
+++ b/packages/core/src/model/model.ts
@@ -1,6 +1,6 @@
 import { bin as d3Bin, scaleOrdinal, stack, stackOffsetDiverging } from 'd3'
+import { cloneDeep } from "lodash-es";
 import {
-	clone,
 	fromPairs,
 	getProperty,
 	groupBy,
@@ -133,7 +133,7 @@ export class ChartModel {
 	 * @param newData The new raw data to be set
 	 */
 	setData(newData: any) {
-		const sanitizedData = this.sanitize(clone(newData))
+		const sanitizedData = this.sanitize(cloneDeep(newData))
 		const dataGroups = this.generateDataGroups(sanitizedData)
 
 		this.set({
@@ -545,7 +545,7 @@ export class ChartModel {
 	 * Should the data point be filled?
 	 * @param group
 	 * @param key
-	 * @param value
+	 * @param data
 	 * @param defaultFilled the default for this chart
 	 */
 	getIsFilled(group: any, key?: any, data?: any, defaultFilled?: boolean) {

--- a/packages/core/src/model/model.ts
+++ b/packages/core/src/model/model.ts
@@ -1,13 +1,12 @@
 import { bin as d3Bin, scaleOrdinal, stack, stackOffsetDiverging } from 'd3'
-import { cloneDeep } from "lodash-es";
 import {
+	cloneDeep,
 	fromPairs,
-	getProperty,
 	groupBy,
 	merge,
 	uniq,
-	updateLegendAdditionalItems
-} from '@/tools'
+} from 'lodash-es'
+import { getProperty, updateLegendAdditionalItems } from '@/tools'
 import { color as colorConfigs, legend as legendConfigs } from '@/configuration'
 import { histogram as histogramConfigs } from '@/configuration-non-customizable'
 import { Events, ScaleTypes, ColorClassNameTypes } from '@/interfaces/enums'

--- a/packages/core/src/services/color-scale-utils.ts
+++ b/packages/core/src/services/color-scale-utils.ts
@@ -1,5 +1,6 @@
 import { extent, scaleLinear, scaleQuantize } from 'd3'
-import { getProperty, isEmpty } from '@/tools'
+import { isEmpty } from 'lodash-es'
+import { getProperty } from '@/tools'
 
 export function getDomain(data: any) {
 	const limits = extent(data, (d: any) => d.value)

--- a/packages/core/src/services/essentials/dom-utils.ts
+++ b/packages/core/src/services/essentials/dom-utils.ts
@@ -1,6 +1,7 @@
 import { select, type Selection } from 'd3'
 import { toPng, toJpeg } from 'html-to-image'
-import { debounce, getProperty } from '@/tools'
+import { debounce } from 'lodash-es'
+import { getProperty } from '@/tools'
 import { carbonPrefix } from '@/configuration-non-customizable' // CSS prefix
 import type { ChartModel } from '@/model/model'
 import { Service } from '@/services/service'

--- a/packages/core/src/services/scales-cartesian.ts
+++ b/packages/core/src/services/scales-cartesian.ts
@@ -19,7 +19,8 @@ import {
 	subSeconds,
 	addSeconds
 } from 'date-fns'
-import { flatten, getProperty, uniq } from '@/tools'
+import { flatten, uniq } from 'lodash-es'
+import { getProperty } from '@/tools'
 import { axis as axisConfigs } from '@/configuration'
 import { Service } from './service'
 import { AxisPositions, CartesianOrientations, ScaleTypes } from '@/interfaces/enums'

--- a/packages/core/src/services/scales-cartesian.ts
+++ b/packages/core/src/services/scales-cartesian.ts
@@ -19,7 +19,7 @@ import {
 	subSeconds,
 	addSeconds
 } from 'date-fns'
-import { flatten, getProperty, removeArrayDuplicates } from '@/tools'
+import { flatten, getProperty, uniq } from '@/tools'
 import { axis as axisConfigs } from '@/configuration'
 import { Service } from './service'
 import { AxisPositions, CartesianOrientations, ScaleTypes } from '@/interfaces/enums'
@@ -496,7 +496,7 @@ export class CartesianScales extends Service {
 		// If scale is a LABELS scale, return some labels as the domain
 		if (axisOptions && scaleType === ScaleTypes.LABELS) {
 			// Get unique values
-			return removeArrayDuplicates(displayData.map((d: any) => d[mapsTo]))
+			return uniq(displayData.map((d: any) => d[mapsTo]))
 		}
 
 		// Get the extent of the domain

--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -1,41 +1,11 @@
 import { pointer, type Numeric } from 'd3'
 import {
-	debounce,
 	merge,
 	cloneDeep,
 	unionBy,
-	uniq,
-	clamp,
-	flatten,
-	groupBy,
-	camelCase,
-	isEmpty,
-	isEqual,
-	flatMapDeep,
-	kebabCase,
-	fromPairs,
-	some
 } from 'lodash-es'
 import { CartesianOrientations, ScaleTypes, TruncationTypes } from '@/interfaces/enums'
 import { defaultLegendAdditionalItems } from './configuration-non-customizable'
-
-// lodash-es functions to export
-export {
-	debounce,
-	merge,
-	unionBy,
-	clamp,
-	flatten,
-	groupBy,
-	camelCase,
-	isEmpty,
-	isEqual,
-	flatMapDeep,
-	kebabCase,
-	fromPairs,
-	some,
-	uniq
-}
 
 export function debounceWithD3MousePosition(fn: any, delay: number, holder: any) {
 	let timer: any = null

--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -33,9 +33,9 @@ export {
 	flatMapDeep,
 	kebabCase,
 	fromPairs,
-	some
+	some,
+	uniq
 }
-export const removeArrayDuplicates = uniq
 
 export function debounceWithD3MousePosition(fn: any, delay: number, holder: any) {
 	let timer: any = null

--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -35,7 +35,6 @@ export {
 	fromPairs,
 	some
 }
-export const clone = cloneDeep
 export const removeArrayDuplicates = uniq
 
 export function debounceWithD3MousePosition(fn: any, delay: number, holder: any) {
@@ -66,7 +65,7 @@ export function debounceWithD3MousePosition(fn: any, delay: number, holder: any)
  * @returns merged options
  */
 export function mergeDefaultChartOptions(defaultOptions: any, providedOptions: any) {
-	const clonedDefaultOptions = clone(defaultOptions)
+	const clonedDefaultOptions = cloneDeep(defaultOptions)
 	const providedAxesNames = Object.keys(providedOptions.axes || {})
 
 	// Use provide controls list if it exists
@@ -132,9 +131,9 @@ export function getDimensions(el: any) {
 }
 
 /**
- * Gets elements's x and y translations from transform attribute or returns null
+ * Gets elements' x and y translations from transform attribute or returns null
  *
- * @param {HTMLElement} element
+ * @param {HTMLElement} elementRef
  * @returns an object containing the translated x and y values or null
  */
 export function getTranslationValues(elementRef: HTMLElement) {
@@ -215,7 +214,7 @@ export function formatWidthHeightValues(value: string | number) {
  * Capitalizes first letter of a string
  *
  * @export
- * @param {any} string the input string to perform first letter capitalization with
+ * @param {any} word the input string to perform first letter capitalization with
  * @returns The transformed string after first letter is capitalized
  */
 export function capitalizeFirstLetter(word: string) {
@@ -326,7 +325,7 @@ export function arrayDifferences(oldArray: any[], newArray: any[]) {
  * Gets the duplicated keys from an array of data
  *
  * @export
- * @param {*} data - array of data
+ * @param {*} arr - array of data
  * @returns A list of the duplicated keys in data
  */
 export function getDuplicateValues(arr: any) {


### PR DESCRIPTION
Second part of refactor to make lodash-imports friendly to tree shaking.

I don't see any reason for tools.ts to re-export the lodash methods.  It makes tree shaking more difficult and it also gives other code two ways to import the lodash methods, which could lead to inconsistency (ex: ruler-binned.ts).

This mainly changes where methods are imported from, but it also reverts clone() to its original name cloneDeep(), and reverts removeArrayDuplicates() to its original name uniq().

Fixes #1507.
