### PR TITLE
fix(treemap): assign leaf text color based on custom colors

### DIFF
--- a/packages/core/src/components/graphs/treemap.ts
+++ b/packages/core/src/components/graphs/treemap.ts
@@ -25,14 +25,15 @@ const findColorShade = (hex: string) => {
 	return null
 }
 
-const textFillColor = function () {
-	const correspondingLeaf = select(this.parentNode).select('rect.leaf') as any
-	const correspondingLeafFill = getComputedStyle(correspondingLeaf.node(), null).getPropertyValue(
-		'fill'
-	)
-	const cl = d3Color(correspondingLeafFill) as any
+const textFillColor = function (data) {
+	const correspondingLeaf = select(this.parentNode).select('rect.leaf')
+	const correspondingLeafFill: string =
+		data.backgroundColor ??
+		getComputedStyle(correspondingLeaf.node() as Element, null).getPropertyValue('fill')
+	const cl = d3Color(correspondingLeafFill)
 
 	let colorShade: any
+
 	if (cl) {
 		colorShade = findColorShade(cl ? cl.hex() : null)
 	}
@@ -199,7 +200,7 @@ export class Treemap extends Component {
 					return [
 						{
 							text: d.data.name,
-							color: color.l < 0.5 ? 'white' : 'black'
+							backgroundColor: color
 						}
 					]
 				},

--- a/packages/core/src/components/graphs/treemap.ts
+++ b/packages/core/src/components/graphs/treemap.ts
@@ -196,11 +196,11 @@ export class Treemap extends Component {
 
 					let parent = d
 					while (parent.depth > 1) parent = parent.parent
-					const color = hsl(this.model.getFillColor(parent.data.name))
+
 					return [
 						{
 							text: d.data.name,
-							backgroundColor: color
+							backgroundColor: this.model.getFillColor(parent.data.name)
 						}
 					]
 				},

--- a/packages/docs/src/lib/treemap/index.ts
+++ b/packages/docs/src/lib/treemap/index.ts
@@ -16,6 +16,21 @@ const options: TreemapChartOptions = {
 	height: '600px'
 }
 
+const customColorOptions: TreemapChartOptions = {
+	title: 'Treemap (Custom colors)',
+	height: '600px',
+	color: {
+		scale: {
+			Oceania: '#d9fbfb',
+			Europe: '#9ef0f0',
+			America: '#3ddbd9',
+			Australia: '#08bdba',
+			Africa: '#009d9a',
+			Asia: '#081a1c'
+		}
+	}
+}
+
 const data: ChartTabularData = [
 	{
 		name: 'Oceania',
@@ -110,6 +125,11 @@ export const examples: Example[] = [
 	{
 		data,
 		options,
+		tags: ['test']
+	},
+	{
+		data,
+		options: customColorOptions,
 		tags: ['test']
 	}
 ]

--- a/packages/docs/src/lib/treemap/index.ts
+++ b/packages/docs/src/lib/treemap/index.ts
@@ -21,12 +21,12 @@ const customColorOptions: TreemapChartOptions = {
 	height: '600px',
 	color: {
 		scale: {
-			Oceania: '#d9fbfb',
-			Europe: '#9ef0f0',
-			America: '#3ddbd9',
-			Australia: '#08bdba',
-			Africa: '#009d9a',
-			Asia: '#081a1c'
+			Oceania: '#3ddbd9',
+			Europe: '#08bdba',
+			America: '#009d9a',
+			Australia: '#007d79',
+			Africa: '#005d5d',
+			Asia: '#004144'
 		}
 	}
 }


### PR DESCRIPTION
- updated treemap chart to set the background color in data for the leaf text node so it can be referenced when determining the text color

Fix #1880

https://github.com/user-attachments/assets/296a09aa-3085-4e9f-a07a-24308498f0d1