### PR TITLE
feat(toolbar): add tooltips

### DIFF
--- a/packages/core/scss/components/_tooltip.scss
+++ b/packages/core/scss/components/_tooltip.scss
@@ -30,6 +30,10 @@
 	.content-box {
 		color: theme.$text-primary;
 
+		.title-tooltip.title-tooltip-nowrap {
+			width: max-content;
+		}
+
 		.title-tooltip {
 			width: auto;
 			padding: 4px;

--- a/packages/core/src/components/axes/toolbar.ts
+++ b/packages/core/src/components/axes/toolbar.ts
@@ -85,7 +85,6 @@ export class Toolbar extends Component {
 				.classed('disabled', (d: any) => d.shouldBeDisabled())
 				.attr('role', 'button')
 				.attr('aria-disabled', (d: any) => d.shouldBeDisabled())
-				.attr('role', 'button')
 				.attr('aria-label', (d: any) => d.title)
 				.html((d: any) => {
 					return `
@@ -470,9 +469,10 @@ export class Toolbar extends Component {
 
 	// special button config for overflow button
 	getOverflowButtonConfig() {
+		const { moreOptions } = getProperty(this.model.getOptions(), 'locale', 'translations', 'toolbar')
 		return {
 			id: 'toolbar-overflow-menu',
-			title: 'More options',
+			title: moreOptions,
 			shouldBeDisabled: () => false,
 			iconSVG: {
 				content: `<circle cx="16" cy="8" r="2"></circle>
@@ -491,7 +491,10 @@ export class Toolbar extends Component {
 
 		const displayData = this.model.getDisplayData()
 		const options = this.model.getOptions()
-		const { exportAsCSV, exportAsJPG, exportAsPNG } = getProperty(
+		const {
+			exportAsCSV, exportAsJPG, exportAsPNG, zoomIn, zoomOut, resetZoom,
+			makeFullScreen, exitFullScreen, showAsTable
+		} = getProperty(
 			options,
 			'locale',
 			'translations',
@@ -504,7 +507,7 @@ export class Toolbar extends Component {
 				if (isZoomBarEnabled) {
 					controlConfig = {
 						id: 'toolbar-zoomIn',
-						title: 'Zoom in',
+						title: zoomIn,
 						shouldBeDisabled: () => this.services.zoom.isMinZoomDomain(),
 						iconSVG: {
 							content: this.getControlIconByType(controlType)
@@ -517,7 +520,7 @@ export class Toolbar extends Component {
 				if (isZoomBarEnabled) {
 					controlConfig = {
 						id: 'toolbar-zoomOut',
-						title: 'Zoom out',
+						title: zoomOut,
 						shouldBeDisabled: () => this.services.zoom.isMaxZoomDomain(),
 						iconSVG: {
 							content: this.getControlIconByType(controlType)
@@ -530,7 +533,7 @@ export class Toolbar extends Component {
 				if (isZoomBarEnabled) {
 					controlConfig = {
 						id: 'toolbar-resetZoom',
-						title: 'Reset zoom',
+						title: resetZoom,
 						shouldBeDisabled: () => this.services.zoom.isMaxZoomDomain(),
 						iconSVG: {
 							content: this.getControlIconByType(controlType)
@@ -547,7 +550,7 @@ export class Toolbar extends Component {
 						width: '15px',
 						height: '15px'
 					},
-					title: 'Make fullscreen',
+					title: makeFullScreen,
 					shouldBeDisabled: () => false,
 					clickFunction: () => {
 						this.services.domUtils.toggleFullscreen()
@@ -562,7 +565,7 @@ export class Toolbar extends Component {
 						width: '15px',
 						height: '15px'
 					},
-					title: 'Exit fullscreen',
+					title: exitFullScreen,
 					shouldBeDisabled: () => false,
 					clickFunction: () => {
 						this.services.domUtils.toggleFullscreen()
@@ -575,7 +578,7 @@ export class Toolbar extends Component {
 					iconSVG: {
 						content: this.getControlIconByType(controlType)
 					},
-					title: 'Show as table',
+					title: showAsTable,
 					shouldBeDisabled: () => displayData.length === 0,
 					clickFunction: () => this.services.events.dispatchEvent(Events.Modal.SHOW)
 				}

--- a/packages/core/src/components/axes/toolbar.ts
+++ b/packages/core/src/components/axes/toolbar.ts
@@ -85,6 +85,7 @@ export class Toolbar extends Component {
 				.classed('disabled', (d: any) => d.shouldBeDisabled())
 				.attr('role', 'button')
 				.attr('aria-disabled', (d: any) => d.shouldBeDisabled())
+				.attr('role', 'button')
 				.attr('aria-label', (d: any) => d.title)
 				.html((d: any) => {
 					return `
@@ -101,12 +102,26 @@ export class Toolbar extends Component {
 				.each(function (d: any, index: number) {
 					select(this)
 						.select('svg')
+						.style('pointer-events', 'none')
 						.style('will-change', 'transform')
 						.style('width', d.iconSVG.width !== undefined ? d.iconSVG.width : '20px')
 						.style('height', d.iconSVG.height !== undefined ? d.iconSVG.height : '20px')
 
 					select(this)
 						.select('button')
+						.on('mouseover focus', function (event: MouseEvent) {
+							const hoveredElement = select(this)
+							hoveredElement.classed('hovered', true)
+							self.services.events.dispatchEvent(Events.Toolbar.SHOW_TOOLTIP, {
+								event,
+								hoveredElement,
+								content: d.title,
+								placement: 'top'
+							})
+						})
+						.on('mouseout blur', function () {
+							self.services.events.dispatchEvent(Events.Toolbar.HIDE_TOOLTIP)
+						})
 						.on('click', (event: CustomEvent<MouseEvent>) => {
 							if (!d.shouldBeDisabled()) {
 								self.triggerFunctionAndEvent(d, event, this)

--- a/packages/core/src/components/axes/toolbar.ts
+++ b/packages/core/src/components/axes/toolbar.ts
@@ -115,7 +115,8 @@ export class Toolbar extends Component {
 								event,
 								hoveredElement,
 								content: d.title,
-								placement: 'top'
+								noWrap: true,
+								placements: ['top', 'bottom']
 							})
 						})
 						.on('mouseout blur', function () {

--- a/packages/core/src/components/essentials/tooltip.ts
+++ b/packages/core/src/components/essentials/tooltip.ts
@@ -80,11 +80,6 @@ export class Tooltip extends Component {
 		this.lastTriggeredEventType = e.type
 	}
 
-	handleShowToolbarTooltip = (e: any) => {
-		this.handleShowTooltip(e)
-		this.positionTooltip(e)
-	}
-
 	handleHideTooltip = () => {
 		this.tooltip.classed('hidden', true).attr('aria-hidden', true)
 	}
@@ -109,7 +104,7 @@ export class Tooltip extends Component {
 		this.services.events.addEventListener(Events.Chart.MOUSEOUT, this.handleHideTooltip)
 
 		// listen to toolbar events
-		this.services.events.addEventListener(Events.Toolbar.SHOW_TOOLTIP, this.handleShowToolbarTooltip)
+		this.services.events.addEventListener(Events.Toolbar.SHOW_TOOLTIP, this.handleShowTooltip)
 		this.services.events.addEventListener(Events.Toolbar.HIDE_TOOLTIP, this.handleHideTooltip)
 	}
 
@@ -127,7 +122,7 @@ export class Tooltip extends Component {
 		this.services.events.removeEventListener(Events.Chart.MOUSEOUT, this.handleHideTooltip)
 
 		// remove the listener of the toolbar
-		this.services.events.removeEventListener(Events.Toolbar.SHOW_TOOLTIP, this.handleShowToolbarTooltip)
+		this.services.events.removeEventListener(Events.Toolbar.SHOW_TOOLTIP, this.handleShowTooltip)
 		this.services.events.removeEventListener(Events.Toolbar.HIDE_TOOLTIP, this.handleHideTooltip)
 	}
 
@@ -283,6 +278,7 @@ export class Tooltip extends Component {
 
 		// set the tooltip based on the placement relative to the triggered dom
 		if (customPlacement) {
+			this.tooltip.select('div.title-tooltip').classed('title-tooltip-nowrap', true)
 			const hovered = getProperty(e, 'detail', 'event', 'target')
 			const hoveredRect = hovered.getBoundingClientRect()
 			const position = defaultPositions[customPlacement](
@@ -297,7 +293,9 @@ export class Tooltip extends Component {
 			this.positionService.setElement(target, position)
 			return ;
 		}
+
 		// set the tooltip based on the mouse position
+		this.tooltip.select('div.title-tooltip').classed('title-tooltip-nowrap', false)
 		if (!mouseRelativePos) {
 			mouseRelativePos = pointer(getProperty(e, 'detail', 'event'), holder)
 		} else {

--- a/packages/core/src/components/essentials/tooltip.ts
+++ b/packages/core/src/components/essentials/tooltip.ts
@@ -288,13 +288,14 @@ export class Tooltip extends Component {
 		if (hasCustomPlacements) {
 			const hoveredElement = getProperty(e, 'detail', 'event', 'target')
 			// calculate the best placement from array "placements"
-			bestPlacementOption = this.positionService.findBestPlacement(
-				hoveredElement,
+			const hoveredPos = this.services.domUtils.getElementOffset(hoveredElement, true)
+			bestPlacementOption = this.positionService.findBestPlacementAt(
+				hoveredPos,
 				target,
 				placements,
 				() => ({
-					top: undefined,
-					left: undefined,
+					top: 0,
+					left: 0,
 					width: holderWidth,
 					height: holderHeight
 				})

--- a/packages/core/src/components/essentials/tooltip.ts
+++ b/packages/core/src/components/essentials/tooltip.ts
@@ -76,7 +76,7 @@ export class Tooltip extends Component {
 		// Fade in
 		this.tooltip.classed('hidden', false).attr('aria-hidden', false)
 
-		// store latest triggered custom event type
+		// Store the latest triggered custom event type
 		this.lastTriggeredEventType = e.type
 	}
 
@@ -126,7 +126,7 @@ export class Tooltip extends Component {
 		// remove the listener on chart-mouseout
 		this.services.events.removeEventListener(Events.Chart.MOUSEOUT, this.handleHideTooltip)
 
-		// remote the listener of the toolbar
+		// remove the listener of the toolbar
 		this.services.events.removeEventListener(Events.Toolbar.SHOW_TOOLTIP, this.handleShowToolbarTooltip)
 		this.services.events.removeEventListener(Events.Toolbar.HIDE_TOOLTIP, this.handleHideTooltip)
 	}
@@ -281,7 +281,7 @@ export class Tooltip extends Component {
 		let mouseRelativePos = getProperty(e, 'detail', 'mousePosition')
 		const customPlacement: PLACEMENTS | undefined | null = getProperty(e, 'detail', 'placement')
 
-		// set Tooltip based on custom placement relative to the triggered dom
+		// set the tooltip based on the placement relative to the triggered dom
 		if (customPlacement) {
 			const hovered = getProperty(e, 'detail', 'event', 'target')
 			const hoveredRect = hovered.getBoundingClientRect()
@@ -297,7 +297,7 @@ export class Tooltip extends Component {
 			this.positionService.setElement(target, position)
 			return ;
 		}
-		// set Tooltip based on mouse position
+		// set the tooltip based on the mouse position
 		if (!mouseRelativePos) {
 			mouseRelativePos = pointer(getProperty(e, 'detail', 'event'), holder)
 		} else {

--- a/packages/core/src/configuration-non-customizable.ts
+++ b/packages/core/src/configuration-non-customizable.ts
@@ -228,7 +228,9 @@ export const spacers = {
 }
 
 export const tooltips = {
-	horizontalOffset: 10
+	horizontalOffset: 10,
+	defaultOffsetSmall: 4,
+	defaultOffsetNormal: 8,
 }
 
 /**

--- a/packages/core/src/configuration-non-customizable.ts
+++ b/packages/core/src/configuration-non-customizable.ts
@@ -228,9 +228,8 @@ export const spacers = {
 }
 
 export const tooltips = {
-	horizontalOffset: 10,
-	defaultOffsetSmall: 4,
-	defaultOffsetNormal: 8,
+	defaultOffset: 4,
+	horizontalOffset: 10
 }
 
 /**

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -258,7 +258,14 @@ const locale: Locale = {
 		toolbar: {
 			exportAsCSV: 'Export to CSV',
 			exportAsJPG: 'Export to JPG',
-			exportAsPNG: 'Export to PNG'
+			exportAsPNG: 'Export to PNG',
+			zoomIn: 'Zoom in',
+			zoomOut: 'Zoom out',
+			resetZoom: 'Reset zoom',
+			moreOptions: 'More options',
+			makeFullScreen: 'Make fullscreen',
+			exitFullScreen: 'Exit fullscreen',
+			showAsTable: 'Show as table'
 		}
 	}
 }

--- a/packages/core/src/interfaces/components.ts
+++ b/packages/core/src/interfaces/components.ts
@@ -51,6 +51,13 @@ export interface Locale {
 			exportAsCSV?: string
 			exportAsJPG?: string
 			exportAsPNG?: string
+			zoomIn?: string
+			zoomOut?: string
+			resetZoom?: string
+			moreOptions?: string
+			makeFullScreen?: string
+			exitFullScreen?: string
+			showAsTable?: string
 		}
 	}
 }

--- a/packages/core/src/interfaces/events.ts
+++ b/packages/core/src/interfaces/events.ts
@@ -30,7 +30,9 @@ export enum Model {
 export enum Toolbar {
 	SHOW_OVERFLOW_MENU = 'show-toolbar-overflow-menu',
 	HIDE_OVERFLOW_MENU = 'hide-toolbar-overflow-menu',
-	BUTTON_CLICK = 'toolbar-button-click'
+	BUTTON_CLICK = 'toolbar-button-click',
+	SHOW_TOOLTIP = 'toolbar-show-tooltip',
+	HIDE_TOOLTIP = 'toolbar-hide-tooltip',
 }
 
 /**

--- a/packages/core/src/services/essentials/dom-utils.ts
+++ b/packages/core/src/services/essentials/dom-utils.ts
@@ -230,11 +230,11 @@ export class DOMUtils extends Service {
 		return this.chartID
 	}
 
-	getElementOffset(element: HTMLElement) {
-		// get relative position { left, top } of the chart holder
+	getElementOffset(element: HTMLElement, byViewPort = false) {
+		// get relative position { left, top } based on "chart holder" OR "viewport"
 		const elementOffset = { left: 0, top: 0 }
 		const childRect = element.getBoundingClientRect()
-		const baseRect = this.getHolder().getBoundingClientRect()
+		const baseRect = byViewPort ? { left: 0, top: 0 } : this.getHolder().getBoundingClientRect()
 
 		try {
 			elementOffset.left = childRect.left - baseRect.left

--- a/packages/core/src/services/essentials/dom-utils.ts
+++ b/packages/core/src/services/essentials/dom-utils.ts
@@ -230,6 +230,22 @@ export class DOMUtils extends Service {
 		return this.chartID
 	}
 
+	getElementOffset(element: HTMLElement) {
+		// get relative position { left, top } of the chart holder
+		const elementOffset = { left: 0, top: 0 }
+		const childRect = element.getBoundingClientRect()
+		const baseRect = this.getHolder().getBoundingClientRect()
+
+		try {
+			elementOffset.left = childRect.left - baseRect.left
+			elementOffset.top = childRect.top - baseRect.top
+		} catch (e) {
+			console.error(e)
+		}
+
+		return elementOffset
+	}
+
 	generateElementIDString(originalID: string | number) {
 		return `chart-${this.chartID}-${originalID}`
 	}


### PR DESCRIPTION
Closes #1549 

### Updates
- Add tooltip (with top placement) for toolbars
- Expose more translation strings

### Some testing

1. Mouse hovering on toolbar and it should display the tooltips
2. Using tab can trigger toolbar focus and display the tooltips
3. Hover the label title -> press tab to get toolbar focus -> move mouse over the label title should still see consistent tooltip content. 
4. Can apply following options to check translated strings
https://deploy-preview-1766--carbon-charts-angular.netlify.app/?path=/story/utility-truncations--truncated-labels-simple-bar
5. Repeat 1-4 in full screen mode
```
{
    "title": "Truncated labels (simple bar)",
      "locale": {
      "translations": {
        "toolbar": {
          "makeFullScreen": "進入全螢幕",
          "exitFullScreen": "離開全螢幕",
          "showAsTable": "顯示為表格",
          "moreOptions": "更多選項",
          "exportAsCSV": "轉存為CSV",
          "exportAsJPG": "轉存為JPG",
          "exportAsPNG": "轉存為PNG"
          }
      },
    "axes": {
      "left": {
        "mapsTo": "group",
        "scaleType": "labels",
        "truncation": {
          "type": "mid_line",
          "threshold": 10,
          "numCharacter": 14
        }
      },
      "bottom": {
        "mapsTo": "value"
      }
    },
    "legend": {
      "truncation": {
        "type": "mid_line",
        "threshold": 15,
        "numCharacter": 12
      }
    },
    "height": "400px",
    "theme": "g100"
  }
}
```

### Demo screenshot or recording

1. Hovering toolbar and shows translation strings (g10 theme)
<img width="557" alt="Screenshot 2024-02-25 at 10 12 54 PM" src="https://github.com/carbon-design-system/carbon-charts/assets/126788428/8f46656c-9b54-407c-953a-e3959d7aa486">

6. Using tab to focus toolbar and shows translation strings (g100 theme)

<img width="591" alt="Screenshot 2024-02-25 at 10 13 41 PM" src="https://github.com/carbon-design-system/carbon-charts/assets/126788428/29f35423-03e4-4327-9a68-74cde8680069">

