### PR TITLE
fix(github): removing PII question from issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/ACCESSIBILITY.yaml
+++ b/.github/ISSUE_TEMPLATE/ACCESSIBILITY.yaml
@@ -10,16 +10,8 @@ body:
   - type: input
     id: name
     attributes:
-      label: Name
-      description: What's your name?
-    validations:
-      required: true
-  - type: checkboxes
-    id: ibm
-    attributes:
-      label: Are you an IBM employee?
-      options:
-        - label: 'Yes'
+      label: Application/Team
+      description: If you are from IBM, which application/team are you from?
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yaml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yaml
@@ -10,16 +10,8 @@ body:
   - type: input
     id: name
     attributes:
-      label: Name
-      description: What's your name?
-    validations:
-      required: true
-  - type: checkboxes
-    id: ibm
-    attributes:
-      label: Are you an IBM employee?
-      options:
-        - label: 'Yes'
+      label: Application/Team
+      description: If you are from IBM, which application/team are you from?
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/ENHANCEMENT.yaml
+++ b/.github/ISSUE_TEMPLATE/ENHANCEMENT.yaml
@@ -10,16 +10,8 @@ body:
   - type: input
     id: name
     attributes:
-      label: Name
-      description: What's your name?
-    validations:
-      required: true
-  - type: checkboxes
-    id: ibm
-    attributes:
-      label: Are you an IBM employee?
-      options:
-        - label: 'Yes'
+      label: Application/Team
+      description: If you are from IBM, which application/team are you from?
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/QUESTION.yaml
+++ b/.github/ISSUE_TEMPLATE/QUESTION.yaml
@@ -19,16 +19,8 @@ body:
   - type: input
     id: name
     attributes:
-      label: Name
-      description: What's your name?
-    validations:
-      required: true
-  - type: checkboxes
-    id: ibm
-    attributes:
-      label: Are you an IBM employee?
-      options:
-        - label: 'Yes'
+      label: Application/Team
+      description: If you are from IBM, which application/team are you from?
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
### Updates
- This update removes the PII questions across issue templates, and instead asks for the application/team information if coming from IBM.
