### PR TITLE
Updated getting started example to fix typo and remove missing style.css

### DIFF
--- a/packages/svelte/src/stories/svelte.stories.mdx
+++ b/packages/svelte/src/stories/svelte.stories.mdx
@@ -20,17 +20,17 @@ npm install --save @carbon/charts-svelte d3 d3-cloud d3-sankey
 ```
 
 ## Getting started
-To start using the `StackedBarChart` component, try the example below:
+To start using the `DonutChart` component, try the example below:
 
 ```tsx
 <script lang="ts">
-  import { DonutChart, DonutChartOptions } from '@carbon/charts-svelte'
-  import '@carbon/styles/css/styles.css' // may affect global styles
+  import { DonutChart } from '@carbon/charts-svelte'
   import '@carbon/charts-svelte/styles.css'
-  import { data, options } from '../../stores'
+  import options from './options.js'
+  import data from './data.js'
 </script>
 
-<DonutChart {data} {options}/>
+<DonutChart {data} {options} />
 ```
 
 ## Data


### PR DESCRIPTION
First time stepping in here, so please let me know if there is anything I can help with.

I went to the getting started page and ended up at this hello world like example for Svelte:
https://charts.carbondesignsystem.com/?path=/docs/docs-getting-started-svelte--docs

To quote from that page:

> To start using the `StackedBarChart` component, try the example below:
> ```tsx
> <script lang="ts">
>   import { DonutChart, DonutChartOptions } from '@carbon/charts-svelte'
>   import '@carbon/styles/css/styles.css' // may affect global styles
>   import '@carbon/charts-svelte/styles.css'
>   import { data, options } from '../../stores'
> </script>
> 
> <DonutChart {data} {options}/>
> ```

Which has a few issues. 
 1. The documentation accidentally talks about `StackedBarChart` when the following example is Donut.
 2. I was unable to `import @carbon/styles/css/styles.css`
 3. The import `DonutChartOptions` is not used

Looking around more on the site I found this other tutorial, which all around was much cleaner and works.
https://charts.carbondesignsystem.com/svelte/?path=/story/simple-charts-donut--donut
```tsx
<script lang="ts">
import { DonutChart } from '@carbon/charts-svelte'
import '@carbon/charts-svelte/styles.css'
import options from './options.js'
import data from './data.js'
</script>

<DonutChart {data} {options} style="padding:2rem;" />
```

I propose that `packages/svelte/src/stories/svelte.stories.mdx` should be updated to have the second example.  Hope this helps people getting started. Please let me know if there are any issues.
