### PR TITLE
chore(angular): linting and add types

### DIFF
--- a/packages/angular/src/lib/charts/alluvial-chart.component.ts
+++ b/packages/angular/src/lib/charts/alluvial-chart.component.ts
@@ -1,15 +1,11 @@
 import { Component, AfterViewInit } from '@angular/core'
 import { BaseChartComponent } from './base-chart.component'
-import {
-	AlluvialChart as AlluvialChartCore,
-	type AlluvialChartOptions,
-	type ChartTabularData
-} from '@carbon/charts'
+import { AlluvialChart as AlluvialChartCore, type AlluvialChartOptions } from '@carbon/charts'
 
 /**
- * Wrapper around `Alluvial` in carbon charts library
+ * Wrapper around `AlluvialChart` from core.
  *
- * Most functions just call their equivalent from the chart library.
+ * Most functions from the core class are exposed.
  */
 @Component({
 	selector: 'ibm-alluvial-chart',
@@ -20,8 +16,8 @@ export class AlluvialChartComponent extends BaseChartComponent implements AfterV
 	 * Runs after view init to create a chart, attach it to `elementRef` and draw it.
 	 */
 	override ngAfterViewInit() {
-		this.chart = new AlluvialChartCore(this.elementRef.nativeElement, {
-			data: this.data as ChartTabularData,
+		this.chart = new AlluvialChartCore(this.elementRef.nativeElement as HTMLDivElement, {
+			data: this.data,
 			options: this.options as AlluvialChartOptions
 		})
 

--- a/packages/angular/src/lib/charts/area-chart-stacked.component.ts
+++ b/packages/angular/src/lib/charts/area-chart-stacked.component.ts
@@ -2,14 +2,13 @@ import { Component, AfterViewInit } from '@angular/core'
 import { BaseChartComponent } from './base-chart.component'
 import {
 	StackedAreaChart as StackedAreaChartCore,
-	type StackedAreaChartOptions,
-	type ChartTabularData
+	type StackedAreaChartOptions
 } from '@carbon/charts'
 
 /**
- * Wrapper around `StackedAreaChart` in carbon charts library
+ * Wrapper around `StackedAreaChart` from core.
  *
- * Most functions just call their equivalent from the chart library.
+ * Most functions from the core class are exposed.
  */
 @Component({
 	selector: 'ibm-stacked-area-chart',
@@ -20,8 +19,8 @@ export class StackedAreaChartComponent extends BaseChartComponent implements Aft
 	 * Runs after view init to create a chart, attach it to `elementRef` and draw it.
 	 */
 	override ngAfterViewInit() {
-		this.chart = new StackedAreaChartCore(this.elementRef.nativeElement, {
-			data: this.data as ChartTabularData,
+		this.chart = new StackedAreaChartCore(this.elementRef.nativeElement as HTMLDivElement, {
+			data: this.data,
 			options: this.options as StackedAreaChartOptions
 		})
 

--- a/packages/angular/src/lib/charts/area-chart.component.ts
+++ b/packages/angular/src/lib/charts/area-chart.component.ts
@@ -1,15 +1,11 @@
 import { Component, AfterViewInit } from '@angular/core'
 import { BaseChartComponent } from './base-chart.component'
-import {
-	AreaChart as AreaChartCore,
-	type AreaChartOptions,
-	type ChartTabularData
-} from '@carbon/charts'
+import { AreaChart as AreaChartCore, type AreaChartOptions } from '@carbon/charts'
 
 /**
- * Wrapper around `AreaChart` in carbon charts library
+ * Wrapper around `AreaChart` from core.
  *
- * Most functions just call their equivalent from the chart library.
+ * Most functions from the core class are exposed.
  */
 @Component({
 	selector: 'ibm-area-chart',
@@ -20,8 +16,8 @@ export class AreaChartComponent extends BaseChartComponent implements AfterViewI
 	 * Runs after view init to create a chart, attach it to `elementRef` and draw it.
 	 */
 	override ngAfterViewInit() {
-		this.chart = new AreaChartCore(this.elementRef.nativeElement, {
-			data: this.data as ChartTabularData,
+		this.chart = new AreaChartCore(this.elementRef.nativeElement as HTMLDivElement, {
+			data: this.data,
 			options: this.options as AreaChartOptions
 		})
 

--- a/packages/angular/src/lib/charts/bar-chart-grouped.component.ts
+++ b/packages/angular/src/lib/charts/bar-chart-grouped.component.ts
@@ -1,15 +1,11 @@
 import { Component, AfterViewInit } from '@angular/core'
 import { BaseChartComponent } from './base-chart.component'
-import {
-	GroupedBarChart as GroupedBarChartCore,
-	type ChartTabularData,
-	type BarChartOptions
-} from '@carbon/charts'
+import { GroupedBarChart as GroupedBarChartCore, type BarChartOptions } from '@carbon/charts'
 
 /**
- * Wrapper around `GroupedBarChart` in carbon charts library
+ * Wrapper around `GroupedBarChart` from core.
  *
- * Most functions just call their equivalent from the chart library.
+ * Most functions from the core class are exposed.
  */
 @Component({
 	selector: 'ibm-grouped-bar-chart',
@@ -20,8 +16,8 @@ export class GroupedBarChartComponent extends BaseChartComponent implements Afte
 	 * Runs after view init to create a chart, attach it to `elementRef` and draw it.
 	 */
 	override ngAfterViewInit() {
-		this.chart = new GroupedBarChartCore(this.elementRef.nativeElement, {
-			data: this.data as ChartTabularData,
+		this.chart = new GroupedBarChartCore(this.elementRef.nativeElement as HTMLDivElement, {
+			data: this.data,
 			options: this.options as BarChartOptions
 		})
 

--- a/packages/angular/src/lib/charts/bar-chart-simple.component.ts
+++ b/packages/angular/src/lib/charts/bar-chart-simple.component.ts
@@ -1,15 +1,11 @@
 import { Component, AfterViewInit } from '@angular/core'
 import { BaseChartComponent } from './base-chart.component'
-import {
-	SimpleBarChart as SimpleBarChartCore,
-	type ChartTabularData,
-	type BarChartOptions
-} from '@carbon/charts'
+import { SimpleBarChart as SimpleBarChartCore, type BarChartOptions } from '@carbon/charts'
 
 /**
- * Wrapper around `SimpleBarChart` in carbon charts library
+ * Wrapper around `SimpleBarChart` from core.
  *
- * Most functions just call their equivalent from the chart library.
+ * Most functions from the core class are exposed.
  */
 @Component({
 	selector: 'ibm-simple-bar-chart',
@@ -20,8 +16,8 @@ export class SimpleBarChartComponent extends BaseChartComponent implements After
 	 * Runs after view init to create a chart, attach it to `elementRef` and draw it.
 	 */
 	override ngAfterViewInit() {
-		this.chart = new SimpleBarChartCore(this.elementRef.nativeElement, {
-			data: this.data as ChartTabularData,
+		this.chart = new SimpleBarChartCore(this.elementRef.nativeElement as HTMLDivElement, {
+			data: this.data,
 			options: this.options as BarChartOptions
 		})
 

--- a/packages/angular/src/lib/charts/bar-chart-stacked.component.ts
+++ b/packages/angular/src/lib/charts/bar-chart-stacked.component.ts
@@ -1,15 +1,11 @@
 import { Component, AfterViewInit } from '@angular/core'
 import { BaseChartComponent } from './base-chart.component'
-import {
-	StackedBarChart as StackedBarChartCore,
-	type ChartTabularData,
-	type StackedBarChartOptions
-} from '@carbon/charts'
+import { StackedBarChart as StackedBarChartCore, type StackedBarChartOptions } from '@carbon/charts'
 
 /**
- * Wrapper around `StackedBarChart` in carbon charts library
+ * Wrapper around `StackedBarChart` from core.
  *
- * Most functions just call their equivalent from the chart library.
+ * Most functions from the core class are exposed.
  */
 @Component({
 	selector: 'ibm-stacked-bar-chart',
@@ -20,8 +16,8 @@ export class StackedBarChartComponent extends BaseChartComponent implements Afte
 	 * Runs after view init to create a chart, attach it to `elementRef` and draw it.
 	 */
 	override ngAfterViewInit() {
-		this.chart = new StackedBarChartCore(this.elementRef.nativeElement, {
-			data: this.data as ChartTabularData,
+		this.chart = new StackedBarChartCore(this.elementRef.nativeElement as HTMLDivElement, {
+			data: this.data,
 			options: this.options as StackedBarChartOptions
 		})
 

--- a/packages/angular/src/lib/charts/boxplot-chart.component.ts
+++ b/packages/angular/src/lib/charts/boxplot-chart.component.ts
@@ -1,15 +1,11 @@
 import { Component, AfterViewInit } from '@angular/core'
 import { BaseChartComponent } from './base-chart.component'
-import {
-	BoxplotChart as BoxplotChartCore,
-	type ChartTabularData,
-	type BoxplotChartOptions
-} from '@carbon/charts'
+import { BoxplotChart as BoxplotChartCore, type BoxplotChartOptions } from '@carbon/charts'
 
 /**
- * Wrapper around `BoxplotChart` in carbon charts library
+ * Wrapper around `BoxplotChart` from core.
  *
- * Most functions just call their equivalent from the chart library.
+ * Most functions from the core class are exposed.
  */
 @Component({
 	selector: 'ibm-boxplot-chart',
@@ -20,8 +16,8 @@ export class BoxplotChartComponent extends BaseChartComponent implements AfterVi
 	 * Runs after view init to create a chart, attach it to `elementRef` and draw it.
 	 */
 	override ngAfterViewInit() {
-		this.chart = new BoxplotChartCore(this.elementRef.nativeElement, {
-			data: this.data as ChartTabularData,
+		this.chart = new BoxplotChartCore(this.elementRef.nativeElement as HTMLDivElement, {
+			data: this.data,
 			options: this.options as BoxplotChartOptions
 		})
 

--- a/packages/angular/src/lib/charts/bubble-chart.component.ts
+++ b/packages/angular/src/lib/charts/bubble-chart.component.ts
@@ -1,15 +1,11 @@
 import { Component, AfterViewInit } from '@angular/core'
 import { BaseChartComponent } from './base-chart.component'
-import {
-	BubbleChart as BubbleChartCore,
-	type BubbleChartOptions,
-	type ChartTabularData
-} from '@carbon/charts'
+import { BubbleChart as BubbleChartCore, type BubbleChartOptions } from '@carbon/charts'
 
 /**
- * Wrapper around `BubbleChart` in carbon charts library
+ * Wrapper around `BubbleChart` from core.
  *
- * Most functions just call their equivalent from the chart library.
+ * Most functions from the core class are exposed.
  */
 @Component({
 	selector: 'ibm-bubble-chart',
@@ -20,8 +16,8 @@ export class BubbleChartComponent extends BaseChartComponent implements AfterVie
 	 * Runs after view init to create a chart, attach it to `elementRef` and draw it.
 	 */
 	override ngAfterViewInit() {
-		this.chart = new BubbleChartCore(this.elementRef.nativeElement, {
-			data: this.data as ChartTabularData,
+		this.chart = new BubbleChartCore(this.elementRef.nativeElement as HTMLDivElement, {
+			data: this.data,
 			options: this.options as BubbleChartOptions
 		})
 

--- a/packages/angular/src/lib/charts/bullet-chart.component.ts
+++ b/packages/angular/src/lib/charts/bullet-chart.component.ts
@@ -1,15 +1,11 @@
 import { Component, AfterViewInit } from '@angular/core'
 import { BaseChartComponent } from './base-chart.component'
-import {
-	BulletChart as BulletChartCore,
-	type BulletChartOptions,
-	type ChartTabularData
-} from '@carbon/charts'
+import { BulletChart as BulletChartCore, type BulletChartOptions } from '@carbon/charts'
 
 /**
- * Wrapper around `BulletChart` in carbon charts library
+ * Wrapper around `BulletChart` from core.
  *
- * Most functions just call their equivalent from the chart library.
+ * Most functions from the core class are exposed.
  */
 @Component({
 	selector: 'ibm-bullet-chart',
@@ -20,8 +16,8 @@ export class BulletChartComponent extends BaseChartComponent implements AfterVie
 	 * Runs after view init to create a chart, attach it to `elementRef` and draw it.
 	 */
 	override ngAfterViewInit() {
-		this.chart = new BulletChartCore(this.elementRef.nativeElement, {
-			data: this.data as ChartTabularData,
+		this.chart = new BulletChartCore(this.elementRef.nativeElement as HTMLDivElement, {
+			data: this.data,
 			options: this.options as BulletChartOptions
 		})
 

--- a/packages/angular/src/lib/charts/choropleth.component.ts
+++ b/packages/angular/src/lib/charts/choropleth.component.ts
@@ -2,14 +2,14 @@ import { Component, AfterViewInit } from '@angular/core'
 import { BaseChartComponent } from './base-chart.component'
 import {
 	ExperimentalChoroplethChart as ChoroplethChartCore,
-	type ChoroplethChartOptions,
-	type ChartTabularData
+	type ChoroplethChartOptions
 } from '@carbon/charts'
 
 /**
- * Wrapper around `Choropleth` in carbon charts library
+ * Wrapper around `ExperimentalChoroplethChart` from core.
  *
- * Most functions just call their equivalent from the chart library.
+ * Most functions from the core class are exposed.
+ * @experimental
  */
 @Component({
 	selector: 'ibm-experimental-choropleth-chart',
@@ -23,8 +23,8 @@ export class ExperimentalChoroplethChartComponent
 	 * Runs after view init to create a chart, attach it to `elementRef` and draw it.
 	 */
 	override ngAfterViewInit() {
-		this.chart = new ChoroplethChartCore(this.elementRef.nativeElement, {
-			data: this.data as ChartTabularData,
+		this.chart = new ChoroplethChartCore(this.elementRef.nativeElement as HTMLDivElement, {
+			data: this.data,
 			options: this.options as ChoroplethChartOptions
 		})
 

--- a/packages/angular/src/lib/charts/circle-pack-chart.component.ts
+++ b/packages/angular/src/lib/charts/circle-pack-chart.component.ts
@@ -1,15 +1,11 @@
 import { Component, AfterViewInit } from '@angular/core'
 import { BaseChartComponent } from './base-chart.component'
-import {
-	CirclePackChart as CirclePackChartCore,
-	type CirclePackChartOptions,
-	type ChartTabularData
-} from '@carbon/charts'
+import { CirclePackChart as CirclePackChartCore, type CirclePackChartOptions } from '@carbon/charts'
 
 /**
- * Wrapper around `CirclePackChart` in carbon charts library
+ * Wrapper around `CirclePackChart` from core.
  *
- * Most functions just call their equivalent from the chart library.
+ * Most functions from the core class are exposed.
  */
 @Component({
 	selector: 'ibm-circle-pack-chart',
@@ -20,8 +16,8 @@ export class CirclePackChartComponent extends BaseChartComponent implements Afte
 	 * Runs after view init to create a chart, attach it to `elementRef` and draw it.
 	 */
 	override ngAfterViewInit() {
-		this.chart = new CirclePackChartCore(this.elementRef.nativeElement, {
-			data: this.data as ChartTabularData,
+		this.chart = new CirclePackChartCore(this.elementRef.nativeElement as HTMLDivElement, {
+			data: this.data,
 			options: this.options as CirclePackChartOptions
 		})
 

--- a/packages/angular/src/lib/charts/combo-chart.component.ts
+++ b/packages/angular/src/lib/charts/combo-chart.component.ts
@@ -1,15 +1,11 @@
 import { Component, AfterViewInit } from '@angular/core'
 import { BaseChartComponent } from './base-chart.component'
-import {
-	ComboChart as ComboChartCore,
-	type ComboChartOptions,
-	type ChartTabularData
-} from '@carbon/charts'
+import { ComboChart as ComboChartCore, type ComboChartOptions } from '@carbon/charts'
 
 /**
- * Wrapper around `ComboChart` in carbon charts library
+ * Wrapper around `ComboChart` from core.
  *
- * Most functions just call their equivalent from the chart library.
+ * Most functions from the core class are exposed.
  */
 @Component({
 	selector: 'ibm-combo-chart',
@@ -20,8 +16,8 @@ export class ComboChartComponent extends BaseChartComponent implements AfterView
 	 * Runs after view init to create a chart, attach it to `elementRef` and draw it.
 	 */
 	override ngAfterViewInit() {
-		this.chart = new ComboChartCore(this.elementRef.nativeElement, {
-			data: this.data as ChartTabularData,
+		this.chart = new ComboChartCore(this.elementRef.nativeElement as HTMLDivElement, {
+			data: this.data,
 			options: this.options as ComboChartOptions
 		})
 

--- a/packages/angular/src/lib/charts/donut-chart.component.ts
+++ b/packages/angular/src/lib/charts/donut-chart.component.ts
@@ -1,15 +1,11 @@
 import { Component, AfterViewInit } from '@angular/core'
 import { BaseChartComponent } from './base-chart.component'
-import {
-	DonutChart as DonutChartCore,
-	type DonutChartOptions,
-	type ChartTabularData
-} from '@carbon/charts'
+import { DonutChart as DonutChartCore, type DonutChartOptions } from '@carbon/charts'
 
 /**
- * Wrapper around `DonutChart` in carbon charts library
+ * Wrapper around `DonutChart` from core.
  *
- * Most functions just call their equivalent from the chart library.
+ * Most functions from the core class are exposed.
  */
 @Component({
 	selector: 'ibm-donut-chart',
@@ -20,8 +16,8 @@ export class DonutChartComponent extends BaseChartComponent implements AfterView
 	 * Runs after view init to create a chart, attach it to `elementRef` and draw it.
 	 */
 	override ngAfterViewInit() {
-		this.chart = new DonutChartCore(this.elementRef.nativeElement, {
-			data: this.data as ChartTabularData,
+		this.chart = new DonutChartCore(this.elementRef.nativeElement as HTMLDivElement, {
+			data: this.data,
 			options: this.options as DonutChartOptions
 		})
 

--- a/packages/angular/src/lib/charts/gauge-chart.component.ts
+++ b/packages/angular/src/lib/charts/gauge-chart.component.ts
@@ -1,15 +1,11 @@
 import { Component, AfterViewInit } from '@angular/core'
 import { BaseChartComponent } from './base-chart.component'
-import {
-	GaugeChart as GaugeChartCore,
-	type GaugeChartOptions,
-	type ChartTabularData
-} from '@carbon/charts'
+import { GaugeChart as GaugeChartCore, type GaugeChartOptions } from '@carbon/charts'
 
 /**
- * Wrapper around `GaugeChart` in carbon charts library
+ * Wrapper around `GaugeChart` from core.
  *
- * Most functions just call their equivalent from the chart library.
+ * Most functions from the core class are exposed.
  */
 @Component({
 	selector: 'ibm-gauge-chart',
@@ -20,8 +16,8 @@ export class GaugeChartComponent extends BaseChartComponent implements AfterView
 	 * Runs after view init to create a chart, attach it to `elementRef` and draw it.
 	 */
 	override ngAfterViewInit() {
-		this.chart = new GaugeChartCore(this.elementRef.nativeElement, {
-			data: this.data as ChartTabularData,
+		this.chart = new GaugeChartCore(this.elementRef.nativeElement as HTMLDivElement, {
+			data: this.data,
 			options: this.options as GaugeChartOptions
 		})
 

--- a/packages/angular/src/lib/charts/heatmap-chart.component.ts
+++ b/packages/angular/src/lib/charts/heatmap-chart.component.ts
@@ -1,15 +1,11 @@
 import { Component, AfterViewInit } from '@angular/core'
 import { BaseChartComponent } from './base-chart.component'
-import {
-	HeatmapChart as HeatmapChartCore,
-	type HeatmapChartOptions,
-	type ChartTabularData
-} from '@carbon/charts'
+import { HeatmapChart as HeatmapChartCore, type HeatmapChartOptions } from '@carbon/charts'
 
 /**
- * Wrapper around `Heatmap` in carbon charts library
+ * Wrapper around `Heatmap` from core.
  *
- * Most functions just call their equivalent from the chart library.
+ * Most functions from the core class are exposed.
  */
 @Component({
 	selector: 'ibm-heatmap-chart',
@@ -20,8 +16,8 @@ export class HeatmapChartComponent extends BaseChartComponent implements AfterVi
 	 * Runs after view init to create a chart, attach it to `elementRef` and draw it.
 	 */
 	override ngAfterViewInit() {
-		this.chart = new HeatmapChartCore(this.elementRef.nativeElement, {
-			data: this.data as ChartTabularData,
+		this.chart = new HeatmapChartCore(this.elementRef.nativeElement as HTMLDivElement, {
+			data: this.data,
 			options: this.options as HeatmapChartOptions
 		})
 

--- a/packages/angular/src/lib/charts/histogram-chart.component.ts
+++ b/packages/angular/src/lib/charts/histogram-chart.component.ts
@@ -1,15 +1,11 @@
 import { Component, AfterViewInit } from '@angular/core'
 import { BaseChartComponent } from './base-chart.component'
-import {
-	HistogramChart as HistogramChartCore,
-	type HistogramChartOptions,
-	type ChartTabularData
-} from '@carbon/charts'
+import { HistogramChart as HistogramChartCore, type HistogramChartOptions } from '@carbon/charts'
 
 /**
- * Wrapper around `HistogramChart` in carbon charts library
+ * Wrapper around `HistogramChart` from core.
  *
- * Most functions just call their equivalent from the chart library.
+ * Most functions from the core class are exposed.
  */
 @Component({
 	selector: 'ibm-histogram-chart',
@@ -20,8 +16,8 @@ export class HistogramChartComponent extends BaseChartComponent implements After
 	 * Runs after view init to create a chart, attach it to `elementRef` and draw it.
 	 */
 	override ngAfterViewInit() {
-		this.chart = new HistogramChartCore(this.elementRef.nativeElement, {
-			data: this.data as ChartTabularData,
+		this.chart = new HistogramChartCore(this.elementRef.nativeElement as HTMLDivElement, {
+			data: this.data,
 			options: this.options as HistogramChartOptions
 		})
 

--- a/packages/angular/src/lib/charts/line-chart.component.ts
+++ b/packages/angular/src/lib/charts/line-chart.component.ts
@@ -1,15 +1,11 @@
 import { Component, AfterViewInit } from '@angular/core'
 import { BaseChartComponent } from './base-chart.component'
-import {
-	LineChart as LineChartCore,
-	type LineChartOptions,
-	type ChartTabularData
-} from '@carbon/charts'
+import { LineChart as LineChartCore, type LineChartOptions } from '@carbon/charts'
 
 /**
- * Wrapper around `LineChart` in carbon charts library
+ * Wrapper around `LineChart` from core.
  *
- * Most functions just call their equivalent from the chart library.
+ * Most functions from the core class are exposed.
  */
 @Component({
 	selector: 'ibm-line-chart',
@@ -20,8 +16,8 @@ export class LineChartComponent extends BaseChartComponent implements AfterViewI
 	 * Runs after view init to create a chart, attach it to `elementRef` and draw it.
 	 */
 	override ngAfterViewInit() {
-		this.chart = new LineChartCore(this.elementRef.nativeElement, {
-			data: this.data as ChartTabularData,
+		this.chart = new LineChartCore(this.elementRef.nativeElement as HTMLDivElement, {
+			data: this.data,
 			options: this.options as LineChartOptions
 		})
 

--- a/packages/angular/src/lib/charts/lollipop-chart.component.ts
+++ b/packages/angular/src/lib/charts/lollipop-chart.component.ts
@@ -1,15 +1,11 @@
 import { Component, AfterViewInit } from '@angular/core'
 import { BaseChartComponent } from './base-chart.component'
-import {
-	LollipopChart as LollipopChartCore,
-	type LollipopChartOptions,
-	type ChartTabularData
-} from '@carbon/charts'
+import { LollipopChart as LollipopChartCore, type LollipopChartOptions } from '@carbon/charts'
 
 /**
- * Wrapper around `LollipopChart` in carbon charts library
+ * Wrapper around `LollipopChart` from core.
  *
- * Most functions just call their equivalent from the chart library.
+ * Most functions from the core class are exposed.
  */
 @Component({
 	selector: 'ibm-lollipop-chart',
@@ -20,8 +16,8 @@ export class LollipopChartComponent extends BaseChartComponent implements AfterV
 	 * Runs after view init to create a chart, attach it to `elementRef` and draw it.
 	 */
 	override ngAfterViewInit() {
-		this.chart = new LollipopChartCore(this.elementRef.nativeElement, {
-			data: this.data as ChartTabularData,
+		this.chart = new LollipopChartCore(this.elementRef.nativeElement as HTMLDivElement, {
+			data: this.data,
 			options: this.options as LollipopChartOptions
 		})
 

--- a/packages/angular/src/lib/charts/meter-chart.component.ts
+++ b/packages/angular/src/lib/charts/meter-chart.component.ts
@@ -1,15 +1,11 @@
 import { Component, AfterViewInit } from '@angular/core'
 import { BaseChartComponent } from './base-chart.component'
-import {
-	MeterChart as MeterChartCore,
-	type MeterChartOptions,
-	type ChartTabularData
-} from '@carbon/charts'
+import { MeterChart as MeterChartCore, type MeterChartOptions } from '@carbon/charts'
 
 /**
- * Wrapper around `MeterChart` in carbon charts library
+ * Wrapper around `MeterChart` from core.
  *
- * Most functions just call their equivalent from the chart library.
+ * Most functions from the core class are exposed.
  */
 @Component({
 	selector: 'ibm-meter-chart',
@@ -20,8 +16,8 @@ export class MeterChartComponent extends BaseChartComponent implements AfterView
 	 * Runs after view init to create a chart, attach it to `elementRef` and draw it.
 	 */
 	override ngAfterViewInit() {
-		this.chart = new MeterChartCore(this.elementRef.nativeElement, {
-			data: this.data as ChartTabularData,
+		this.chart = new MeterChartCore(this.elementRef.nativeElement as HTMLDivElement, {
+			data: this.data,
 			options: this.options as MeterChartOptions
 		})
 

--- a/packages/angular/src/lib/charts/pie-chart.component.ts
+++ b/packages/angular/src/lib/charts/pie-chart.component.ts
@@ -1,15 +1,11 @@
 import { Component, AfterViewInit } from '@angular/core'
 import { BaseChartComponent } from './base-chart.component'
-import {
-	PieChart as PieChartCore,
-	type PieChartOptions,
-	type ChartTabularData
-} from '@carbon/charts'
+import { PieChart as PieChartCore, type PieChartOptions } from '@carbon/charts'
 
 /**
- * Wrapper around `PieChart` in carbon charts library
+ * Wrapper around `PieChart` from core.
  *
- * Most functions just call their equivalent from the chart library.
+ * Most functions from the core class are exposed.
  */
 @Component({
 	selector: 'ibm-pie-chart',
@@ -20,8 +16,8 @@ export class PieChartComponent extends BaseChartComponent implements AfterViewIn
 	 * Runs after view init to create a chart, attach it to `elementRef` and draw it.
 	 */
 	override ngAfterViewInit() {
-		this.chart = new PieChartCore(this.elementRef.nativeElement, {
-			data: this.data as ChartTabularData,
+		this.chart = new PieChartCore(this.elementRef.nativeElement as HTMLDivElement, {
+			data: this.data,
 			options: this.options as PieChartOptions
 		})
 

--- a/packages/angular/src/lib/charts/radar-chart.component.ts
+++ b/packages/angular/src/lib/charts/radar-chart.component.ts
@@ -1,15 +1,11 @@
 import { Component, AfterViewInit } from '@angular/core'
 import { BaseChartComponent } from './base-chart.component'
-import {
-	RadarChart as RadarChartCore,
-	type RadarChartOptions,
-	type ChartTabularData
-} from '@carbon/charts'
+import { RadarChart as RadarChartCore, type RadarChartOptions } from '@carbon/charts'
 
 /**
- * Wrapper around `RadarChart` in carbon charts library
+ * Wrapper around `RadarChart` from core.
  *
- * Most functions just call their equivalent from the chart library.
+ * Most functions from the core class are exposed.
  */
 @Component({
 	selector: 'ibm-radar-chart',
@@ -20,8 +16,8 @@ export class RadarChartComponent extends BaseChartComponent implements AfterView
 	 * Runs after view init to create a chart, attach it to `elementRef` and draw it.
 	 */
 	override ngAfterViewInit() {
-		this.chart = new RadarChartCore(this.elementRef.nativeElement, {
-			data: this.data as ChartTabularData,
+		this.chart = new RadarChartCore(this.elementRef.nativeElement as HTMLDivElement, {
+			data: this.data,
 			options: this.options as RadarChartOptions
 		})
 

--- a/packages/angular/src/lib/charts/scatter-chart.component.ts
+++ b/packages/angular/src/lib/charts/scatter-chart.component.ts
@@ -1,15 +1,11 @@
 import { Component, AfterViewInit } from '@angular/core'
 import { BaseChartComponent } from './base-chart.component'
-import {
-	ScatterChart as ScatterChartCore,
-	type ScatterChartOptions,
-	type ChartTabularData
-} from '@carbon/charts'
+import { ScatterChart as ScatterChartCore, type ScatterChartOptions } from '@carbon/charts'
 
 /**
- * Wrapper around `ScatterChart` in carbon charts library
+ * Wrapper around `ScatterChart` from core.
  *
- * Most functions just call their equivalent from the chart library.
+ * Most functions from the core class are exposed.
  */
 @Component({
 	selector: 'ibm-scatter-chart',
@@ -20,8 +16,8 @@ export class ScatterChartComponent extends BaseChartComponent implements AfterVi
 	 * Runs after view init to create a chart, attach it to `elementRef` and draw it.
 	 */
 	override ngAfterViewInit() {
-		this.chart = new ScatterChartCore(this.elementRef.nativeElement, {
-			data: this.data as ChartTabularData,
+		this.chart = new ScatterChartCore(this.elementRef.nativeElement as HTMLDivElement, {
+			data: this.data,
 			options: this.options as ScatterChartOptions
 		})
 

--- a/packages/angular/src/lib/charts/tree-chart.component.ts
+++ b/packages/angular/src/lib/charts/tree-chart.component.ts
@@ -1,15 +1,11 @@
 import { Component, AfterViewInit } from '@angular/core'
 import { BaseChartComponent } from './base-chart.component'
-import {
-	TreeChart as TreeChartCore,
-	type TreemapChartOptions,
-	type ChartTabularData
-} from '@carbon/charts'
+import { TreeChart as TreeChartCore } from '@carbon/charts'
 
 /**
- * Wrapper around `TreeChart` in carbon charts library
+ * Wrapper around `TreeChart` from core.
  *
- * Most functions just call their equivalent from the chart library.
+ * Most functions from the core class are exposed.
  */
 @Component({
 	selector: 'ibm-tree-chart',
@@ -20,9 +16,9 @@ export class TreeChartComponent extends BaseChartComponent implements AfterViewI
 	 * Runs after view init to create a chart, attach it to `elementRef` and draw it.
 	 */
 	override ngAfterViewInit() {
-		this.chart = new TreeChartCore(this.elementRef.nativeElement, {
-			data: this.data as ChartTabularData,
-			options: this.options as TreemapChartOptions
+		this.chart = new TreeChartCore(this.elementRef.nativeElement as HTMLDivElement, {
+			data: this.data,
+			options: this.options
 		})
 
 		Object.assign(this, this.chart)

--- a/packages/angular/src/lib/charts/treemap-chart.component.ts
+++ b/packages/angular/src/lib/charts/treemap-chart.component.ts
@@ -1,15 +1,11 @@
 import { Component, AfterViewInit } from '@angular/core'
 import { BaseChartComponent } from './base-chart.component'
-import {
-	TreemapChart as TreemapChartCore,
-	type TreemapChartOptions,
-	type ChartTabularData
-} from '@carbon/charts'
+import { TreemapChart as TreemapChartCore } from '@carbon/charts'
 
 /**
- * Wrapper around `TreemapChart` in carbon charts library
+ * Wrapper around `TreemapChart` from core.
  *
- * Most functions just call their equivalent from the chart library.
+ * Most functions from the core class are exposed.
  */
 @Component({
 	selector: 'ibm-treemap-chart',
@@ -20,9 +16,9 @@ export class TreemapChartComponent extends BaseChartComponent implements AfterVi
 	 * Runs after view init to create a chart, attach it to `elementRef` and draw it.
 	 */
 	override ngAfterViewInit() {
-		this.chart = new TreemapChartCore(this.elementRef.nativeElement, {
-			data: this.data as ChartTabularData,
-			options: this.options as TreemapChartOptions
+		this.chart = new TreemapChartCore(this.elementRef.nativeElement as HTMLDivElement, {
+			data: this.data,
+			options: this.options
 		})
 
 		Object.assign(this, this.chart)

--- a/packages/angular/src/lib/charts/wordcloud-chart.component.ts
+++ b/packages/angular/src/lib/charts/wordcloud-chart.component.ts
@@ -2,14 +2,13 @@ import { Component, AfterViewInit } from '@angular/core'
 import { BaseChartComponent } from './base-chart.component'
 import {
 	WordCloudChart as WordCloudChartCore,
-	type WorldCloudChartOptions,
-	type ChartTabularData
+	type WorldCloudChartOptions as WordCloudChartOptions
 } from '@carbon/charts'
 
 /**
- * Wrapper around `WordCloudChart` in carbon charts library
+ * Wrapper around `WordCloudChart` from core.
  *
- * Most functions just call their equivalent from the chart library.
+ * Most functions from the core class are exposed.
  */
 @Component({
 	selector: 'ibm-wordcloud-chart',
@@ -20,9 +19,9 @@ export class WordCloudChartComponent extends BaseChartComponent implements After
 	 * Runs after view init to create a chart, attach it to `elementRef` and draw it.
 	 */
 	override ngAfterViewInit() {
-		this.chart = new WordCloudChartCore(this.elementRef.nativeElement, {
-			data: this.data as ChartTabularData,
-			options: this.options as WorldCloudChartOptions
+		this.chart = new WordCloudChartCore(this.elementRef.nativeElement as HTMLDivElement, {
+			data: this.data,
+			options: this.options as WordCloudChartOptions
 		})
 
 		Object.assign(this, this.chart)

--- a/packages/angular/src/lib/diagrams/nodes/cards/card-node.component.ts
+++ b/packages/angular/src/lib/diagrams/nodes/cards/card-node.component.ts
@@ -76,7 +76,6 @@ export class CardNodeComponent implements OnInit {
 	@Input() stacked = false
 	@Input() position = 'static'
 
-	// eslint-disable-next-line @angular-eslint/no-output-native
 	@Output() click: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>()
 	@Output() mouseEnter: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>()
 	@Output() mouseOver: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>()

--- a/packages/angular/src/lib/index.ts
+++ b/packages/angular/src/lib/index.ts
@@ -48,3 +48,35 @@ export {
 	ShapeNodeComponent,
 	ShapeNodeModule
 } from './diagrams'
+
+// Republish essential types from core so it's not a required dependency for TypeScript projects
+export type {
+	ChartTabularData,
+	ChartOptions,
+	AlluvialChartOptions,
+	AreaChartOptions,
+	BarChartOptions,
+	BoxplotChartOptions,
+	BubbleChartOptions,
+	BulletChartOptions,
+	ChoroplethChartOptions,
+	CirclePackChartOptions,
+	ComboChartOptions,
+	DonutChartOptions,
+	GaugeChartOptions,
+	HeatmapChartOptions,
+	HistogramChartOptions,
+	LineChartOptions,
+	LollipopChartOptions,
+	MeterChartOptions,
+	PieChartOptions,
+	RadarChartOptions,
+	ScatterChartOptions,
+	StackedAreaChartOptions,
+	TreeChartOptions,
+	TreemapChartOptions,
+	WorldCloudChartOptions as WordCloudChartOptions
+} from '@carbon/charts'
+
+// Commonly-used enums
+export { Alignments, ChartTheme, ScaleTypes } from '@carbon/charts'

--- a/packages/angular/telemetry.yml
+++ b/packages/angular/telemetry.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
 version: 1
 projectId: 418a02f0-ef56-4acf-81ec-481d9078cbc9
-endpoint: "https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics"
+endpoint: 'https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics'
 collect:
   npm:
     dependencies: null
   js:
     functions: {}
-    tokens: 
+    tokens:


### PR DESCRIPTION
### Updates

- Removed explicit types for ChartTabularData that were already established in the BaseChartComponent.
- Updated comments
- Added @experimental to JSDoc comment for Choropleth
- Republished common types so users don't have to import `@carbon/charts` just for types
- Submitting separately from docs PR to break it down into smaller pieces