### PR TITLE
fix(modal):removal of repeated classes from modal

### DIFF
--- a/packages/core/src/components/essentials/modal.ts
+++ b/packages/core/src/components/essentials/modal.ts
@@ -80,30 +80,30 @@ export class Modal extends Component {
 		const tableArray = this.model.getTabularDataArray()
 
 		return `
-		<div class="cds--modal-container cds--modal-container">
-			<div class="cds--modal-header cds--modal-header">
+		<div class="cds--modal-container">
+			<div class="cds--modal-header">
 
-				<p class="cds--modal-header__label cds--type-delta cds--modal-header__label cds--type-delta" id="modal-title">${title}</p>
+				<p class="cds--modal-header__label cds--type-delta" id="modal-title">${title}</p>
 
-				<p class="cds--modal-header__heading cds--type-beta cds--modal-header__heading cds--type-beta" id="${id}__modal-description">${sanitizeText(
+				<p class="cds--modal-header__heading cds--type-beta" id="${id}__modal-description">${sanitizeText(
 					options.title
 				)}</p>
 
-				<button class="cds--modal-close cds--modal-close" type="button" data-modal-close aria-label="close modal"  data-modal-primary-focus>
-					<svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-label="Close" width="20" height="20" viewBox="0 0 32 32" role="img" class="cds--modal-close__icon cds--modal-close__icon">
+				<button class="cds--modal-close" type="button" data-modal-close aria-label="close modal"  data-modal-primary-focus>
+					<svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-label="Close" width="20" height="20" viewBox="0 0 32 32" role="img" class="cds--modal-close__icon">
 						<path d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"></path>
 					</svg>
 				</button>
 			</div>
 
-			<div class="cds--modal-content cds--modal-content">
-				<table class="cds--data-table cds--data-table--no-border cds--data-table cds--data-table--no-border">
+			<div class="cds--modal-content">
+				<table class="cds--data-table cds--data-table--no-border">
 					<thead>
 						<tr>
 							${get(tableArray, 0)
 								.map(
 									(heading: any) => `<th scope="col">
-								<div class="cds--table-header-label cds--table-header-label">${sanitizeText(heading)}</div>
+								<div class="cds--table-header-label">${sanitizeText(heading)}</div>
 							</th>`
 								)
 								.join('')}
@@ -123,9 +123,9 @@ export class Modal extends Component {
 				</table>
 			</div>
 
-			<div class="cds--modal-footer cds--modal-footer">
+			<div class="cds--modal-footer">
 			  <div class="${carbonPrefix}--${chartprefix}-modal-footer-spacer"></div>
-			  <button class="cds--btn cds--btn--primary cds--btn cds--btn--primary" type="button" data-modal-primary-focus>${downloadAsCSV}</button>
+			  <button class="cds--btn cds--btn--primary" type="button" data-modal-primary-focus>${downloadAsCSV}</button>
 			</div>
 		</div>`
 	}


### PR DESCRIPTION
### Updates
- [#1670](https://github.com/carbon-design-system/carbon-charts/issues/1670)
- Repeated classes removed from modal.

### Demo screenshot or recording
<img width="1728" alt="image" src="https://github.com/carbon-design-system/carbon-charts/assets/76566868/40ed8ff8-76a1-40e9-ab04-3b5eb6e40d26">

