### PR TITLE
fix(pieModel) : Unable to view model and export CSV while using valueMapsTo

### DIFF
--- a/packages/core/src/model/pie.ts
+++ b/packages/core/src/model/pie.ts
@@ -28,12 +28,13 @@ export class PieChartModel extends ChartModel {
 		const displayData = this.getDisplayData()
 		const options = this.getOptions()
 		const { groupMapsTo } = options.data
+		const { valueMapsTo } = options.pie
 
 		const result = [
 			['Group', 'Value'],
 			...displayData.map((datum: any) => [
 				datum[groupMapsTo],
-				datum['value'] === null ? '&ndash;' : datum['value'].toLocaleString()
+				datum[valueMapsTo] === null ? '&ndash;' : datum[valueMapsTo].toLocaleString()
 			])
 		]
 


### PR DESCRIPTION
### Updates
- https://github.com/carbon-design-system/carbon-charts/issues/1693
- removal of hardcoded 'value' property in getTabularDataArray
- valueMapsTo will be checked for property name 

### Demo screenshot or recording
<img width="1358" alt="image" src="https://github.com/carbon-design-system/carbon-charts/assets/76566868/4cb47535-bbe8-4758-a662-c6b5eb6dd91d">
