### PR TITLE
including a random id in the aria-label does not help screenreader users

### DIFF
--- a/packages/core/src/components/axes/toolbar.ts
+++ b/packages/core/src/components/axes/toolbar.ts
@@ -39,7 +39,7 @@ export class Toolbar extends Component {
 	render(animate = true) {
 		const container = this.getComponentContainer()
 			.attr('role', 'toolbar')
-			.attr('aria-label', `chart-${this.services.domUtils.getChartID()} toolbar`)
+			.attr('aria-label', `chart toolbar`)
 
 		const isDataLoading = getProperty(this.getOptions(), 'data', 'loading')
 


### PR DESCRIPTION
### Updates
removed the chartID from aria-label attribute.

related issue: https://github.com/carbon-design-system/carbon-charts/issues/1728