### PR TITLE
fix(modal): padding of export to csv button

### DIFF
--- a/packages/core/scss/components/toolbar/_modal.scss
+++ b/packages/core/scss/components/toolbar/_modal.scss
@@ -5,6 +5,7 @@
 	--#{globals.$prefix}-layout-size-height-lg: 3rem;
 	--#{globals.$prefix}-layout-size-height-max: 999999999px;
 	--#{globals.$prefix}-layout-density-padding-inline-min: 0px;
+	--#{globals.$prefix}-layout-density-padding-inline-normal: 1rem;
 	--#{globals.$prefix}-layout-density-padding-inline-max: 999999999px;
 	--#{globals.$prefix}-layout-size-height-lg: 3rem;
 


### PR DESCRIPTION
Closes #1730

### Updates
- Fix `padding-inline-start` and `padding-inline-end` of export to csv button.

### Demo screenshot or recording

Add the missing variable for padding of button

<img width="995" alt="Screenshot 2024-02-08 at 11 14 46 PM" src="https://github.com/carbon-design-system/carbon-charts/assets/126788428/31b6ddbf-8816-4660-ba82-aacbed58b92a">
<img width="995" alt="Screenshot 2024-02-08 at 11 15 15 PM" src="https://github.com/carbon-design-system/carbon-charts/assets/126788428/19e62134-a590-422f-a0c7-0fbe4904bdb4">
