### PR TITLE
fix: add presentation role for pie n donut chart skeleton

### DIFF
--- a/packages/core/src/components/graphs/skeleton.ts
+++ b/packages/core/src/components/graphs/skeleton.ts
@@ -184,6 +184,7 @@ export class Skeleton extends Component {
 		const container = DOMUtils.appendOrSelect(svg, 'svg.chart-skeleton')
 			.attr('width', width)
 			.attr('height', height)
+			.attr('role', 'presentation')
 
 		const optionName = innerRadius === 0 ? 'pie' : 'donut'
 


### PR DESCRIPTION
closes: https://github.com/carbon-design-system/carbon-charts/issues/1984

### Updates

Added `role` as `presentation` for skeleton svgs of pie and donut chart

### Demo screenshot or recording

<img width="499" alt="Screenshot 2025-05-07 at 4 43 23 PM" src="https://github.com/user-attachments/assets/e9bc9fa1-34b2-4d16-ae13-7ac4486c7e7d" />
