### PR TITLE
fix(stackblitz/vue): remove export ambiguity

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yaml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yaml
@@ -28,7 +28,7 @@ body:
     attributes:
       label: Version
       description: What version of our packages are you using?
-      placeholder: e.g. `@carbon/charts@1.11.10`
+      placeholder: e.g. `@carbon/charts@1.13.28`
     validations:
       required: true
   - type: textarea
@@ -46,13 +46,13 @@ body:
   - type: input
     id: sandbox
     attributes:
-      label: Codesandbox example
+      label: StackBlitz example
       description: >
-        Do you have a sandbox where we can see the issue reproduced?
+        Do you have a repro for this issue?
         
-        **Most of our demos offer a StackBlitz example that can help you get started**
+        **Get started** using the StackBlitz examples at
         https://carbon-design-system.github.io/carbon-charts/
-      placeholder: ex. https://www.stackblitz.com/...
+      placeholder: https://www.stackblitz.com/...
     validations:
       required: false
   - type: dropdown

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "husky": "^9.0.10",
     "lerna": "8.0.2",
     "pinst": "^3.0.0",
-    "prettier": "^3.2.4",
+    "prettier": "^3.2.5",
     "prettier-config-carbon": "^0.11.0",
     "prettier-eslint": "^16.3.0",
     "prettier-plugin-svelte": "^3.1.2",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -11,7 +11,7 @@
 		".": {
 			"style": "./dist/styles.css",
 			"types": "./dist/index.d.ts",
-			"default": "./dist/index.mjs"
+			"import": "./dist/index.mjs"
 		}
 	},
 	"files": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2198,7 +2198,7 @@ __metadata:
     husky: "npm:^9.0.10"
     lerna: "npm:8.0.2"
     pinst: "npm:^3.0.0"
-    prettier: "npm:^3.2.4"
+    prettier: "npm:^3.2.5"
     prettier-config-carbon: "npm:^0.11.0"
     prettier-eslint: "npm:^16.3.0"
     prettier-plugin-svelte: "npm:^3.1.2"
@@ -18523,12 +18523,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^3.2.4":
-  version: 3.2.4
-  resolution: "prettier@npm:3.2.4"
+"prettier@npm:^3.2.5":
+  version: 3.2.5
+  resolution: "prettier@npm:3.2.5"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 88dfeb78ac6096522c9a5b81f1413d875f568420d9bb6a5e5103527912519b993f2bcdcac311fcff5718d5869671d44e4f85827d3626f3a6ce32b9abc65d88e0
+  checksum: ea327f37a7d46f2324a34ad35292af2ad4c4c3c3355da07313339d7e554320f66f65f91e856add8530157a733c6c4a897dc41b577056be5c24c40f739f5ee8c6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Updates
- change export for @carbon/charts-vue from "default" to "import" in case StackBlitz is trying to load via require
- bump prettier
- minor tweaks to bug tracking template
- might close https://github.com/carbon-design-system/carbon-charts/issues/1740

