### PR TITLE
fix(pie): distortion issues of hovered slices

### DIFF
--- a/packages/core/src/components/graphs/pie.ts
+++ b/packages/core/src/components/graphs/pie.ts
@@ -1,5 +1,5 @@
 import { arc, interpolate, pie, select } from 'd3'
-import { debounce } from 'lodash-es'
+import { delay } from 'lodash-es'
 import { convertValueToPercentage, getProperty } from '@/tools'
 import { pie as pieConfigs } from '@/configuration'
 import { Component } from '@/components/component'
@@ -392,41 +392,22 @@ export class Pie extends Component {
 	addEventListeners() {
 		const self = this
 
-		const debouncedMouseOver = debounce((hoveredElement: any) => {
-			if (!this.isRendering) {
-				hoveredElement
-					.classed('hovered', true)
-					.transition('pie_slice_mouseover')
-					.call((t: any) =>
-						self.services.transitions.setupTransition({
-							transition: t,
-							name: 'pie_slice_mouseover'
-						})
-					)
-					.attr('d', self.hoverArc)
-			}
-		}, 120, { trailing: true })
-
-		const debouncedMouseOut = debounce((hoveredElement: any) => {
-			if (!this.isRendering) {
-				hoveredElement
-					.classed('hovered', false)
-					.transition('pie_slice_mouseout')
-					.call((t: any) =>
-						self.services.transitions.setupTransition({
-							transition: t,
-							name: 'pie_slice_mouseout'
-						})
-					)
-					.attr('d', self.arc)
-			}
-		}, 120, { trailing: true })
-
 		this.parent
 			.selectAll('path.slice')
 			.on('mouseover', function (event: MouseEvent, datum: any) {
 				const hoveredElement = select(this)
-				debouncedMouseOver(hoveredElement)
+				if (!self.isRendering) {
+					hoveredElement
+						.classed('hovered', true)
+						.transition('pie_slice_mouseover')
+						.call((t: any) =>
+							self.services.transitions.setupTransition({
+								transition: t,
+								name: 'pie_slice_mouseover'
+							})
+						)
+						.attr('d', self.hoverArc)
+				}
 
 				// Dispatch mouse event
 				self.services.events.dispatchEvent(Events.Pie.SLICE_MOUSEOVER, {
@@ -474,7 +455,20 @@ export class Pie extends Component {
 			})
 			.on('mouseout', function (event: MouseEvent, datum: any) {
 				const hoveredElement = select(this)
-				debouncedMouseOut(hoveredElement)
+				delay(() => {
+					if (!self.isRendering) {
+						hoveredElement
+							.classed('hovered', false)
+							.transition('pie_slice_mouseout')
+							.call((t: any) =>
+								self.services.transitions.setupTransition({
+									transition: t,
+									name: 'pie_slice_mouseout'
+								})
+							)
+							.attr('d', self.arc)
+					}
+				}, 100)
 
 				// Dispatch mouse event
 				self.services.events.dispatchEvent(Events.Pie.SLICE_MOUSEOUT, {

--- a/packages/core/src/configuration-non-customizable.ts
+++ b/packages/core/src/configuration-non-customizable.ts
@@ -241,6 +241,9 @@ export const transitions = {
 	pie_slice_mouseover: {
 		duration: 100
 	},
+	pie_slice_mouseout: {
+		duration: 100
+	},
 	pie_chart_titles: {
 		duration: 375
 	},


### PR DESCRIPTION
### Updates
- Fix #1685
- Fix #1764
- use debounce for mouse events to prevent distortion on leaving fullscreen
- add a variable `isRendering` to prevent mouse events fired on rendering animation

### Demo screenshot or recording

Thanks to @ilyas-sov, using the code here for verifying: https://stackblitz.com/edit/react-imtvrq?file=src%2Findex.js,src%2Fdata.js,package.json

1. Deleted by mouse
![delete_via_mouse](https://github.com/carbon-design-system/carbon-charts/assets/126788428/27f93561-6045-4bb7-b173-8363009d6103)

2. Deleted by keyboard + mouse over (easier for verifying)
![delete_via_tab](https://github.com/carbon-design-system/carbon-charts/assets/126788428/c859a726-50b4-4de3-a66f-39c329e2a1fb)

3. Verifying the donut distortion of issue 1685:

    1. Open https://deploy-preview-1771--carbon-charts-core.netlify.app/?path=/story/simple-charts-donut--donut
    2. Enter fullscreen mode
    3. Mouse over to one of the slices
    4. Press "ESC"

