### PR TITLE
fix(1633): use of arrow function lost lexical this

### DIFF
--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -9,7 +9,7 @@ import { defaultLegendAdditionalItems } from './configuration-non-customizable'
 
 export function debounceWithD3MousePosition(fn: any, delay: number, holder: any) {
 	let timer: any = null
-	return (...args: any) => {
+	return function(...args: any) {
 		const context = this
 
 		// Get D3 event here


### PR DESCRIPTION
### Updates
- packages/core/src/tools.ts:debounceWithD3MousePosition():12 returned arrow function where there is no lexical this. Changed to return standard function.
- closes https://github.com/carbon-design-system/carbon-charts/issues/1633
