### PR TITLE
chore: onboard other charts flavors to IBM Telemetry

### DIFF
--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -40,3 +40,12 @@ For instructions on using the **tabular data format**, see
 
 Customizable options (specific to chart type) can be found
 [here](https://charts.carbondesignsystem.com/documentation/modules/interfaces.html)
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect metrics data. By installing this
+package as a dependency you are agreeing to telemetry collection. To opt out,
+see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/angular/ng-package.json
+++ b/packages/angular/ng-package.json
@@ -6,6 +6,6 @@
   },
   "allowedNonPeerDependencies": [
     "@carbon/charts",
-    "@carbon/telemetry"
+    "@ibm/telemetry-js"
   ]
 }

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -10,7 +10,7 @@
 	"type": "module",
 	"scripts": {
 		"ng": "ng",
-		"postinstall": "carbon-telemetry collect --install",
+		"postinstall": "ibmtelemetry --config=telemetry.yml",
 		"file:md": "cp *.md dist",
 		"file:styles": "cp ../core/dist/styles.* dist",
 		"disabled:file:downlevel:dts": "downlevel-dts dist dist",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -35,7 +35,7 @@
 	},
 	"dependencies": {
 		"@carbon/charts": "workspace:*",
-		"@carbon/telemetry": "~0.1.0",
+		"@ibm/telemetry-js": "1.2.0",
 		"tslib": "^2.6.2"
 	},
 	"devDependencies": {

--- a/packages/angular/telemetry.yml
+++ b/packages/angular/telemetry.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+version: 1
+projectId: 418a02f0-ef56-4acf-81ec-481d9078cbc9
+endpoint: "https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics"
+collect:
+  npm:
+    dependencies: null

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -44,3 +44,12 @@ For instructions on using the **tabular data format**, see
 
 Customizable options (specific to chart type) can be found
 [here](https://charts.carbondesignsystem.com/documentation/modules/interfaces.html)
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect metrics data. By installing this
+package as a dependency you are agreeing to telemetry collection. To opt out,
+see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -80,8 +80,8 @@
 	},
 	"dependencies": {
 		"@carbon/colors": "^11.20.1",
-		"@carbon/telemetry": "~0.1.0",
 		"@carbon/utils-position": "^1.1.4",
+		"@ibm/telemetry-js": "1.2.0",
 		"carbon-components": "^10.58.13",
 		"d3": "^7.8.5",
 		"d3-cloud": "^1.2.7",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,10 +50,11 @@
 		"scss",
 		"styles.css",
 		"styles.min.css",
-		"CHANGELOG.md"
+		"CHANGELOG.md",
+		"telemetry.yml"
 	],
 	"scripts": {
-		"postinstall": "carbon-telemetry collect --install",
+		"postinstall": "ibmtelemetry --config=telemetry.yml",
 		"file:css:charts": "sass scss/index.scss dist/styles.css --load-path=./node_modules --load-path=../../node_modules",
 		"file:css:min:charts": "sass scss/index.scss dist/styles.min.css --style=compressed --load-path=./node_modules --load-path=../../node_modules",
 		"file:css:demo": "sass scss/demos.scss dist/demo/styles.css --load-path=./node_modules --load-path=../../node_modules",

--- a/packages/core/telemetry.yml
+++ b/packages/core/telemetry.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+version: 1
+projectId: 6e01c9a5-9f9d-4eb9-8b46-3b55fbeac6e0
+endpoint: "https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics"
+collect:
+  npm:
+    dependencies: null

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
 	},
 	optimizeDeps: {
 		exclude: [
-			'@carbon/telemetry' // prevent Storybook issue
+			'@ibm/telemetry-js' // prevent Storybook issue
 		]
 	},
 	resolve: {

--- a/packages/react/.storybook/main.ts
+++ b/packages/react/.storybook/main.ts
@@ -39,7 +39,7 @@ const config: StorybookConfig = {
 				// }
 			},
 			optimizeDeps: {
-				exclude: ['@carbon/telemetry']
+				exclude: ['@ibm/telemetry-js']
 			}
 		})
 	},

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -268,3 +268,12 @@ type ChartProps = ComponentProps<BarChartSimple>
 // Indexed access type to access the type of the `chart` property
 let chart: ChartProps['chart'] = null
 ```
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect metrics data. By installing this
+package as a dependency you are agreeing to telemetry collection. To opt out,
+see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -3,7 +3,7 @@
 	"version": "1.13.24",
 	"description": "Carbon Charts component library for Svelte",
 	"scripts": {
-		"postinstall": "carbon-telemetry collect --install",
+		"postinstall": "ibmtelemetry --config=telemetry.yml",
 		"file:styles": "cp ../core/dist/styles.* dist",
 		"build:package": "svelte-kit sync && svelte-package && yarn file:styles",
 		"demo:mdx:svelte": "cp ../core/src/stories/getting-started/svelte.stories.mdx src/stories",
@@ -36,7 +36,8 @@
 	},
 	"files": [
 		"dist",
-		"CHANGELOG.md"
+		"CHANGELOG.md",
+		"telemetry.yml"
 	],
 	"peerDependencies": {
 		"svelte": "^3.31.0 || ^4.0.0"

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -43,7 +43,7 @@
 	},
 	"dependencies": {
 		"@carbon/charts": "workspace:*",
-		"@carbon/telemetry": "~0.1.0"
+		"@ibm/telemetry-js": "1.2.0"
 	},
 	"devDependencies": {
 		"@stackblitz/sdk": "^1.9.0",

--- a/packages/svelte/telemetry.yml
+++ b/packages/svelte/telemetry.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+version: 1
+projectId: f4284ccd-bed3-420a-ab93-829c790246e7
+endpoint: "https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics"
+collect:
+  npm:
+    dependencies: null

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -46,3 +46,12 @@ For instructions on using the **tabular data format**, see
 
 Customizable options (specific to chart type) can be found
 [here](https://charts.carbondesignsystem.com/documentation/modules/interfaces.html)
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect metrics data. By installing this
+package as a dependency you are agreeing to telemetry collection. To opt out,
+see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -16,10 +16,11 @@
 	},
 	"files": [
 		"dist",
-		"CHANGELOG.md"
+		"CHANGELOG.md",
+		"telemetry.yml"
 	],
 	"scripts": {
-		"postinstall": "carbon-telemetry collect --install",
+		"postinstall": "ibmtelemetry --config=telemetry.yml",
 		"file:styles": "cp ../core/dist/styles.* dist",
 		"build:package": "vite build && yarn file:styles",
 		"demo:mdx:vue": "cp ../core/src/stories/getting-started/vue.stories.mdx src/stories",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -39,7 +39,7 @@
 	},
 	"dependencies": {
 		"@carbon/charts": "workspace:*",
-		"@carbon/telemetry": "~0.1.0",
+		"@ibm/telemetry-js": "1.2.0",
 		"vue": "^3.4.15"
 	},
 	"devDependencies": {

--- a/packages/vue/telemetry.yml
+++ b/packages/vue/telemetry.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+version: 1
+projectId: f37fae0f-81da-434b-86ac-22cfac61fe62
+endpoint: "https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics"
+collect:
+  npm:
+    dependencies: null

--- a/yarn.lock
+++ b/yarn.lock
@@ -2153,7 +2153,7 @@ __metadata:
     "@carbon/charts": "workspace:*"
     "@carbon/icon-helpers": "npm:^10.45.1"
     "@carbon/icons": "npm:^11.34.0"
-    "@carbon/telemetry": "npm:~0.1.0"
+    "@ibm/telemetry-js": "npm:1.2.0"
     "@stackblitz/sdk": "npm:^1.9.0"
     "@storybook/angular": "npm:^7.6.10"
     "@types/carbon__icon-helpers": "npm:^10.7.4"
@@ -2256,7 +2256,7 @@ __metadata:
   resolution: "@carbon/charts-svelte@workspace:packages/svelte"
   dependencies:
     "@carbon/charts": "workspace:*"
-    "@carbon/telemetry": "npm:~0.1.0"
+    "@ibm/telemetry-js": "npm:1.2.0"
     "@stackblitz/sdk": "npm:^1.9.0"
     "@sveltejs/adapter-auto": "npm:^3.1.1"
     "@sveltejs/kit": "npm:^2.4.1"
@@ -2284,7 +2284,7 @@ __metadata:
   resolution: "@carbon/charts-vue@workspace:packages/vue"
   dependencies:
     "@carbon/charts": "workspace:*"
-    "@carbon/telemetry": "npm:~0.1.0"
+    "@ibm/telemetry-js": "npm:1.2.0"
     "@stackblitz/sdk": "npm:^1.9.0"
     "@types/d3": "npm:^7.4.3"
     "@vitejs/plugin-vue": "npm:^5.0.3"
@@ -2311,9 +2311,9 @@ __metadata:
     "@carbon/import-once": "npm:^10.7.0"
     "@carbon/layout": "npm:^11.20.1"
     "@carbon/styles": "npm:1.48.0"
-    "@carbon/telemetry": "npm:~0.1.0"
     "@carbon/themes": "npm:^11.29.0"
     "@carbon/utils-position": "npm:^1.1.4"
+    "@ibm/telemetry-js": "npm:1.2.0"
     "@rollup/plugin-replace": "npm:^5.0.5"
     "@stackblitz/sdk": "npm:^1.9.0"
     "@types/d3": "npm:^7.4.3"
@@ -2447,7 +2447,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/telemetry@npm:0.1.0, @carbon/telemetry@npm:~0.1.0":
+"@carbon/telemetry@npm:0.1.0":
   version: 0.1.0
   resolution: "@carbon/telemetry@npm:0.1.0"
   bin:
@@ -3205,7 +3205,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm/telemetry-js@npm:^1.2.0":
+"@ibm/telemetry-js@npm:1.2.0, @ibm/telemetry-js@npm:^1.2.0":
   version: 1.2.0
   resolution: "@ibm/telemetry-js@npm:1.2.0"
   bin:


### PR DESCRIPTION
Adds config files and dependencies necessary to start tracking telemetry data via [IBM Telemetry](https://github.com/ibm-telemetry/telemetry-js) on `@carbon/charts`, `@carbon/charts-svelte`, `@carbon/charts-vue` & `@carbon/charts-angular`

### Updates
- Adds readme telemetry disclosure to `@carbon/charts`, `@carbon/charts-svelte`, `@carbon/charts-vue` & `@carbon/charts-angular`
- Removes `@carbon/telemetry` dependency from `@carbon/charts`, `@carbon/charts-svelte`, `@carbon/charts-vue` & `@carbon/charts-angular`
- Adds @ibm/telemetry-js dependency to `@carbon/charts`, `@carbon/charts-svelte`, `@carbon/charts-vue` & `@carbon/charts-angular`
- Updates postinstall script to use IBM telemetry command `@carbon/charts`, `@carbon/charts-svelte`, `@carbon/charts-vue` & `@carbon/charts-angular`
- Adds `telemetry.yml` config file to `@carbon/charts`, `@carbon/charts-svelte`, `@carbon/charts-vue` & `@carbon/charts-angular`
- Include `telemetry.yml` in package.json files config of `@carbon/charts`, `@carbon/charts-svelte`, `@carbon/charts-vue`

### Demo screenshot or recording

N/A
