### PR TITLE
fix(svelte): strongly type dispatched events

### DIFF
--- a/packages/svelte/src/lib/BaseChart.svelte
+++ b/packages/svelte/src/lib/BaseChart.svelte
@@ -14,7 +14,13 @@
 	export let ref: HTMLDivElement | null = null // reference to chart's div so parent can manipulate it
 	export let id = `chart-${Math.random().toString(36)}` // id for chart holder element
 
-	const dispatch = createEventDispatcher()
+	interface DispatchedEvents {
+		load: null
+		update: { data: ChartTabularData; options: ChartOptions }
+		destroy: null
+	}
+
+	const dispatch = createEventDispatcher<DispatchedEvents>()
 
 	onMount(() => {
 		try {


### PR DESCRIPTION
Currently, the TypeScript definitions for Svelte components are auto-generated by `@sveltejs/package`. However, the exact types for the dispatched events use `any`.

For example, they currently look like:

```ts
declare const __propDef: {
    props: {
        [x: string]: any;
        options: BarChartOptions;
        data: ChartTabularData;
        chart?: SimpleBarChartCore | null;
        ref?: HTMLDivElement | null;
    };
    events: {
        load: CustomEvent<any>;
        update: CustomEvent<any>;
        destroy: CustomEvent<any>;
    } & {
        [evt: string]: CustomEvent<any>;
    };
    slots: {};
};
```

The solution is to define the types for dispatched events, and pass it as a type variable to the generic `createEventDispatcher`.

To test this, I ran `yarn build:package` and inspected the generated types:

```ts
declare const __propDef: {
    props: {
        [x: string]: any;
        options: BarChartOptions;
        data: ChartTabularData;
        chart?: SimpleBarChartCore | null;
        ref?: HTMLDivElement | null;
    };
    events: {
        load: CustomEvent<null>;
        update: CustomEvent<{
            data: ChartTabularData;
            options: ChartOptions;
        }>;
        destroy: CustomEvent<null>;
    } & {
        [evt: string]: CustomEvent<any>;
    };
    slots: {};
};
```


### Updates
- fix(svelte): strongly type dispatched events

### Demo screenshot or recording
