### PR TITLE
fix(lerna version): hoist prettier-plugin-svelte due to lerna bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "lerna": "^7.1.4",
     "pinst": "^3.0.0",
     "prettier": "^3.0.0",
-    "prettier-config-carbon": "^0.11.0"
+    "prettier-config-carbon": "^0.11.0",
+    "prettier-plugin-svelte": "^3.0.0"
   },
   "husky": {
     "hooks": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2447,6 +2447,7 @@ __metadata:
     pinst: ^3.0.0
     prettier: ^3.0.0
     prettier-config-carbon: ^0.11.0
+    prettier-plugin-svelte: ^3.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Updates
- lerna version has some checks for prettier for some unknown reason. One of those checks is to look for `prettier-plugin-svelte` in the top-level node_modules. But it normally resides in packages/svelte/node_modules. This update adds it as a devDependency to the top-level package.json to force it to be hoisted.
- [An issue](https://github.com/lerna/lerna/issues/3788) has been opened on Lerna's GitHub to get the problem corrected.