### PR TITLE
fix(model-csvFile-#1468):time level precision not availabe in date

### DIFF
--- a/packages/core/src/model/cartesian-charts.ts
+++ b/packages/core/src/model/cartesian-charts.ts
@@ -50,9 +50,9 @@ export class ChartModelCartesian extends ChartModel {
 		return scales
 	}
 
-	dateFormatter(value: any) {
+	modelDateFormatter(value: any) {
 		const options = this.getOptions()
-		const valueFormatter = getProperty(options, 'dateFormatter')
+		const valueFormatter = getProperty(options, 'model', 'dateFormatter')
 
 		if (valueFormatter) {
 			return valueFormatter(value)
@@ -86,7 +86,7 @@ export class ChartModelCartesian extends ChartModel {
 		const domainScaleType = cartesianScales.getDomainAxisScaleType()
 		let domainValueFormatter: any
 		if (domainScaleType === ScaleTypes.TIME) {
-			domainValueFormatter = (d: any) => this.dateFormatter(d)
+			domainValueFormatter = (d: any) => this.modelDateFormatter(d)
 		}
 
 		const result = [


### PR DESCRIPTION
### Updates
- #1468 
-Addition of dateFormatter under model property in options object.
-User is now able to format date as per need.
-Changes will be reflected in the subsequent CSV file.

### Demo screenshot or recording
<img width="1728" alt="image" src="https://github.com/carbon-design-system/carbon-charts/assets/76566868/63452708-a458-41af-a566-51e03b326a28">

