### PR TITLE
fix(bar): bleed-out for includeZero set to false

### DIFF
--- a/packages/core/src/components/graphs/bar-grouped.ts
+++ b/packages/core/src/components/graphs/bar-grouped.ts
@@ -134,7 +134,8 @@ export class GroupedBar extends Bar {
 				const x0 = startX
 				const x1 = startX + barWidth
 				const rangeAxis = this.services.cartesianScales.getRangeAxisPosition({ datum: d })
-				const y0 = this.services.cartesianScales.getValueThroughAxisPosition(rangeAxis, 0)
+				const lowerBound = this.services.cartesianScales.getDomainLowerBound(rangeAxis)
+				const y0 = this.services.cartesianScales.getValueThroughAxisPosition(rangeAxis, lowerBound)
 				const y1 = this.services.cartesianScales.getRangeValue(d)
 
 				// don't show if part of bar is out of zoom domain - test zoom on bar pos, not group

--- a/packages/core/src/services/scales-cartesian.ts
+++ b/packages/core/src/services/scales-cartesian.ts
@@ -636,6 +636,27 @@ export class CartesianScales extends Service {
 		return scale
 	}
 
+	getDomainLowerBound(position: any): number {
+		let domainRange: number[]
+		let lowerBound = 0
+
+		// get domain ranges based on orientations
+		if (this.getOrientation() === CartesianOrientations.VERTICAL) {
+			domainRange = this.getMainYScale().domain() as number[]
+		} else {
+			domainRange = this.getMainXScale().domain() as number[]
+		}
+
+		if (getProperty(this.model.getOptions(), 'axes', position, 'includeZero') === false) {
+			// get domain lowerBound if all are positive values
+			if (domainRange[0] > 0 && domainRange[1] > 0) {
+				lowerBound = domainRange[0]
+			}
+		}
+
+		return lowerBound
+	}
+
 	getHighestDomainThreshold(): null | {
 		threshold: ThresholdOptions
 		scaleValue: number


### PR DESCRIPTION
### Updates
- Closes #1776
- Calculate a lower bound and set to grouped-bar chart when includeZero is set to false in the data axis.

### Demo screenshot or recording

**Test 1: v1.15.2 vertical grouped bar with includeZero set to false**

 - Before: https://charts.carbondesignsystem.com/?path=/story/simple-charts-bar-grouped--vertical-grouped-bar-time-series&args=options.axes.left.includeZero:!false
 - After: https://deploy-preview-1780--carbon-charts-angular.netlify.app/?path=/story/simple-charts-bar-grouped--vertical-grouped-bar-time-series&args=options.axes.left.includeZero:!false

**Test 2: v1.15.2 horizonal grouped bar with includeZero set to false**
 - Before: https://charts.carbondesignsystem.com/?path=/story/simple-charts-bar-grouped--horizontal-grouped-bar-time-series&args=options.axes.bottom.includeZero:!false
 - After: https://deploy-preview-1780--carbon-charts-angular.netlify.app/?path=/story/simple-charts-bar-grouped--horizontal-grouped-bar-time-series&args=options.axes.bottom.includeZero:!false