### PR TITLE
fix(cardNode-shapeNode):addition of className to props

### DIFF
--- a/packages/react/src/diagrams/CardNode.tsx
+++ b/packages/react/src/diagrams/CardNode.tsx
@@ -11,18 +11,19 @@ type CardNodeProps = {
 	color?: string
 	position?: CssPosition
 	children?: React.ReactNode
+	className?: string
 }
 
 const CardNode: React.FC<
 	CardNodeProps & React.HTMLAttributes<HTMLAnchorElement | HTMLDivElement | HTMLButtonElement>
-> = ({ tag = 'div', children, color, href, position = 'static', stacked, ...rest }) => {
+> = ({ tag = 'div', className, children, color, href, position = 'static', stacked, ...rest }) => {
 	const Component = href ? 'a' : rest.onClick ? 'button' : tag
 
 	const namespace = `${carbonPrefix}--cc--card-node`
 	const cardClasses = classnames(namespace, {
 		[`${namespace}--stacked`]: stacked,
 		[`${namespace}--${Component}`]: Component,
-		[rest.className as string]: rest.className
+		[className as string]: className
 	})
 
 	return (

--- a/packages/react/src/diagrams/ShapeNode.tsx
+++ b/packages/react/src/diagrams/ShapeNode.tsx
@@ -16,6 +16,7 @@ type ShapeNodeProps = {
 	position?: CssPosition
 	bodyPosition?: CssPosition
 	stacked?: boolean
+	className?: string
 }
 
 const ShapeNode: React.FC<
@@ -24,6 +25,7 @@ const ShapeNode: React.FC<
 	shape = 'circle',
 	tag = 'div',
 	title = 'Title',
+	className,
 	subtitle,
 	description,
 	renderIcon,
@@ -41,7 +43,7 @@ const ShapeNode: React.FC<
 		[`${namespace}--stacked`]: stacked,
 		[`${namespace}--${shape}`]: shape,
 		[`${namespace}--${Component}`]: Component,
-		[rest.className as string]: rest.className
+		[className as string]: className
 	})
 
 	const titleElement = title ? <div className={`${namespace}__title`}>{title}</div> : null


### PR DESCRIPTION
### Updates
- class provided as props is not getting appended to carbon charts classes
- addition of className prop to ShapeNode and CardNode

### Demo screenshot or recording
![image](https://github.com/carbon-design-system/carbon-charts/assets/76566868/dd3946fe-21d3-4818-ad85-c186719a7c4d)
