### PR TITLE
fix(guage): number formatter not respected when not number

### DIFF
--- a/packages/core/src/components/graphs/gauge.ts
+++ b/packages/core/src/components/graphs/gauge.ts
@@ -210,7 +210,10 @@ export class Gauge extends Component {
 			.merge(valueNumber as any)
 			.style('font-size', `${fontSize}px`)
 			.attr('text-anchor', 'middle')
-			.text((d: any) => localeNumberFormatter(Number(numberFormatter(d)), localeCode))
+			.text((d: any) => {
+				const formattedNumber = Number(numberFormatter(d));
+				return isNaN(formattedNumber) ? numberFormatter(d) : localeNumberFormatter(formattedNumber, localeCode);
+			})
 
 		// add the percentage symbol beside the valueNumber
 		const { width: valueNumberWidth } = DOMUtils.getSVGElementSize(
@@ -287,10 +290,10 @@ export class Gauge extends Component {
 				.merge(deltaNumber)
 				.attr('text-anchor', 'middle')
 				.style('font-size', `${deltaFontSize(radius)}px`)
-				.text(
-					(d: any) =>
-						`${localeNumberFormatter(Number(numberFormatter(d)), localeCode)}${gaugeSymbol}`
-				)
+				.text((d: any) => {
+					const formattedNumber = Number(numberFormatter(d));
+					return `${isNaN(formattedNumber) ? numberFormatter(d) : localeNumberFormatter(formattedNumber, localeCode)}${gaugeSymbol}`
+				})
 
 			// Add the caret for the delta number
 			const { width: deltaNumberWidth } = DOMUtils.getSVGElementSize(


### PR DESCRIPTION
A PR seems to have broken the use of numberFormatter for some components.  This is quite a large PR so hard to go through and fix each. But I think a quick look:

`localeNumberFormatter(Number(numberFormatter(d)), localeCode))`

numberFormatter should not be wrapped by Number since numberFormatter should allow the consumer to return a string numberFormatter?: (value: number) => string;

Commit introducing this:
https://github.com/RiyaJethwa/carbon-charts/commit/60ef1ec0003be80b3dadbeae26ceaab0327e4729

Checking for NaN was the best option I could find since numberFormatter had a default thing coming from `const gaugeChart: GaugeChartOptions = merge({}, chart, {` which would have been riskier to alter.

Example of the issue:

![Screenshot 2024-02-27 at 12 07 29](https://github.com/carbon-design-system/carbon-charts/assets/8028956/ba33d068-3e6b-4944-92da-ae6d15bc49be)
