### PR TITLE
chore: onboard @carbon/charts-react to ibm telemetry

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -48,3 +48,12 @@ For instructions on using the **tabular data format**, see
 
 Customizable options (specific to chart type) can be found
 [here](https://charts.carbondesignsystem.com/documentation/modules/interfaces.html)
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect metrics data. By installing this
+package as a dependency you are agreeing to telemetry collection. To opt out,
+see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -18,10 +18,11 @@
 	},
 	"files": [
 		"dist",
-		"README.md"
+		"README.md",
+		"telemetry.yml"
 	],
 	"scripts": {
-		"postinstall": "carbon-telemetry collect --install",
+		"postinstall": "ibmtelemetry --config=telemetry.yml",
 		"file:styles": "cp ../core/dist/styles.* dist",
 		"file:downlevel:dts": "downlevel-dts dist dist",
 		"postbundle": "concurrently \"yarn:file:*\"",
@@ -41,7 +42,7 @@
 	"dependencies": {
 		"@carbon/charts": "workspace:*",
 		"@carbon/icons-react": "^11.34.0",
-		"@carbon/telemetry": "~0.1.0",
+		"@ibm/telemetry-js": "^1.2.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0"
 	},

--- a/packages/react/telemetry.yml
+++ b/packages/react/telemetry.yml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+version: 1
+projectId: 5784a186-6343-49d8-8e9a-1e591596f962
+endpoint: "https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics"
+collect:
+  npm:
+    dependencies: null
+  jsx:
+    elements:
+      allowedAttributeNames:
+        # General
+        - options
+        - data
+        # React
+        - key
+        - ref

--- a/yarn.lock
+++ b/yarn.lock
@@ -2227,7 +2227,7 @@ __metadata:
   dependencies:
     "@carbon/charts": "workspace:*"
     "@carbon/icons-react": "npm:^11.34.0"
-    "@carbon/telemetry": "npm:~0.1.0"
+    "@ibm/telemetry-js": "npm:^1.2.0"
     "@stackblitz/sdk": "npm:1.9.0"
     "@types/react": "npm:^18.2.48"
     "@types/react-dom": "npm:^18.2.18"
@@ -3202,6 +3202,15 @@ __metadata:
   version: 6.0.0-next.6
   resolution: "@ibm/plex@npm:6.0.0-next.6"
   checksum: 7f47f9535def1047dff51703fd1041c2f2915df1d405f1d62e785cc55b56478ea91af2e95b838692ef4142835ea765217935e2e336bac5a4437a9092ec0cfb4f
+  languageName: node
+  linkType: hard
+
+"@ibm/telemetry-js@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@ibm/telemetry-js@npm:1.2.0"
+  bin:
+    ibmtelemetry: dist/collect.js
+  checksum: 6b5a154067c52cc8f6abe7bf71308764aa5df361d3d867d8c96862e6196de67799eeb36435355f41ce201a57e75aa9a9279ab461ec7bd98ae5908f06694e3fc4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds config file and dependency necessary to start tracking telemetry data via [IBM Telemetry](https://github.com/ibm-telemetry/telemetry-js)

### Updates
- Updates readme telemetry disclosure
- Removes `@carbon/telemetry` dependency
- Adds @ibm/telemetry-js dependency
- Updates postinstall script to use IBM telemetry command
- Adds [telemetry.yml](packages/react/telemetry.yml) config file
- Include `telemetry.yml` in package.json files config 

#### Review
Please look through [telemetry.yml](packages/react/telemetry.yml) config file and ensure desired props/values have been captured. For more info see [Telemetry Config Schema](https://github.com/ibm-telemetry/telemetry-config-schema?tab=readme-ov-file#jsx-scope)

### Demo screenshot or recording

N/A
