### PR TITLE
fix(1856): add cjs to umd bundles and update package.json exports

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,7 @@
 	"description": "Carbon Charts component library",
 	"type": "module",
 	"module": "./dist/index.mjs",
-	"main": "./dist/umd/bundle.umd.js",
+	"main": "./dist/umd/bundle.umd.cjs",
 	"types": "./dist/index.d.ts",
 	"exports": {
 		"./package.json": "./package.json",
@@ -16,11 +16,11 @@
 			"types": "./dist/index.d.ts",
 			"browser": {
 				"import": "./dist/index.mjs",
-				"require": "./dist/umd/bundle.umd.js"
+				"require": "./dist/umd/bundle.umd.cjs"
 			},
 			"node": {
 				"import": "./dist/index.mjs",
-				"require": "./dist/umd/bundle.umd.js"
+				"require": "./dist/umd/bundle.umd.cjs"
 			}
 		},
 		"./components": {

--- a/packages/core/vite.umd.config.ts
+++ b/packages/core/vite.umd.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
 	build: {
 		rollupOptions: {
 			output: {
-				entryFileNames: 'bundle.umd.js'
+				entryFileNames: 'bundle.umd.cjs'
 			},
 			plugins: [
 				replace({

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -3,15 +3,15 @@
 	"version": "1.16.9",
 	"description": "Carbon Charts component library for React",
 	"type": "module",
-	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",
+	"main": "./dist/index.umd.cjs",
 	"types": "./dist/index.d.ts",
 	"exports": {
 		"./package.json": "./package.json",
 		".": {
 			"types": "./dist/index.d.ts",
 			"import": "./dist/index.mjs",
-			"require": "./dist/index.js"
+			"require": "./dist/index.umd.cjs"
 		},
 		"./styles.min.css": "./dist/styles.min.css",
 		"./styles.min": "./dist/styles.min.css",

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
 		lib: {
 			entry: 'src/index.ts',
 			name: 'ChartsReact',
-			fileName: format => `index.${format === 'es' ? 'm' : ''}js`
+			fileName: format => `index.${format === 'es' ? 'm' : 'umd.c'}js`
 		},
 		rollupOptions: {
 			external: ['react', 'react-dom'],


### PR DESCRIPTION
### Updates

- Vite.js recommends that library projects have "type": "module" in their package.json. If you are generating UMD, Vite now defaults to adding a .cjs extension to reinforce that it should be loaded with `require`.
- `@carbon/charts` and `@carbon/charts-react` generate UMD files but their extensions where .js. Because their package.json files had "type": "module", Webpack assumed these to be ES modules - not UMD.
- This change makes the UMD bundles for both packages end in .cjs so Webpack recognizes their format correctly. 
- Should close https://github.com/carbon-design-system/carbon-charts/issues/1856 but needs to be confirmed