### PR TITLE
fix(lerna): lerna version doesn't know we are sharing eslintignore file

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,17 @@
+# Root-level only
+.git
+.yarn
+pages
+yarn.lock
+
+# All packages
+**/.angular
+**/.DS_Store
+**/.svelte-kit
+**/dist
+**/demo/bundle
+**/node_modules
+**/LICENSE.md
+
+# Prettier (which shares this config) totally messess up Storybook MDX files right now
+*.mdx

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
   "prettier.configPath": "prettier.config.cjs",
-  "prettier.ignorePath": ".eslintignore",
+  "prettier.ignorePath": ".prettierignore",
   "prettier.prettierPath": ""
 }


### PR DESCRIPTION
### Updates
- `lerna version` for some unknown reason messes with prettier. Because prettier's ignore is set in .vscode/settings.json (and points to eslint's ignore file), it tries to parse yarn.lock. This PR creates a prettier ignore file that is identical to the eslint ignore file so lerna knows not to parse yarn.lock.

