### PR TITLE
refactor(axis): use css-classes instead of style

### DIFF
--- a/packages/core/scss/components/_axis.scss
+++ b/packages/core/scss/components/_axis.scss
@@ -32,6 +32,14 @@
 		g.tick text {
 			fill: theme.$text-secondary;
 			font-family: var(--#{globals.$prefix}-charts-font-family-condensed);
+
+			&.primary-tick-label {
+				font-weight: bold;
+			}
+
+			&.tick-label {
+				font-weight: normal;
+			}
 		}
 
 		g.tick line {

--- a/packages/core/scss/components/_axis.scss
+++ b/packages/core/scss/components/_axis.scss
@@ -33,7 +33,7 @@
 			fill: theme.$text-secondary;
 			font-family: var(--#{globals.$prefix}-charts-font-family-condensed);
 
-			&.primary-tick-label {
+			&.tick-label--primary {
 				font-weight: bold;
 			}
 

--- a/packages/core/src/components/axes/axis.ts
+++ b/packages/core/src/components/axes/axis.ts
@@ -406,11 +406,11 @@ export class Axis extends Component {
 				.data(axis.tickValues(), scale)
 				.order()
 				.select('text')
-			ticks.style('font-weight', (tick: number, i: number) => {
-				return isTickPrimary(tick, i, axis.tickValues(), timeInterval, showDayName)
-					? 'bold'
-					: 'normal'
-			})
+			ticks.attr('class', (tick: number, i: number) =>
+				isTickPrimary(tick, i, axis.tickValues(), timeInterval, showDayName)
+					? 'primary-tick-label'
+					: 'tick-label'
+			)
 		} else {
 			if (!animate || !axisRefExists) {
 				axisRef = axisRef.call(axis)

--- a/packages/core/src/components/axes/axis.ts
+++ b/packages/core/src/components/axes/axis.ts
@@ -408,7 +408,7 @@ export class Axis extends Component {
 				.select('text')
 			ticks.attr('class', (tick: number, i: number) =>
 				isTickPrimary(tick, i, axis.tickValues(), timeInterval, showDayName)
-					? 'primary-tick-label'
+					? 'tick-label--primary'
 					: 'tick-label'
 			)
 		} else {


### PR DESCRIPTION
* adds css-classes to ticks to make them more accessible from outside

### Updates

- issues #1896 