### PR TITLE
fix(charts-angular): issue 1650 - @carbon/charts-angular 1.8.1 release

### DIFF
--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -1,14 +1,14 @@
 # Carbon Charts - Angular
 
-Carbon Charts Angular is a thin Angular wrapper around the vanilla JavaScript `@carbon/charts` component library. This release is for Angular >= 7 and < 16.
+Carbon Charts Angular is a thin Angular wrapper around the vanilla JavaScript `@carbon/charts` component library. This release is for Angular >= 6 and < 16.
 
-If you need support for Angular 16 or higher please install `@carbon/charts-angular@next`.
+If you need support for Angular 16 or higher, please install `@carbon/charts-angular@next`.
 
 The required styles should be imported from `@carbon/charts-angular/styles.css` and `@carbon/styles/css/styles.css`. Additional documentation is provided in the Storybook demos.
 
 **[Storybook demos](https://carbon-design-system.github.io/carbon-charts/angular)**
 
-**[Storybook demo sources](https://github.com/carbon-design-system/carbon-charts/tree/master/packages/core/demo/data)**
+**[Storybook demo sources](https://github.com/carbon-design-system/carbon-charts/tree/master/packages/angular/src/stories)**
 
 ## Getting started
 

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -15,14 +15,14 @@ The required styles should be imported from `@carbon/charts-angular/styles.css` 
 Run the following command using [npm](https://www.npmjs.com/):
 
 ```bash
-npm install -S @carbon/charts-angular@next @carbon/styles d3 d3-cloud d3-sankey
+npm install -S @carbon/charts-angular@latest @carbon/styles d3 d3-cloud d3-sankey
 ```
 
 If you prefer [Yarn](https://yarnpkg.com/en/), use the following command
 instead:
 
 ```bash
-yarn add @carbon/charts-angular@next @carbon/styles d3 d3-cloud d3-sankey
+yarn add @carbon/charts-angular@latest @carbon/styles d3 d3-cloud d3-sankey
 ```
 
 ## Step-by-step instructions

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -1,4 +1,4 @@
-# Carbon Charts Angular
+# Carbon Charts - Angular
 
 Carbon Charts Angular is a thin Angular wrapper around the vanilla JavaScript `@carbon/charts` component library. This release is for Angular >= 7 and < 16.
 

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -1,55 +1,41 @@
-# Notice
+# Carbon Charts Angular
 
-### This version relies on **Carbon v11**. If you're using Carbon v10, [see the legacy demo site](https://carbon-charts-0x.netlify.app)
+Carbon Charts Angular is a thin Angular wrapper around the vanilla JavaScript `@carbon/charts` component library. This release is for Angular >= 7 and < 16.
 
-## `@carbon/charts-angular`
+If you need support for Angular 16 or higher please install `@carbon/charts-angular@next`.
 
-> Carbon Charting Angular Wrappers
+The required styles should be imported from `@carbon/charts-angular/styles.css` and `@carbon/styles/css/styles.css`. Additional documentation is provided in the Storybook demos.
 
 **[Storybook demos](https://carbon-design-system.github.io/carbon-charts/angular)**
 
 **[Storybook demo sources](https://github.com/carbon-design-system/carbon-charts/tree/master/packages/core/demo/data)**
-
-**[Angular 13 example](https://github.com/nstuyvesant/carbon-charts-angular-13)**
 
 ## Getting started
 
 Run the following command using [npm](https://www.npmjs.com/):
 
 ```bash
-npm install -S @carbon/charts @carbon/charts-angular d3
+npm install -S @carbon/charts-angular@next @carbon/styles d3 d3-cloud d3-sankey
 ```
 
 If you prefer [Yarn](https://yarnpkg.com/en/), use the following command
 instead:
 
 ```bash
-yarn add @carbon/charts @carbon/charts-angular d3
+yarn add @carbon/charts-angular@next @carbon/styles d3 d3-cloud d3-sankey
 ```
-
-**Note:** you'd also need to install `carbon-components` if you're not using a
-bundled version of the library.
 
 ## Step-by-step instructions
 
 Read
-[here](https://carbon-design-system.github.io/carbon-charts/?path=/story/docs-getting-started--angular)
+[Getting Started](https://charts.carbondesignsystem.com/?path=/docs/docs-getting-started-angular--docs)
 
 ## Charting data & options
 
-Although we will definitely introduce new models in the future as we start
-shipping new components such as maps, Data and options follow the same model in
-all charts, with minor exceptions and differences in specific components.
-
-For instance in the case of a donut chart you're able to pass in an additional
-field called `center` in your options configuring the donut center.
+Although new charts will be introduced in the future (such as a choropleth), data and options follow the same model for all charts with minor exceptions. For example, in the case of a donut chart, you're able to pass in an additional field called `center` in your options to configure the donut center.
 
 For instructions on using the **tabular data format**, see
-[here](https://carbon-design-system.github.io/carbon-charts/?path=/story/docs-tutorials--tabular-data-format)
-
-There are also additional options available depending on the chart type being
-used,
-[see our demo examples here](https://github.com/carbon-design-system/carbon-charts/tree/master/packages/core/demo/data).
+[here](https://charts.carbondesignsystem.com/angular/?path=/docs/docs-tutorials-tabular-data-format--docs)
 
 Customizable options (specific to chart type) can be found
-[here](https://carbon-design-system.github.io/carbon-charts/documentation/modules/_interfaces_charts_.html)
+[here](https://charts.carbondesignsystem.com/documentation/modules/interfaces.html)

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/charts-angular",
-  "version": "1.8.0",
-  "description": "Carbon charting components for Angular",
+  "version": "1.8.1",
+  "description": "Carbon Charts component library for Angular",
   "main": "index.js",
   "scripts": {
     "build": "bash build.sh",
@@ -41,7 +41,7 @@
     "scss"
   ],
   "dependencies": {
-    "@carbon/charts": "^1.8.0",
+    "@carbon/charts": "~1.8.0",
     "@carbon/telemetry": "0.1.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## What problem does this solve?
- Fixes https://github.com/carbon-design-system/carbon-charts/issues/1650
- For version 1.8.0 of `@carbon/charts-angular`, the dependency on `@carbon/charts` was `^1.8.0`. Many changes were introduced in `1.9.0` and later that were not designed for `@carbon/charts-angular` 1.8.0. This PR updates the package.json  so the core dependency is now `~1.8.0` to keep it from installing an incompatible version.
- Also, the README.md has been updated to let users know about where to get support for Angular 16 and newer using the dist tag `next`.

### To release to npmjs.com...
- [ ] Merge to branch 1.8.0
- [ ] Rename branch to `charts-angular-latest`
- [ ] Locally, `git fetch origin` and `git checkout origin/charts-angular-latest`
- [ ] `cd packages/angular`
- [ ] Switch to node 14 (you might have to delete the package's local node_modules directory before running the next step.
- [ ] `yarn install`
- [ ] `yarn build` to update the dist folder
- [ ] `cd dist`
- [ ]  `npm publish —access public —tag latest`

Only `@carbon/charts-angular@1.8.1` will be published.