### PR TITLE
fix(config): add SSR guard for `window.navigator`

### DIFF
--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -76,7 +76,7 @@ const standardTruncationOptions = {
  * Locale options
  */
 const locale: Locale = {
-	code: navigator?.language || 'en-US', // read from browser's navigator.language
+	code: typeof navigator !== 'undefined' && navigator?.language || 'en-US', // read from browser's navigator.language
 	number: (value, language = navigator?.language || 'en-US') => value.toLocaleString(language), // based on code property if specified
 	date: (
 		value,


### PR DESCRIPTION
Fixes #1755

`window.navigator` is a browser API. This PR adds a check so that Carbon Charts can be used with SSR.

### Updates
- fix(config): add SSR guard for `window.navigator`

### Demo screenshot or recording
