### PR TITLE
fix(core/scss): Replace hard-coded font-family set by mixin to CSS custom properties then reuse

### DIFF
--- a/packages/core/scss/_type.scss
+++ b/packages/core/scss/_type.scss
@@ -3,7 +3,11 @@
 @use '@carbon/layout' as *;
 
 .#{$prefix}--#{$charts-prefix}--chart-wrapper {
-	font-family: font-family('sans-condensed');
+	// Set CSS custom properties using font-family mixin then reuse them
+	--#{$charts-prefix}-font-family: #{font-family('sans')};
+	--#{$charts-prefix}-font-family-condensed: #{font-family('sans-condensed')};
+
+	font-family: var(--#{$charts-prefix}-font-family-condensed);
 
 	p {
 		padding: 0;
@@ -24,7 +28,7 @@
 	}
 
 	g.gauge-numbers text.gauge-value-number {
-		font-family: font-family('sans');
+		font-family: var(--#{$charts-prefix}-font-family);
 		// TODO-V11
 		// font-weight: font-weight('light');
 		font-weight: 300;
@@ -33,7 +37,7 @@
 	text.meter-title,
 	text.percent-value {
 		font-size: $base-font-size;
-		font-family: font-family('sans');
+		font-family: var(--#{$charts-prefix}-font-family);
 	}
 
 	text.meter-title {

--- a/packages/core/scss/components/_axis.scss
+++ b/packages/core/scss/components/_axis.scss
@@ -30,7 +30,7 @@
 
 		g.tick text {
 			fill: $text-secondary;
-			font-family: font-family('sans-condensed');
+			font-family: var(--#{$charts-prefix}-font-family-condensed);
 		}
 
 		g.tick line {
@@ -42,7 +42,7 @@
 		}
 
 		.axis-title {
-			font-family: font-family('sans');
+			font-family: var(--#{$charts-prefix}-font-family);
 			// TODO-V11
 			// font-weight: font-weight('semibold');
 			font-weight: 600;

--- a/packages/core/scss/components/_threshold.scss
+++ b/packages/core/scss/components/_threshold.scss
@@ -37,7 +37,7 @@
 	position: absolute;
 	word-wrap: break-word;
 	z-index: 1059;
-	font-family: font-family('sans-condensed');
+	font-family: var(--#{$charts-prefix}-font-family-condensed);
 
 	color: $text-primary;
 	line-height: 16px;

--- a/packages/core/scss/components/_title.scss
+++ b/packages/core/scss/components/_title.scss
@@ -5,7 +5,7 @@
 	p.title {
 		color: $text-primary;
 		font-size: 16px;
-		font-family: font-family('sans');
+		font-family: var(--#{$charts-prefix}-font-family);
 		// TODO-V11
 		// font-weight: font-weight('semibold');
 		font-weight: 600;

--- a/packages/core/scss/components/_tooltip.scss
+++ b/packages/core/scss/components/_tooltip.scss
@@ -12,7 +12,7 @@
 	position: absolute;
 	word-wrap: break-word;
 	z-index: 1059;
-	font-family: font-family('sans-condensed');
+	font-family: var(--#{$charts-prefix}-font-family-condensed);
 	transition: visibility 0s linear 0.1s, opacity 0.1s;
 
 	&.hidden {

--- a/packages/core/scss/components/diagrams/_card-node.scss
+++ b/packages/core/scss/components/diagrams/_card-node.scss
@@ -21,7 +21,7 @@
 		background-color: $layer-01;
 		z-index: 1;
 		box-sizing: border-box;
-		font-family: font-family('sans');
+		font-family: var(--#{$charts-prefix}-font-family);
 		width: 100%;
 		height: 100%;
 		padding: $spacing-05 $spacing-03;
@@ -39,7 +39,7 @@
 	}
 
 	.#{$prefix}--#{$charts-prefix}--card-node--button {
-		font-family: font-family('sans');
+		font-family: var(--#{$charts-prefix}-font-family);
 		text-align: left;
 		width: 100%;
 	}

--- a/packages/core/scss/components/diagrams/_shape-node.scss
+++ b/packages/core/scss/components/diagrams/_shape-node.scss
@@ -10,7 +10,7 @@
 		align-items: center;
 		background-color: $layer-01;
 		box-sizing: border-box;
-		font-family: font-family('sans');
+		font-family: var(--#{$charts-prefix}-font-family);
 		width: 100%;
 		height: 100%;
 		position: relative;
@@ -37,7 +37,7 @@
 	}
 
 	.#{$prefix}--#{$charts-prefix}--shape-node--button {
-		font-family: font-family('sans');
+		font-family: var(--#{$charts-prefix}-font-family);
 		text-align: left;
 		width: 100%;
 	}


### PR DESCRIPTION
### Updates
- In the generated styles.css file, 12 selectors had hard-coded font-families for two font faces. This seemed to be unintentional as CSS custom properties are used elsewhere. Restyling required users to explicitly restyle all 12 selectors just to change the font.
- Nothing changes with the look-and-feel of the fonts (still use IBM Plex Sans and IBM Plex Sans Condensed) but now a custom CSS property assignment like this can propagate to axes, tooltips, etc.
```scss
.cds--cc--chart-wrapper {
  --cc-font-family: Verdana;
  --cc-font-family-condensed: 'DIN Condensed';
}
```
- Closes https://github.com/carbon-design-system/carbon-charts/issues/1638

