### PR TITLE
Fix vite error with Vue3 caused by package.json exports lacking a "." property (issue 1641)

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -8,7 +8,11 @@
   "exports": {
     "./styles.min.css": "./dist/styles.min.css",
     "./styles.css": "./dist/styles.css",
-    "./*": "./*"
+    ".": {
+      "style": "./dist/styles.css",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.mjs"
+    }
   },
   "files": [
     "dist",


### PR DESCRIPTION
### Updates
- When using `@carbon/charts-vue` in an environment with vite, an error would be displayed because the package did not an export like this:
```json
    ".": {
      "style": "./dist/styles.css",
      "types": "./dist/index.d.ts",
      "default": "./dist/index.mjs"
    }
```

Closes https://github.com/carbon-design-system/carbon-charts/discussions/1641