### PR TITLE
fix(legend-#1529):Legend truncation value has no effect on tooltip display and issue with length of legend and its truncation

### DIFF
--- a/packages/core/src/components/essentials/legend.ts
+++ b/packages/core/src/components/essentials/legend.ts
@@ -335,7 +335,7 @@ export class Legend extends Component {
 		// truncate the legend label if it's too long
 		if (truncationType !== TruncationTypes.NONE) {
 			addedLegendItemsText.html(function (d: any) {
-				if (d.name.length > truncationThreshold) {
+				if (d.name.length > truncationThreshold && d.name.length !== truncationNumCharacter) {
 					return truncateLabel(d.name, truncationType, truncationNumCharacter)
 				} else {
 					return d.name
@@ -367,7 +367,7 @@ export class Legend extends Component {
 				const hoveredItemData = hoveredItem.datum() as any
 				if (
 					hoveredItemData.name.length > truncation.threshold &&
-					truncation.numCharacter <= hoveredItemData.name.length &&
+					truncation.numCharacter < hoveredItemData.name.length &&
 					truncation.type !== TruncationTypes.NONE
 				) {
 					self.services.events.dispatchEvent(Events.Tooltip.SHOW, {

--- a/packages/core/src/components/essentials/legend.ts
+++ b/packages/core/src/components/essentials/legend.ts
@@ -17,8 +17,8 @@ export class Legend extends Component {
 	renderType = RenderTypes.HTML
 
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+	// @ts-ignore
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	render(animate = false) {
 		const options = this.getOptions()
 		const legendOptions = getProperty(options, 'legend')
@@ -367,6 +367,7 @@ export class Legend extends Component {
 				const hoveredItemData = hoveredItem.datum() as any
 				if (
 					hoveredItemData.name.length > truncation.threshold &&
+					truncation.numCharacter <= hoveredItemData.name.length &&
 					truncation.type !== TruncationTypes.NONE
 				) {
 					self.services.events.dispatchEvent(Events.Tooltip.SHOW, {


### PR DESCRIPTION
### Updates
-[#1529](https://github.com/carbon-design-system/carbon-charts/issues/1529)
-Tooltip will only be displayed for truncated legends.
-Length of legend will be taken into consideration while truncation of legend


### Demo screenshot or recording
![image](https://github.com/carbon-design-system/carbon-charts/assets/76566868/f26262ea-87c8-48ec-a8aa-2635e07c1253)

