### PR TITLE
docs(svelte): simplify "Event listeners" example

### DIFF
--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -150,7 +150,7 @@ In this example, an event listener is attached to the `BarChartSimple` component
 ```svelte
 <script>
 	import '@carbon/charts-svelte/styles.css'
-	import { onDestroy, onMount } from 'svelte'
+	import { onMount } from 'svelte'
 	import { BarChartSimple } from '@carbon/charts-svelte'
 
 	let chart
@@ -160,16 +160,12 @@ In this example, an event listener is attached to the `BarChartSimple` component
 	}
 
 	onMount(() => {
-		// do something
-	})
+		chart.services.events.addEventListener('bar-mouseover', barMouseOver)
 
-	onDestroy(() => {
-		if (chart) {
-			chart.services.events.removeEventListener('bar-mouseover', barMouseOver)
+		return () => {
+			chart?.services.events.removeEventListener('bar-mouseover', barMouseOver)
 		}
 	})
-
-	$: if (chart) chart.services.events.addEventListener('bar-mouseover', barMouseOver)
 </script>
 
 <BarChartSimple


### PR DESCRIPTION
This PR is a docs suggestion to simplify the "Event listeners" example.

- Use the `return function` in `onMount` instead of `onDestroy
- Use optional chaining operator on `charts`
- Add event listener in `onMount` instead of a reactive statement

I've tested this in my repo: https://github.com/metonym/carbon-charts-svelte-examples

### Updates
- docs(svelte): simplify "Event listeners" example

### Demo screenshot or recording
