### PR TITLE
Bump date-fns, SvelteKit and minor devDependencies, cleanup exports

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -13,7 +13,7 @@ jobs:
         if:
           (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the
           DCO document and I hereby sign the DCO.') || github.event_name == 'pull_request_target'
-        uses: cla-assistant/github-action@v2.2.1
+        uses: contributor-assistant/github-action@v2.3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.DCO_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,15 +12,14 @@ jobs:
 
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_TOKEN }}
 
       - name: Use Node.js 18.19.0
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '18.19.0'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies 🔧
         run: yarn install --immutable --check-cache

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "cz-conventional-changelog": "^3.3.0",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
-    "eslint-plugin-prettier": "^5.1.0",
+    "eslint-plugin-prettier": "^5.1.1",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
     "eslint-plugin-storybook": "^0.6.15",
@@ -66,11 +66,6 @@
     "storybook": "~7.6.6",
     "vite": "^5.0.10",
     "vue": "^3.3.13"
-  },
-  "resolutions": {
-    "@joshwooding/vite-plugin-react-docgen-typescript": "^0.3.1",
-    "@vitejs/plugin-react": "^4.2.1",
-    "vite": "^5.0.8"
   },
   "husky": {
     "hooks": {

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -39,14 +39,14 @@
 		"tslib": "^2.6.2"
 	},
 	"devDependencies": {
-		"@angular-devkit/build-angular": "^16.2.10",
+		"@angular-devkit/build-angular": "^16.2.11",
 		"@angular-eslint/builder": "^16.3.1",
 		"@angular-eslint/eslint-plugin": "^16.3.1",
 		"@angular-eslint/eslint-plugin-template": "^16.3.1",
 		"@angular-eslint/schematics": "^16.3.1",
 		"@angular-eslint/template-parser": "^16.3.1",
 		"@angular/animations": "^16.2.12",
-		"@angular/cli": "^16.2.10",
+		"@angular/cli": "^16.2.11",
 		"@angular/common": "^16.2.12",
 		"@angular/compiler": "^16.2.12",
 		"@angular/compiler-cli": "^16.2.12",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -86,7 +86,7 @@
 		"d3": "^7.8.5",
 		"d3-cloud": "^1.2.7",
 		"d3-sankey": "^0.12.3",
-		"date-fns": "^3.0.1",
+		"date-fns": "^3.0.5",
 		"html-to-image": "^1.11.11",
 		"lodash-es": "^4.17.21",
 		"topojson-client": "^3.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -86,7 +86,7 @@
 		"d3": "^7.8.5",
 		"d3-cloud": "^1.2.7",
 		"d3-sankey": "^0.12.3",
-		"date-fns": "^3.0.5",
+		"date-fns": "^3.0.6",
 		"html-to-image": "^1.11.11",
 		"lodash-es": "^4.17.21",
 		"topojson-client": "^3.1.0",

--- a/packages/react/.storybook/main.ts
+++ b/packages/react/.storybook/main.ts
@@ -39,9 +39,6 @@ const config: StorybookConfig = {
         // }
 			},
 			optimizeDeps: {
-				include: [
-					'@carbon/charts'
-				],
 				exclude: ['@carbon/telemetry']
 			}
 		})

