### PR TITLE
chore(svelte): use CODEOWNERS for support

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,3 @@
 * @theiliad @Akshat55 @carbon-design-system/carbon-charts
+
+/packages/svelte @nstuyvesant @metonym

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -6,12 +6,6 @@ Carbon Charts Svelte is a thin Svelte wrapper around the vanilla JavaScript `@ca
 
 **[Storybook demo sources](https://github.com/carbon-design-system/carbon-charts/tree/master/packages/core/demo/data)**
 
-## Maintenance & support
-
-These Svelte wrappers were developed by Eric Liu.
-
-Please direct all questions regarding support, bug fixes and feature requests to [@metonym](https://github.com/metonym).
-
 ## Getting started
 
 Run the following command using [npm](https://www.npmjs.com/):


### PR DESCRIPTION
I propose replacing the "Maintenance & support" section in the Svelte README with a section in CODEOWNERS for `/packages/svelte`.

I also nominate @nstuyvesant as the primary maintainer for the Svelte charts (if `@nstuyvesant` is up for it).