### PR TITLE
fix: exclude jsx-runtime from bundle

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -43,8 +43,8 @@
 		"@ibm/telemetry-js": "^1.8.0"
 	},
 	"peerDependencies": {
-		"react": "17.0.1 || ^18.2.0",
-		"react-dom": "^17.0.1 || ^18.2.0"
+		"react": "^16.8.6 || ^17.0.1 || ^18.2.0",
+		"react-dom": "^16.8.6 || ^17.0.1 || ^18.2.0"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.49.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -43,8 +43,8 @@
 		"@ibm/telemetry-js": "^1.8.0"
 	},
 	"peerDependencies": {
-		"react": "^16.8.6 || ^17.0.1 || ^18.2.0",
-		"react-dom": "^16.8.6 || ^17.0.1 || ^18.2.0"
+		"react": "17.0.1 || ^18.2.0",
+		"react-dom": "^17.0.1 || ^18.2.0"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.49.0",

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
 			fileName: format => `index.${format === 'es' ? 'm' : 'umd.c'}js`
 		},
 		rollupOptions: {
-			external: ['react', 'react-dom'],
+			external: ['react', 'react-dom', 'react/jsx-runtime'],
 			output: {
 				globals: {
 					react: 'React'


### PR DESCRIPTION
### Updates

Exclude react/jsx-runtime from the final bundle.  This should be excluded to allow users to update to React v19.

Including this dependency in the bundle results in 
`"TypeError: Cannot read properties of undefined (reading 'ReactCurrentDispatcher')"`

fixes #1927 
