### PR TITLE
fix(pie): uncaught exception on pie and donut chart load

### DIFF
--- a/packages/core/src/components/graphs/pie.ts
+++ b/packages/core/src/components/graphs/pie.ts
@@ -132,8 +132,7 @@ export class Pie extends Component {
 			.attrTween('d', function (a: any) {
 				return arcTween.bind(this)(a, self.arc)
 			})
-			.end()
-			.finally(() => {
+			.on('end', () => {
 				self.isRendering = false
 			})
 


### PR DESCRIPTION
### Updates
- Closes #1783.
- fix uncaught errors on pie/donut chart load. Quite tricky, I can only re-produce it on production mode.

### Demo screenshot or recording

**Before (uncaught promise):**
https://deploy-preview-1771--carbon-charts-core.netlify.app/?path=/story/simple-charts-donut--donut

**After:**
https://deploy-preview-1784--carbon-charts-react.netlify.app/?path=/story/simple-charts-donut--donut-centered
