### PR TITLE
fix(svelte): resolve Svelte 5 warning for self-closing tags

### DIFF
--- a/packages/svelte/src/lib/BaseChart.svelte
+++ b/packages/svelte/src/lib/BaseChart.svelte
@@ -53,4 +53,4 @@
 	})
 </script>
 
-<div {id} bind:this={ref} class={chartHolderCssClass} {...$$restProps} />
+<div {id} bind:this={ref} class={chartHolderCssClass} {...$$restProps}></div>


### PR DESCRIPTION
Svelte 5 now emits a development warning against [self-closing tags](https://svelte.dev/docs/svelte/compiler-warnings#elementinvalidselfclosingtag) for non-void elements.

For background, I'm upgrading my [examples repo](https://github.com/metonym/carbon-charts-svelte-examples) to use Svelte 5.

This library is generally compatible as-is. See https://github.com/metonym/carbon-charts-svelte-examples/pull/5 for a repro.

```sh
Self-closing HTML tags for non-void elements are ambiguous — use `<div ...></div>` rather than `<div ... />`
```


### Updates

- fix(svelte): resolve Svelte self-closing tag warning

### Demo screenshot or recording