--- a/packages/react/.storybook/main.ts
+++ b/packages/react/.storybook/main.ts
@@ -27,7 +27,7 @@ const config: StorybookConfig = {
 	},
 	async viteFinal(config) {
 		config.plugins = config.plugins!.filter((plugin) => plugin!.name !== 'vite:dts')
-		const newConfig: InlineConfig = mergeConfig(config, {
+		return mergeConfig(config, {
 			build: {
 				chunkSizeWarningLimit: 1800,
 				// Leave commented properties here until Storybook has a solution for this non-blocking error
@@ -42,7 +42,6 @@ const config: StorybookConfig = {
 				exclude: ['@carbon/telemetry']
 			}
 		})
-		return newConfig
 	},
 	features: {
 		storyStoreV7: false // required for storiesOf API

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -3,19 +3,13 @@
 	"version": "1.13.14",
 	"description": "Carbon Charts component library for React",
 	"type": "module",
-	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",
 	"types": "./dist/index.d.ts",
 	"exports": {
 		"./package.json": "./package.json",
 		".": {
 			"types": "./dist/index.d.ts",
-			"browser": {
-				"import": "./dist/index.mjs",
-				"require": "./dist/index.js"
-			},
-			"import": "./dist/index.mjs",
-			"require": "./dist/index.js"
+			"import": "./dist/index.mjs"
 		},
 		"./styles.min.css": "./dist/styles.min.css",
 		"./styles.css": "./dist/styles.css"

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -48,7 +48,7 @@
 	"devDependencies": {
 		"@stackblitz/sdk": "^1.9.0",
 		"@sveltejs/adapter-auto": "^3.0.1",
-		"@sveltejs/kit": "^2.0.4",
+		"@sveltejs/kit": "^2.0.6",
 		"@sveltejs/package": "^2.2.4",
 		"@sveltejs/vite-plugin-svelte": "^3.0.1",
 		"concurrently": "^8.2.2",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -3,7 +3,6 @@
 	"version": "1.13.14",
 	"description": "Carbon Charts component library for Vue",
 	"type": "module",
-	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -54,7 +54,7 @@
 		"typescript": "^5.3.3",
 		"vite": "^5.0.10",
 		"vite-plugin-dts": "^3.6.4",
-		"vue-tsc": "^1.8.25"
+		"vue-tsc": "^1.8.26"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2315,7 +2315,7 @@ __metadata:
     d3: "npm:^7.8.5"
     d3-cloud: "npm:^1.2.7"
     d3-sankey: "npm:^0.12.3"
-    date-fns: "npm:^3.0.1"
+    date-fns: "npm:^3.0.5"
     downlevel-dts: "npm:^0.11.0"
     html-to-image: "npm:^1.11.11"
     jsdom: "npm:^23.0.1"
@@ -10594,10 +10594,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"date-fns@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "date-fns@npm:3.0.1"
-  checksum: d840a0b25ba4c262868df804d1f4939e809326b6fbdacc04f7f5184c2af9891de84ca5620777a98b077fad52777928032bb2cd8cd3a99d22eb1c75220f0aae34
+"date-fns@npm:^3.0.5":
+  version: 3.0.5
+  resolution: "date-fns@npm:3.0.5"
+  checksum: 25667a6810f8e5d31aef59952809ac3be40c7da518752864cca179854d804b9a0d9334f85cce9bf71fe0e43cfda3378db2ed1dd7571f908e6eaeba4237b03466
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2315,7 +2315,7 @@ __metadata:
     d3: "npm:^7.8.5"
     d3-cloud: "npm:^1.2.7"
     d3-sankey: "npm:^0.12.3"
-    date-fns: "npm:^3.0.5"
+    date-fns: "npm:^3.0.6"
     downlevel-dts: "npm:^0.11.0"
     html-to-image: "npm:^1.11.11"
     jsdom: "npm:^23.0.1"
@@ -10609,10 +10609,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"date-fns@npm:^3.0.5":
-  version: 3.0.5
-  resolution: "date-fns@npm:3.0.5"
-  checksum: 25667a6810f8e5d31aef59952809ac3be40c7da518752864cca179854d804b9a0d9334f85cce9bf71fe0e43cfda3378db2ed1dd7571f908e6eaeba4237b03466
+"date-fns@npm:^3.0.6":
+  version: 3.0.6
+  resolution: "date-fns@npm:3.0.6"
+  checksum: ca6ac81aca623fd6d12a43da59cc216e13a75a2eecf7fac692654524fca625e073f5cd36951ef0deac9621ead564eb06b4c3723f77b34e86f21ca3c0c3b32ff7
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,24 +29,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular-devkit/architect@npm:0.1602.10":
-  version: 0.1602.10
-  resolution: "@angular-devkit/architect@npm:0.1602.10"
+"@angular-devkit/architect@npm:0.1602.11":
+  version: 0.1602.11
+  resolution: "@angular-devkit/architect@npm:0.1602.11"
   dependencies:
-    "@angular-devkit/core": "npm:16.2.10"
+    "@angular-devkit/core": "npm:16.2.11"
     rxjs: "npm:7.8.1"
-  checksum: ec10fdf77f5874df16151c77e587a03433a40b34528e905a3a2a86c81a1f2a1994bf2837aed39c8dbcc087b60403c8bb81899ba9f7d603fccfae75ff4abfbc9c
+  checksum: ac7922af2522bf05419a28b979b4007bc2c2096db8db0f0e2dd452e3667e95bd0de419121f65d38de86db17f2352d068a86484d0d312ee6415c83e0c91bb1cb7
   languageName: node
   linkType: hard
 
-"@angular-devkit/build-angular@npm:^16.2.10":
-  version: 16.2.10
-  resolution: "@angular-devkit/build-angular@npm:16.2.10"
+"@angular-devkit/build-angular@npm:^16.2.11":
+  version: 16.2.11
+  resolution: "@angular-devkit/build-angular@npm:16.2.11"
   dependencies:
     "@ampproject/remapping": "npm:2.2.1"
-    "@angular-devkit/architect": "npm:0.1602.10"
-    "@angular-devkit/build-webpack": "npm:0.1602.10"
-    "@angular-devkit/core": "npm:16.2.10"
+    "@angular-devkit/architect": "npm:0.1602.11"
+    "@angular-devkit/build-webpack": "npm:0.1602.11"
+    "@angular-devkit/core": "npm:16.2.11"
     "@babel/core": "npm:7.22.9"
     "@babel/generator": "npm:7.22.9"
     "@babel/helper-annotate-as-pure": "npm:7.22.5"
@@ -58,7 +58,7 @@ __metadata:
     "@babel/runtime": "npm:7.22.6"
     "@babel/template": "npm:7.22.5"
     "@discoveryjs/json-ext": "npm:0.5.7"
-    "@ngtools/webpack": "npm:16.2.10"
+    "@ngtools/webpack": "npm:16.2.11"
     "@vitejs/plugin-basic-ssl": "npm:1.0.1"
     ansi-colors: "npm:4.1.3"
     autoprefixer: "npm:10.4.14"
@@ -102,7 +102,7 @@ __metadata:
     text-table: "npm:0.2.0"
     tree-kill: "npm:1.2.2"
     tslib: "npm:2.6.1"
-    vite: "npm:4.4.7"
+    vite: "npm:4.5.1"
     webpack: "npm:5.88.2"
     webpack-dev-middleware: "npm:6.1.1"
     webpack-dev-server: "npm:4.15.1"
@@ -142,26 +142,26 @@ __metadata:
       optional: true
     tailwindcss:
       optional: true
-  checksum: 7654c61cf9e0458d2391081d27cb2095a4ca2149777abf69f9786d383b7a5a7c8e18f390e5cc5cf6064e0ea56b7dcfa24f3a6c89afd7074fecda5b319617ef38
+  checksum: 53358989e260e78aff6bfb3d99858529bf81297bdc5c92dc8f6102bf9f4ea9a5e33d234d97ae66cb48b5b1b78538a0de43b13c3ab133cfc5583057e0f7dd704f
   languageName: node
   linkType: hard
 
-"@angular-devkit/build-webpack@npm:0.1602.10":
-  version: 0.1602.10
-  resolution: "@angular-devkit/build-webpack@npm:0.1602.10"
+"@angular-devkit/build-webpack@npm:0.1602.11":
+  version: 0.1602.11
+  resolution: "@angular-devkit/build-webpack@npm:0.1602.11"
   dependencies:
-    "@angular-devkit/architect": "npm:0.1602.10"
+    "@angular-devkit/architect": "npm:0.1602.11"
     rxjs: "npm:7.8.1"
   peerDependencies:
     webpack: ^5.30.0
     webpack-dev-server: ^4.0.0
-  checksum: e78fd4bfb0956109490b4a6be61a33c5435a84cf22b462d7b60367c2dc570737875305f7ff9843304a3570c16b02b69a1c69e2c4373ab25957bf9bde82df8e7f
+  checksum: edb73f3a3865bc227a65f8abd06cb2bf91c9b0f2a0feaabeb15eead2aa566f804c79f6087913495ce29faa84cf6954a7ff1a699eec5a5eccf13c8ecc1106a1cd
   languageName: node
   linkType: hard
 
-"@angular-devkit/core@npm:16.2.10":
-  version: 16.2.10
-  resolution: "@angular-devkit/core@npm:16.2.10"
+"@angular-devkit/core@npm:16.2.11":
+  version: 16.2.11
+  resolution: "@angular-devkit/core@npm:16.2.11"
   dependencies:
     ajv: "npm:8.12.0"
     ajv-formats: "npm:2.1.1"
@@ -174,20 +174,20 @@ __metadata:
   peerDependenciesMeta:
     chokidar:
       optional: true
-  checksum: b3252540dde1c248027c9bf532b1024cf1169c4f6b2c6319cd22747db7e3320770031490062ccaae9981f403606c0d229dc6ab78fb11cde74e3633e7fc834e97
+  checksum: 3afec959b4155bce9f05e9fcb9abd46a4bed92d0d751c5901421dffdb77531b6517a27a8cd4a0b39665d9ff8db2837f75b39105b9c597988d4f48792f01d8c7e
   languageName: node
   linkType: hard
 
-"@angular-devkit/schematics@npm:16.2.10":
-  version: 16.2.10
-  resolution: "@angular-devkit/schematics@npm:16.2.10"
+"@angular-devkit/schematics@npm:16.2.11":
+  version: 16.2.11
+  resolution: "@angular-devkit/schematics@npm:16.2.11"
   dependencies:
-    "@angular-devkit/core": "npm:16.2.10"
+    "@angular-devkit/core": "npm:16.2.11"
     jsonc-parser: "npm:3.2.0"
     magic-string: "npm:0.30.1"
     ora: "npm:5.4.1"
     rxjs: "npm:7.8.1"
-  checksum: 47ff66fb24a0dd9e674fbcd644b3bea3a045b10348accbb7ad0b94ebf45d4957675e3b3be8c26fa2c6226431af59fa478516945ef83aa6c2dc8964b2e16146b0
+  checksum: d0ba11cb66569148d520c8f40afb8b829ba35de89dff85436638752e0c26698094b096d69ab9a037897f70ccb27b9a6fce7ce4196d2888ed025e9bc25ef31e5b
   languageName: node
   linkType: hard
 
@@ -295,14 +295,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular/cli@npm:^16.2.10":
-  version: 16.2.10
-  resolution: "@angular/cli@npm:16.2.10"
+"@angular/cli@npm:^16.2.11":
+  version: 16.2.11
+  resolution: "@angular/cli@npm:16.2.11"
   dependencies:
-    "@angular-devkit/architect": "npm:0.1602.10"
-    "@angular-devkit/core": "npm:16.2.10"
-    "@angular-devkit/schematics": "npm:16.2.10"
-    "@schematics/angular": "npm:16.2.10"
+    "@angular-devkit/architect": "npm:0.1602.11"
+    "@angular-devkit/core": "npm:16.2.11"
+    "@angular-devkit/schematics": "npm:16.2.11"
+    "@schematics/angular": "npm:16.2.11"
     "@yarnpkg/lockfile": "npm:1.1.0"
     ansi-colors: "npm:4.1.3"
     ini: "npm:4.1.1"
@@ -319,7 +319,7 @@ __metadata:
     yargs: "npm:17.7.2"
   bin:
     ng: bin/ng.js
-  checksum: fab8d9f00501b92f11e52cf179ff2197d816815f1466228882827a40189eb9b61227df5c499ad61a8e25b9eefa47374ee7e7731691b300eb289c81551acecee0
+  checksum: 8a4603779a7df27aaff442da475a87efd5f78df4cd27a463c5146a4d2956e3c0dd7211d8e62f9bea59a64d0b092cccaecc599500e214deb19aacffdfaba31480
   languageName: node
   linkType: hard
 
@@ -509,7 +509,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3, @babel/core@npm:^7.18.9, @babel/core@npm:^7.23.0, @babel/core@npm:^7.23.2, @babel/core@npm:^7.23.5":
+"@babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3, @babel/core@npm:^7.18.9, @babel/core@npm:^7.20.12, @babel/core@npm:^7.23.0, @babel/core@npm:^7.23.2, @babel/core@npm:^7.23.5":
   version: 7.23.6
   resolution: "@babel/core@npm:7.23.6"
   dependencies:
@@ -1608,7 +1608,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-react-jsx-self@npm:^7.23.3":
+"@babel/plugin-transform-react-jsx-self@npm:^7.18.6, @babel/plugin-transform-react-jsx-self@npm:^7.23.3":
   version: 7.23.3
   resolution: "@babel/plugin-transform-react-jsx-self@npm:7.23.3"
   dependencies:
@@ -1619,7 +1619,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-react-jsx-source@npm:^7.23.3":
+"@babel/plugin-transform-react-jsx-source@npm:^7.19.6, @babel/plugin-transform-react-jsx-source@npm:^7.23.3":
   version: 7.23.3
   resolution: "@babel/plugin-transform-react-jsx-source@npm:7.23.3"
   dependencies:
@@ -2124,14 +2124,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@carbon/charts-angular@workspace:packages/angular"
   dependencies:
-    "@angular-devkit/build-angular": "npm:^16.2.10"
+    "@angular-devkit/build-angular": "npm:^16.2.11"
     "@angular-eslint/builder": "npm:^16.3.1"
     "@angular-eslint/eslint-plugin": "npm:^16.3.1"
     "@angular-eslint/eslint-plugin-template": "npm:^16.3.1"
     "@angular-eslint/schematics": "npm:^16.3.1"
     "@angular-eslint/template-parser": "npm:^16.3.1"
     "@angular/animations": "npm:^16.2.12"
-    "@angular/cli": "npm:^16.2.10"
+    "@angular/cli": "npm:^16.2.11"
     "@angular/common": "npm:^16.2.12"
     "@angular/compiler": "npm:^16.2.12"
     "@angular/compiler-cli": "npm:^16.2.12"
@@ -2189,7 +2189,7 @@ __metadata:
     cz-conventional-changelog: "npm:^3.3.0"
     eslint: "npm:^8.56.0"
     eslint-config-prettier: "npm:^9.1.0"
-    eslint-plugin-prettier: "npm:^5.1.0"
+    eslint-plugin-prettier: "npm:^5.1.1"
     eslint-plugin-react-hooks: "npm:^4.6.0"
     eslint-plugin-react-refresh: "npm:^0.4.5"
     eslint-plugin-storybook: "npm:^0.6.15"
@@ -2248,7 +2248,7 @@ __metadata:
     "@carbon/telemetry": "npm:~0.1.0"
     "@stackblitz/sdk": "npm:^1.9.0"
     "@sveltejs/adapter-auto": "npm:^3.0.1"
-    "@sveltejs/kit": "npm:^2.0.4"
+    "@sveltejs/kit": "npm:^2.0.6"
     "@sveltejs/package": "npm:^2.2.4"
     "@sveltejs/vite-plugin-svelte": "npm:^3.0.1"
     concurrently: "npm:^8.2.2"
@@ -2286,7 +2286,7 @@ __metadata:
     vite: "npm:^5.0.10"
     vite-plugin-dts: "npm:^3.6.4"
     vue: "npm:^3.3.13"
-    vue-tsc: "npm:^1.8.25"
+    vue-tsc: "npm:^1.8.26"
   peerDependencies:
     vue: ^3.3.0
   languageName: unknown
@@ -3285,9 +3285,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@joshwooding/vite-plugin-react-docgen-typescript@npm:^0.3.1":
-  version: 0.3.1
-  resolution: "@joshwooding/vite-plugin-react-docgen-typescript@npm:0.3.1"
+"@joshwooding/vite-plugin-react-docgen-typescript@npm:0.3.0":
+  version: 0.3.0
+  resolution: "@joshwooding/vite-plugin-react-docgen-typescript@npm:0.3.0"
   dependencies:
     glob: "npm:^7.2.0"
     glob-promise: "npm:^4.2.0"
@@ -3299,7 +3299,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: a9c7a03d7d1daf5bd64949255516ba64c88d5600366c8c74dcdb6f37c2a6099daaec02860b7587d2220e61afa47a0b2de17ef70d723c2db02f24e0890edfd9f3
+  checksum: 31098ad8fcc2440437534599c111d9f2951dd74821e8ba46c521b969bae4c918d830b7bb0484efbad29a51711bb62d3bc623d5a1ed5b1695b5b5594ea9dd4ca0
   languageName: node
   linkType: hard
 
@@ -3516,14 +3516,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ngtools/webpack@npm:16.2.10":
-  version: 16.2.10
-  resolution: "@ngtools/webpack@npm:16.2.10"
+"@ngtools/webpack@npm:16.2.11":
+  version: 16.2.11
+  resolution: "@ngtools/webpack@npm:16.2.11"
   peerDependencies:
     "@angular/compiler-cli": ^16.0.0
     typescript: ">=4.9.3 <5.2"
     webpack: ^5.54.0
-  checksum: 74c4296c2b713efb065d506a7681dbcb55a11a7666fd4458d867030ae1fd0b82fec22cfea808390b4543ee720ed691fbe9d767d2a1b92aa196f8c595b0fb9b5d
+  checksum: ddef60f6291e84798feca824708b1aff5200cc2e5ca61c1a069105bbf7089571ca74512cc52b85a71bab3792003e9051a43de0d3b1f0be20ac0035975961f99c
   languageName: node
   linkType: hard
 
@@ -4089,7 +4089,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polka/url@npm:^1.0.0-next.20":
+"@polka/url@npm:^1.0.0-next.24":
   version: 1.0.0-next.24
   resolution: "@polka/url@npm:1.0.0-next.24"
   checksum: 97d98fa911857158514457bedad8c36084c1f608302458f580ab300a25c3abf456d1d54fcf2ea7927464bee0858baf5e8e5b374b95c3375b9eb3784d81411ebd
@@ -4861,14 +4861,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@schematics/angular@npm:16.2.10":
-  version: 16.2.10
-  resolution: "@schematics/angular@npm:16.2.10"
+"@schematics/angular@npm:16.2.11":
+  version: 16.2.11
+  resolution: "@schematics/angular@npm:16.2.11"
   dependencies:
-    "@angular-devkit/core": "npm:16.2.10"
-    "@angular-devkit/schematics": "npm:16.2.10"
+    "@angular-devkit/core": "npm:16.2.11"
+    "@angular-devkit/schematics": "npm:16.2.11"
     jsonc-parser: "npm:3.2.0"
-  checksum: 5e3858191908857c66c2e9cc1938a5eb123ebb074ff3a2602f3171bc302971ad13f73e7a2b60f2670c28552decc6de121792f39c0545cf299bce1543058a82b9
+  checksum: 1a3bb8926e9dcebf3c9855c838d1222d9cc5cfc22f93345bbd127490d0e1e538bcc3e2daa8d0af51ac68b0b6cfc38b7d530b561b96bd709f4ffd7bcc556bd70a
   languageName: node
   linkType: hard
 
@@ -6015,9 +6015,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sveltejs/kit@npm:^2.0.4":
-  version: 2.0.4
-  resolution: "@sveltejs/kit@npm:2.0.4"
+"@sveltejs/kit@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "@sveltejs/kit@npm:2.0.6"
   dependencies:
     "@types/cookie": "npm:^0.6.0"
     cookie: "npm:^0.6.0"
@@ -6025,10 +6025,10 @@ __metadata:
     esm-env: "npm:^1.0.0"
     kleur: "npm:^4.1.5"
     magic-string: "npm:^0.30.5"
-    mrmime: "npm:^1.0.1"
+    mrmime: "npm:^2.0.0"
     sade: "npm:^1.8.1"
     set-cookie-parser: "npm:^2.6.0"
-    sirv: "npm:^2.0.3"
+    sirv: "npm:^2.0.4"
     tiny-glob: "npm:^0.2.9"
   peerDependencies:
     "@sveltejs/vite-plugin-svelte": ^3.0.0
@@ -6036,7 +6036,7 @@ __metadata:
     vite: ^5.0.3
   bin:
     svelte-kit: svelte-kit.js
-  checksum: a71464ebcc82c3b3317e1b7aa130748afafa8371103e07fa2d20253b5b06c6d1e2fd4d8ab1a404cc5fcdf189192a08cea8461a52350819fc8909cbed7ee1b04b
+  checksum: 6bc9a36bc12649c0496c71663b1e10d6146b6d18eb433db7d77b23b040d5e4bfc5bed09ff246a6674c63920e34e297476bb6636e7eefa8120f525415ecb86f47
   languageName: node
   linkType: hard
 
@@ -7114,9 +7114,9 @@ __metadata:
   linkType: hard
 
 "@types/qs@npm:*, @types/qs@npm:^6.9.5":
-  version: 6.9.10
-  resolution: "@types/qs@npm:6.9.10"
-  checksum: 6be12e5f062d1b41eb037d59bf9cb65bc9410cedd5e6da832dfd7c8e2b3f4c91e81c9b90b51811140770e5052c6c4e8361181bd9437ddcd4515dc128b7c00353
+  version: 6.9.11
+  resolution: "@types/qs@npm:6.9.11"
+  checksum: 657a50f05b694d6fd3916d24177cfa0f3b8b87d9deff4ffa4dddcb0b03583ebf7c47b424b8de400270fb9a5cc1e9cf790dd82c833c6935305851e7da8ede3ff5
   languageName: node
   linkType: hard
 
@@ -7566,6 +7566,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vitejs/plugin-react@npm:^3.0.1":
+  version: 3.1.0
+  resolution: "@vitejs/plugin-react@npm:3.1.0"
+  dependencies:
+    "@babel/core": "npm:^7.20.12"
+    "@babel/plugin-transform-react-jsx-self": "npm:^7.18.6"
+    "@babel/plugin-transform-react-jsx-source": "npm:^7.19.6"
+    magic-string: "npm:^0.27.0"
+    react-refresh: "npm:^0.14.0"
+  peerDependencies:
+    vite: ^4.1.0-beta.0
+  checksum: 259a92a303cd736240dc0d3282d1261339e7bbcf51c5b326868c910b35d4bd22a360334b2dafa5bfc7f3e935f2cd0fdc7ccb6ec6b519b81017c4c4812cd05290
+  languageName: node
+  linkType: hard
+
 "@vitejs/plugin-react@npm:^4.2.1":
   version: 4.2.1
   resolution: "@vitejs/plugin-react@npm:4.2.1"
@@ -7784,9 +7799,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/language-core@npm:1.8.25, @vue/language-core@npm:^1.8.20":
-  version: 1.8.25
-  resolution: "@vue/language-core@npm:1.8.25"
+"@vue/language-core@npm:1.8.26, @vue/language-core@npm:^1.8.20":
+  version: 1.8.26
+  resolution: "@vue/language-core@npm:1.8.26"
   dependencies:
     "@volar/language-core": "npm:~1.11.1"
     "@volar/source-map": "npm:~1.11.1"
@@ -7802,7 +7817,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: d0a06e6c30721fe211167e2ed18d490be0c525e7d2c24b6f465209347254a1feb3aa042bcfdbbc16b9c393a5fc8fae0ae517ba15ab68b55f1700d0abe19226f6
+  checksum: b0f783543a640443d605f97028584c2d76a041942116dbc259b7050c2d053fa2600a62b9c6f8217b036113ea2c119f19ed3278624971c158bfd5678715f1e41e
   languageName: node
   linkType: hard
 
@@ -9181,9 +9196,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001464, caniuse-lite@npm:^1.0.30001538, caniuse-lite@npm:^1.0.30001565":
-  version: 1.0.30001570
-  resolution: "caniuse-lite@npm:1.0.30001570"
-  checksum: e47230d2016edea56e002fa462a5289f697b48dcfbf703fb01aecc6c98ad4ecaf945ab23c253cb7af056c2d05f266e4e4cbebf45132100e2c9367439cb95b95b
+  version: 1.0.30001571
+  resolution: "caniuse-lite@npm:1.0.30001571"
+  checksum: 632f476e39febbfb5dc91c236981f3d518dc0cf55c42cc2bba431a6b6f4cceae3f9cd74d26312f30e9de65a3cc92ccf80d964ba8de061e25f37b7f0518303dad
   languageName: node
   linkType: hard
 
@@ -11207,9 +11222,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.4.601":
-  version: 1.4.615
-  resolution: "electron-to-chromium@npm:1.4.615"
-  checksum: 6602172761e44ca1a6c010a010efd0c42710e1e08911e76dd2d3df72ae2a563fb75b0853387273d1e45a4befd314162b2b1debcf9055513f62c6d6a8df4de73a
+  version: 1.4.616
+  resolution: "electron-to-chromium@npm:1.4.616"
+  checksum: a02416f3293d28120d5132546a6aea614ebd2d820a684f41b1c20138331922ddc672c4a59bfc4b91bb5aee1ba608f6c10cd3f69c344cd434397e7f14a4c97348
   languageName: node
   linkType: hard
 
@@ -11505,7 +11520,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.18.0":
+"esbuild@npm:^0.18.0, esbuild@npm:^0.18.10":
   version: 0.18.20
   resolution: "esbuild@npm:0.18.20"
   dependencies:
@@ -11730,9 +11745,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-prettier@npm:^5.0.0, eslint-plugin-prettier@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "eslint-plugin-prettier@npm:5.1.0"
+"eslint-plugin-prettier@npm:^5.0.0, eslint-plugin-prettier@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "eslint-plugin-prettier@npm:5.1.1"
   dependencies:
     prettier-linter-helpers: "npm:^1.0.0"
     synckit: "npm:^0.8.5"
@@ -11746,7 +11761,7 @@ __metadata:
       optional: true
     eslint-config-prettier:
       optional: true
-  checksum: 76b9a6cc5fa8dcc0d5d8aac5e7b717c08c736d2f158ba63709d94526d3152761d36963f930f9c64a29270a107519eca24b41e82b67cc43f0291d43db4a975fd1
+  checksum: cb9fb797e3b872864d9bd4a6154cc0aeccdd9b3d7add510b2077f6d5149fb4b681abd180dacb5dafda603defb6089824a7c6f97faf1f099dba4f4e77f86c46c3
   languageName: node
   linkType: hard
 
@@ -12542,9 +12557,9 @@ __metadata:
   linkType: hard
 
 "flow-parser@npm:0.*":
-  version: 0.225.0
-  resolution: "flow-parser@npm:0.225.0"
-  checksum: cec08182ef5e7887a5e83026e6bceeab575b01c1b57e1809f3bbb9b08d65b7060fc22e34dcf9a667a3efad0e475baaca338461dc1fa67e7668fd3f0c093b71f2
+  version: 0.225.1
+  resolution: "flow-parser@npm:0.225.1"
+  checksum: 6932c209289a6ac86181804bad44a6a394484928a84ee65c380a11a20cea5ac7a2d72dcfc79f9436e4e2851d950ad99a24e4688f0f8f03ac4b45d32b0627c55e
   languageName: node
   linkType: hard
 
@@ -16242,10 +16257,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mrmime@npm:1.0.1, mrmime@npm:^1.0.0, mrmime@npm:^1.0.1":
+"mrmime@npm:1.0.1":
   version: 1.0.1
   resolution: "mrmime@npm:1.0.1"
   checksum: ab071441da76fd23b3b0d1823d77aacf8679d379a4a94cacd83e487d3d906763b277f3203a594c613602e31ab5209c26a8119b0477c4541ef8555b293a9db6d3
+  languageName: node
+  linkType: hard
+
+"mrmime@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mrmime@npm:2.0.0"
+  checksum: 312b35ed288986aec90955410b21ed7427fd1e4ee318cb5fc18765c8d029eeded9444faa46589e5b1ed6b35fb2054a802ac8dcb917ddf6b3e189cb3bf11a965c
   languageName: node
   linkType: hard
 
@@ -16863,11 +16885,11 @@ __metadata:
   linkType: hard
 
 "npm-run-path@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "npm-run-path@npm:5.1.0"
+  version: 5.2.0
+  resolution: "npm-run-path@npm:5.2.0"
   dependencies:
     path-key: "npm:^4.0.0"
-  checksum: ff6d77514489f47fa1c3b1311d09cd4b6d09a874cc1866260f9dea12cbaabda0436ed7f8c2ee44d147bf99a3af29307c6f63b0f83d242b0b6b0ab25dff2629e3
+  checksum: 7963c1f98e42afebe9524a08b0881477ec145aab34f6018842a315422b25ad40e015bdee709b697571e5efda2ecfa2640ee917d92674e4de1166fa3532a211b1
   languageName: node
   linkType: hard
 
@@ -17914,13 +17936,13 @@ __metadata:
   linkType: hard
 
 "postcss-modules-scope@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "postcss-modules-scope@npm:3.0.0"
+  version: 3.1.0
+  resolution: "postcss-modules-scope@npm:3.1.0"
   dependencies:
     postcss-selector-parser: "npm:^6.0.4"
   peerDependencies:
     postcss: ^8.1.0
-  checksum: 60af503910363689568c2c3701cb019a61b58b3d739391145185eec211bea5d50ccb6ecbe6955b39d856088072fd50ea002e40a52b50e33b181ff5c41da0308a
+  checksum: bc8e12e9312d7070f34ccef2929f65154102e2b2984a385eaf2ef25b6d4e22234de71116c240a05b541a79946b717d6fa8c5d314f6697bf05f295261693050fe
   languageName: node
   linkType: hard
 
@@ -17977,7 +17999,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.2.14, postcss@npm:^8.4.16, postcss@npm:^8.4.21, postcss@npm:^8.4.23, postcss@npm:^8.4.32":
+"postcss@npm:^8.2.14, postcss@npm:^8.4.16, postcss@npm:^8.4.21, postcss@npm:^8.4.23, postcss@npm:^8.4.27, postcss@npm:^8.4.32":
   version: 8.4.32
   resolution: "postcss@npm:8.4.32"
   dependencies:
@@ -19217,7 +19239,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup@npm:^2.25.0 || ^3.3.0, rollup@npm:^3.0.0":
+"rollup@npm:^2.25.0 || ^3.3.0, rollup@npm:^3.0.0, rollup@npm:^3.27.1":
   version: 3.29.4
   resolution: "rollup@npm:3.29.4"
   dependencies:
@@ -19780,14 +19802,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sirv@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "sirv@npm:2.0.3"
+"sirv@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "sirv@npm:2.0.4"
   dependencies:
-    "@polka/url": "npm:^1.0.0-next.20"
-    mrmime: "npm:^1.0.0"
+    "@polka/url": "npm:^1.0.0-next.24"
+    mrmime: "npm:^2.0.0"
     totalist: "npm:^3.0.0"
-  checksum: 333bd665ee5ac3805047ea47757e04e2b18ca562749b9a07f5bbbee6dabd99ff00011604689b1ada3d22e46a4198c61e05e2d1abd5454d94da483ce3a3813205
+  checksum: 68f8ee857f6a9415e9c07a1f31c7c561df8d5f1b1ba79bee3de583fa37da8718def5309f6b1c6e2c3ef77de45d74f5e49efc7959214443aa92d42e9c99180a4e
   languageName: node
   linkType: hard
 
@@ -21076,12 +21098,12 @@ __metadata:
   linkType: hard
 
 "typescript@npm:next":
-  version: 5.4.0-dev.20231220
-  resolution: "typescript@npm:5.4.0-dev.20231220"
+  version: 5.4.0-dev.20231221
+  resolution: "typescript@npm:5.4.0-dev.20231221"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 39ed9e3dbfb1ef8dd821653a07cdcc3809795fd48dbd43bb4f8b7e5c4670219d02ac971c1afad8506056d22bf4465026ad621d4af64875b33d49697ffb066be3
+  checksum: 2679f8fe9c57128e2d78ef9f1255cdd6190c0dfa96387980e28ba0cc564295ee8fa53631d947f8affb4126f70fa2320786c7d11df9f2844ee0bcd82cc7538ae3
   languageName: node
   linkType: hard
 
@@ -21106,12 +21128,12 @@ __metadata:
   linkType: hard
 
 "typescript@patch:typescript@npm%3Anext#optional!builtin<compat/typescript>":
-  version: 5.4.0-dev.20231220
-  resolution: "typescript@patch:typescript@npm%3A5.4.0-dev.20231220#optional!builtin<compat/typescript>::version=5.4.0-dev.20231220&hash=e012d7"
+  version: 5.4.0-dev.20231221
+  resolution: "typescript@patch:typescript@npm%3A5.4.0-dev.20231221#optional!builtin<compat/typescript>::version=5.4.0-dev.20231221&hash=e012d7"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: d2f8781d2a8642ce7b7756d830e5a953c4e328590f5aaa9ab052947364b7333efed4d8f17d7d7fd104c66334ea416c0a37c90653ebba9fb051cc7e47513c0da5
+  checksum: 627d3a16be8ac0800093a58112cb896c88d49d778c8744f2135ba7592fcb88f56215800b0284b21ab9adceba601a581ddef29a0924af7345e5fc9500d72871b2
   languageName: node
   linkType: hard
 
@@ -21542,7 +21564,47 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^5.0.8":
+"vite@npm:4.5.1":
+  version: 4.5.1
+  resolution: "vite@npm:4.5.1"
+  dependencies:
+    esbuild: "npm:^0.18.10"
+    fsevents: "npm:~2.3.2"
+    postcss: "npm:^8.4.27"
+    rollup: "npm:^3.27.1"
+  peerDependencies:
+    "@types/node": ">= 14"
+    less: "*"
+    lightningcss: ^1.21.0
+    sass: "*"
+    stylus: "*"
+    sugarss: "*"
+    terser: ^5.4.0
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    less:
+      optional: true
+    lightningcss:
+      optional: true
+    sass:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 352a94b13f793e4bcbc424d680a32507343223eeda8917fde0f23c1fa1ba3db7c806dade8461ca5cfb270154ddb8895a219fdd4384519fe9b8e46d1cf491a890
+  languageName: node
+  linkType: hard
+
+"vite@npm:^5.0.0, vite@npm:^5.0.10":
   version: 5.0.10
   resolution: "vite@npm:5.0.10"
   dependencies:
@@ -21667,9 +21729,9 @@ __metadata:
   linkType: hard
 
 "vue-component-type-helpers@npm:latest":
-  version: 1.8.25
-  resolution: "vue-component-type-helpers@npm:1.8.25"
-  checksum: a81704568d6d25c424036ad5fd77c6c5402e090977f6fdcea3b719bc75dbf0fc9218e2cbc576cd895996c208f1a9e7eaa1cce271ca49f8ac4ff762cdfe1cdfbc
+  version: 1.8.26
+  resolution: "vue-component-type-helpers@npm:1.8.26"
+  checksum: 5cc563ebf7e411fa11c8aec53646a5612d0fd67ae0f68a28936e302f15eceea568a662f732849fd376187db76c485569ee642f5c22ccebd7d43759b1f23fad9c
   languageName: node
   linkType: hard
 
@@ -21730,18 +21792,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vue-tsc@npm:^1.8.20, vue-tsc@npm:^1.8.25":
-  version: 1.8.25
-  resolution: "vue-tsc@npm:1.8.25"
+"vue-tsc@npm:^1.8.20, vue-tsc@npm:^1.8.26":
+  version: 1.8.26
+  resolution: "vue-tsc@npm:1.8.26"
   dependencies:
     "@volar/typescript": "npm:~1.11.1"
-    "@vue/language-core": "npm:1.8.25"
+    "@vue/language-core": "npm:1.8.26"
     semver: "npm:^7.5.4"
   peerDependencies:
     typescript: "*"
   bin:
     vue-tsc: bin/vue-tsc.js
-  checksum: e3d1e222c9ab9bdb037246725f93538889bd4bd900fb15230b737b4e89710f50089b8525bb64f08e4f2e758bec816f8a5d7ddd326d8d5d667eed8e1e08ef7ec6
+  checksum: 4f1f29da98ac2616fe85436d61015f89d79522cd15a8f060e9e01d972c265e542c6e1ffa600faf472e04b22bdfcd4c2fb516363f038e364746c875ce1cedd589
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Updates
- Bump Github actions, SvelteKit, date-fns, @angular/cli, @angular/devkit, vue-tsc
- Remove yarn resolutions in top-level package.json
- Remove invalid exports from package.json (react and vue)

