### PR TITLE
fix(meter): meter width shouldn't be smaller than 2px

### DIFF
--- a/packages/core/src/components/graphs/meter.ts
+++ b/packages/core/src/components/graphs/meter.ts
@@ -134,7 +134,7 @@ export class Meter extends Component {
 				})
 			)
 			.attr('width', (d: any) => {
-				return d.value > domainMax ? xScale(domainMax) : d.width
+				return d.value > domainMax ? xScale(domainMax) : Math.max(d.width, 2)
 			})
 			.style('fill', (d: any) => self.model.getFillColor(d[groupMapsTo], null, d))
 			// a11y


### PR DESCRIPTION
### Updates
- sets a minimum width of 2px for meter rectangle (this was already in place in case of a value of 0)
