### PR TITLE
chore(HeatmapChartOptions): include typings for axes on HeatmapChartOptions

### DIFF
--- a/packages/core/src/interfaces/charts.ts
+++ b/packages/core/src/interfaces/charts.ts
@@ -552,6 +552,7 @@ export interface AlluvialChartOptions extends BaseChartOptions {
  * options specific to Heatmap charts
  */
 export interface HeatmapChartOptions extends BaseChartOptions {
+	axes?: AxesOptions<ComboChartAxisOptions>
 	heatmap: {
 		/**
 		 * Divider width state - will default to auto


### PR DESCRIPTION
### Updates

The Heatmap component supports axes (which are also used on the stories in storybook), but the typings for HeatmapCharOptions does not include any axes.

I wasn't sure whether it is enough to just add the `axes` prop, or we instead should extend the `AxisChartOptions` instead of `BaseChartOptions`
