### PR TITLE
docs(svelte): add TypeScript reference

### DIFF
--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -211,3 +211,58 @@ Customizable options (specific to chart type) can be found
 ## TypeScript support
 
 Svelte version 3.31 or greater is required to use this library with TypeScript. Svelte 4.x+ is recommended.
+
+### Enums and types
+
+For your convenience, enums and types from `@carbon/charts` are re-exported from
+`@carbon/charts-svelte`.
+
+```ts
+import { ScaleTypes, type BarChartOptions } from '@carbon/charts-svelte'
+
+const options: BarChartOptions = {
+	title: 'Simple bar (discrete)',
+	height: '400px',
+	axes: {
+		left: { mapsTo: 'value' },
+		bottom: {
+			mapsTo: 'group',
+			scaleType: ScaleTypes.LABELS
+		}
+	}
+}
+```
+
+### Component type
+
+Use the `ComponentType` utility type from `svelte` to extract the component type for chart
+components.
+
+```ts
+import { onMount, type ComponentType } from 'svelte'
+import type { BarChartSimple } from '@carbon/charts-svelte'
+
+let component: ComponentType<BarChartSimple> = null
+
+onMount(async () => {
+	component = (await import('@carbon/charts-svelte')).BarChartSimple
+})
+```
+
+### Component props
+
+Use the `ComponentProps` utility type from `svelte` to extract the props for chart components.
+
+You can then use an
+[indexed access type](https://www.typescriptlang.org/docs/handbook/2/indexed-access-types.html) to
+extract types for individual properties.
+
+```ts
+import { type ComponentProps } from 'svelte'
+import { BarChartSimple } from '@carbon/charts-svelte'
+
+type ChartProps = ComponentProps<BarChartSimple>
+
+// Indexed access type to access the type of the `chart` property
+let chart: ChartProps['chart'] = null
+```


### PR DESCRIPTION
This PR proposes bolstering the TypeScript section of the README to include simple examples for reference. These are based on my own experience.

For example, it seeks to answer:

- How can I strongly type options passed to charts?
- How can I type a chart when dynamically importing it?
- How can I get the prop types for a component? A specific property on the type?

### Updates
- docs(svelte): add TypeScript reference

### Demo screenshot or recording
