### PR TITLE
fix(heatmap-choropleth):legend hidden when data array is empty

### DIFF
--- a/packages/core/src/charts/choropleth.ts
+++ b/packages/core/src/charts/choropleth.ts
@@ -90,7 +90,8 @@ export class ExperimentalChoroplethChart extends Chart {
 
 		const isLegendEnabled =
 			getProperty(configs, 'legend', 'enabled') !== false &&
-			this.model.getOptions().legend.enabled !== false
+			this.model.getOptions().legend.enabled !== false &&
+			this.model.getData().length > 0
 
 		// Decide the position of the legend in reference to the chart
 		const fullFrameComponentDirection = LayoutDirection.COLUMN_REVERSE

--- a/packages/core/src/charts/heatmap.ts
+++ b/packages/core/src/charts/heatmap.ts
@@ -95,7 +95,8 @@ export class HeatmapChart extends AxisChart {
 
 		const isLegendEnabled =
 			getProperty(configs, 'legend', 'enabled') !== false &&
-			this.model.getOptions().legend.enabled !== false
+			this.model.getOptions().legend.enabled !== false &&
+			this.model.getData().length > 0
 
 		// Decide the position of the legend in reference to the chart
 		const fullFrameComponentDirection = LayoutDirection.COLUMN_REVERSE


### PR DESCRIPTION
### Updates
- https://github.com/carbon-design-system/carbon-charts/issues/1759
- hiding legend when data array is empty for heatmap and choropleth charts

### Demo screenshot or recording
<img width="1728" alt="image" src="https://github.com/carbon-design-system/carbon-charts/assets/76566868/4638994e-e2a6-4049-ae46-bda2491c572c">

<img width="1728" alt="image" src="https://github.com/carbon-design-system/carbon-charts/assets/76566868/2d92f2d5-07b3-42d1-a0f1-7627e0caeeb8">
