### PR TITLE
feat(tooltip): pass datum to customHTML callback function

### DIFF
--- a/packages/core/src/components/axes/ruler-binned.ts
+++ b/packages/core/src/components/axes/ruler-binned.ts
@@ -86,6 +86,7 @@ export class BinnedRuler extends Ruler {
 
 			if (thereIsMatchingData) {
 				this.services.events.dispatchEvent(Events.Tooltip.SHOW, {
+					event,
 					mousePosition: [x, y],
 					hoveredElement: rulerLine,
 					items: [

--- a/packages/core/src/components/axes/ruler.ts
+++ b/packages/core/src/components/axes/ruler.ts
@@ -159,6 +159,7 @@ export class Ruler extends Component {
 			this.elementsToHighlight = elementsToHighlight
 
 			this.services.events.dispatchEvent(Events.Tooltip.SHOW, {
+				event,
 				mousePosition: [x, y],
 				hoveredElement: rulerLine,
 				data: this.formatTooltipData(tooltipData)

--- a/packages/core/src/components/essentials/tooltip.ts
+++ b/packages/core/src/components/essentials/tooltip.ts
@@ -27,6 +27,7 @@ export class Tooltip extends Component {
 
 	handleShowTooltip = (e: any) => {
 		const data = e.detail.data || e.detail.items
+		const datum = select(e.detail.event.target).datum()
 
 		let defaultHTML: any
 		const formattedItems = this.formatItems(this.getItems(e))
@@ -49,7 +50,7 @@ export class Tooltip extends Component {
 			} else {
 				tooltipTextContainer.html(
 					`<div class="title-tooltip"><p>${sanitizeHtml(
-						this.model.getOptions().tooltip.customHTML(data, defaultHTML)
+						this.model.getOptions().tooltip.customHTML(data, defaultHTML, datum)
 					)}</p></div>`
 				)
 			}

--- a/packages/core/src/interfaces/components.ts
+++ b/packages/core/src/interfaces/components.ts
@@ -159,9 +159,10 @@ export interface TooltipOptions {
 	valueFormatter?: (value: any, label: string) => string
 	/**
 	 * custom function for returning tooltip HTML
-	 * passed an array or object with the data, and then the default tooltip markup
+	 * passed an array or object with the data, the default tooltip markup
+	 * and the corresponding datum of the hovered element
 	 */
-	customHTML?: (data: any, defaultHTML: string) => string
+	customHTML?: (data: any, defaultHTML: string, datum: any) => string
 	/**
 	 * customizes the `Group` label shown inside tooltips
 	 */


### PR DESCRIPTION
### Updates

- updated handler for tooltip show event to extract the datum from the event details and pass it as an argument to the customHTML callback function if one was specified within the chart options

Close #1518

### Details

The raw data point/points provided to the chart is not what gets propagated to the tooltip's customHTML callback function. 

This PR tries to address that issue by providing the "datum" associated with the hovered element as an argument to the `customHTML` callback, however, this solution still does not propagate the _raw_ data point/points passed to the chart as certain charts will modify the datum with extraneous properties.

This solution was chosen due to its unobtrusiveness rather than its preciseness. Ideally, the _raw_ data would be passed as an argument to the `customHTML` callback but it was unclear how to accomplish this without the solution getting more involved.

### Other issues

https://github.com/carbon-design-system/carbon-charts/issues/774
https://github.com/carbon-design-system/carbon-charts/issues/1426
