### PR TITLE
fix(modal): styles of export to csv button

### DIFF
--- a/packages/core/scss/components/toolbar/_modal.scss
+++ b/packages/core/scss/components/toolbar/_modal.scss
@@ -325,7 +325,7 @@
 					vertical-align: top;
 				}
 
-				.#{globals.$prefix}--btn-primary {
+				.#{globals.$prefix}--btn--primary {
 					&:hover {
 						color: var(--#{globals.$prefix}-text-on-color, #ffffff);
 						background-color: var(--#{globals.$prefix}-button-primary-hover, #0050e6);


### PR DESCRIPTION
Closes #1730

### Updates
- Fix css selector or primary button in export to csv modal

### Demo screenshot or recording

After fixing the css selector, we can see the styles in _modal.scss are applied.

<img width="988" alt="Screenshot 2024-02-08 at 2 57 20 AM" src="https://github.com/carbon-design-system/carbon-charts/assets/126788428/09aabd55-cf29-4c7a-a047-f0059d60b84f">
