### PR TITLE
fix: Update package.json style export

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -14,7 +14,9 @@
 			"require": "./dist/index.js"
 		},
 		"./styles.min.css": "./dist/styles.min.css",
-		"./styles.css": "./dist/styles.css"
+		"./styles.min": "./dist/styles.min.css"
+		"./styles.css": "./dist/styles.css",
+		"./styles": "./dist/styles.css",
 	},
 	"files": [
 		"dist",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -14,9 +14,9 @@
 			"require": "./dist/index.js"
 		},
 		"./styles.min.css": "./dist/styles.min.css",
-		"./styles.min": "./dist/styles.min.css"
+		"./styles.min": "./dist/styles.min.css",
 		"./styles.css": "./dist/styles.css",
-		"./styles": "./dist/styles.css",
+		"./styles": "./dist/styles.css"
 	},
 	"files": [
 		"dist",


### PR DESCRIPTION
fix the restricted exports provided by package.json to allow scss to import

### Updates
- adds in a more generic ./styles import so A. you don't have to provide an explicit import of a .css file and B. scss can now handle loading that file using @use instead of @import
