### PR TITLE
fix(gauge):conditional gauge numberFormatter

### DIFF
--- a/packages/core/src/components/graphs/gauge.ts
+++ b/packages/core/src/components/graphs/gauge.ts
@@ -211,7 +211,12 @@ export class Gauge extends Component {
 			.style('font-size', `${fontSize}px`)
 			.attr('text-anchor', 'middle')
 			.text((d: any) => {
-				const value = Number(d.toFixed(2)) % 1 !== 0 ? d.toFixed(2) : d.toFixed()
+				let value
+				if (d !== null && d !== undefined) {
+					value = Number(d.toFixed(2)) % 1 !== 0 ? d.toFixed(2) : d.toFixed()
+				} else {
+					value = 0
+				}
 				if (numberFormatter) {
 					return numberFormatter(value)
 				} else {
@@ -295,7 +300,12 @@ export class Gauge extends Component {
 				.attr('text-anchor', 'middle')
 				.style('font-size', `${deltaFontSize(radius)}px`)
 				.text((d: any) => {
-					const value = Number(d.toFixed(2)) % 1 !== 0 ? d.toFixed(2) : d.toFixed()
+					let value
+					if (d !== null && d !== undefined) {
+						value = Number(d.toFixed(2)) % 1 !== 0 ? d.toFixed(2) : d.toFixed()
+					} else {
+						value = 0
+					}
 					if (numberFormatter) {
 						return `${numberFormatter(value)}${gaugeSymbol}`
 					} else {

--- a/packages/core/src/components/graphs/gauge.ts
+++ b/packages/core/src/components/graphs/gauge.ts
@@ -210,7 +210,14 @@ export class Gauge extends Component {
 			.merge(valueNumber as any)
 			.style('font-size', `${fontSize}px`)
 			.attr('text-anchor', 'middle')
-			.text((d: any) => localeNumberFormatter(Number(numberFormatter(d)), localeCode))
+			.text((d: any) => {
+				const value = Number(d.toFixed(2)) % 1 !== 0 ? d.toFixed(2) : d.toFixed()
+				if (numberFormatter) {
+					return numberFormatter(value)
+				} else {
+					return localeNumberFormatter(Number(value), localeCode)
+				}
+			})
 
 		// add the percentage symbol beside the valueNumber
 		const { width: valueNumberWidth } = DOMUtils.getSVGElementSize(
@@ -287,10 +294,14 @@ export class Gauge extends Component {
 				.merge(deltaNumber)
 				.attr('text-anchor', 'middle')
 				.style('font-size', `${deltaFontSize(radius)}px`)
-				.text(
-					(d: any) =>
-						`${localeNumberFormatter(Number(numberFormatter(d)), localeCode)}${gaugeSymbol}`
-				)
+				.text((d: any) => {
+					const value = Number(d.toFixed(2)) % 1 !== 0 ? d.toFixed(2) : d.toFixed()
+					if (numberFormatter) {
+						return `${numberFormatter(value)}${gaugeSymbol}`
+					} else {
+						return `${localeNumberFormatter(Number(value), localeCode)}${gaugeSymbol}`
+					}
+				})
 
 			// Add the caret for the delta number
 			const { width: deltaNumberWidth } = DOMUtils.getSVGElementSize(

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -661,10 +661,6 @@ const gaugeChart: GaugeChartOptions = merge({}, chart, {
 		numberSpacing: 10,
 		deltaFontSize: (radius: number) => radius / 8,
 		valueFontSize: (radius: number) => radius / 2.5,
-		numberFormatter: (value: number) =>
-			Number(value.toFixed(2)) % 1 !== 0
-				? value.toFixed(2).toLocaleString()
-				: value.toFixed().toLocaleString(),
 		alignment: Alignments.LEFT
 	}
 } as GaugeChartOptions)


### PR DESCRIPTION
### Updates
- Removal of default gauge numberFormatter
- Created gauge numberFormatter conditional thus when not passed, defaults to localeNumberFormatter.

### Demo screenshot or recording
When gauge numberFormatter is passed:
<img width="1728" alt="image" src="https://github.com/carbon-design-system/carbon-charts/assets/76566868/12261c0f-6fdb-438e-b87e-a1985d918a16">

When gauge numberFormatter is not passed:
<img width="1728" alt="image" src="https://github.com/carbon-design-system/carbon-charts/assets/76566868/8f6fa334-42cf-4f37-a969-f06b741ea0e8">

Default:
<img width="1728" alt="image" src="https://github.com/carbon-design-system/carbon-charts/assets/76566868/70aa19b3-de14-4738-afdd-916b05566de5">


 