### PR TITLE
Accessibility toolbar btn #1560

### DIFF
--- a/packages/core/src/components/axes/toolbar.ts
+++ b/packages/core/src/components/axes/toolbar.ts
@@ -77,7 +77,6 @@ export class Toolbar extends Component {
 				.enter()
 				.append('div')
 				.attr('class', 'toolbar-control cds--overflow-menu cds--overflow-menu')
-				.attr('role', 'button')
 
 			const self = this
 			enteringToolbarControls

--- a/packages/core/src/components/axes/toolbar.ts
+++ b/packages/core/src/components/axes/toolbar.ts
@@ -32,9 +32,9 @@ export class Toolbar extends Component {
 		})
 	}
 
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	render(animate = true) {
 		const container = this.getComponentContainer()
 			.attr('role', 'toolbar')


### PR DESCRIPTION
### Updates
- [#1560](https://github.com/carbon-design-system/carbon-charts/issues/1560)
-Chart toolbar buttons were enclosed in div with a role of button
-Issue fixed by removing said role

### Demo screenshot or recording
<img width="773" alt="image" src="https://github.com/carbon-design-system/carbon-charts/assets/76566868/b6c54fae-3407-4067-92f2-39e1d5d1d7d2">
