### PR TITLE
fix(charts): missing paddings on firefox fullscreen

### DIFF
--- a/packages/core/scss/_chart-holder.scss
+++ b/packages/core/scss/_chart-holder.scss
@@ -42,8 +42,7 @@
 	@include theme.theme(themes.$g100);
 }
 
-.#{globals.$prefix}--chart-holder.fullscreen,
-.#{globals.$prefix}--chart-holder:-webkit-full-screen {
+.#{globals.$prefix}--chart-holder.fullscreen {
 	// important used to ensure full-screen experience
 	width: 100% !important;
 	height: 100% !important;


### PR DESCRIPTION
Closes #1753 

### Updates
 - Remove css selector `.#{globals.$prefix}--chart-holder:-webkit-full-screen` and only leave `.#{globals.$prefix}--chart-holder.fullscreen` then it would give expected behaviors in both Chrome/Firefox/Safari/Edge.

### Demo screenshot or recording

Can try on preview with firefox or using developer tools do live editing to see this behavior.