### PR TITLE
fix: add field name in aria label for pie and donut chart

### DIFF
--- a/packages/core/src/components/graphs/pie.ts
+++ b/packages/core/src/components/graphs/pie.ts
@@ -128,7 +128,7 @@ export class Pie extends Component {
 				(d: any) =>
 					`${d[valueMapsTo]}, ${
 						convertValueToPercentage(d.data[valueMapsTo], displayData, valueMapsTo) + '%'
-					}`
+					}  ${d.data[groupMapsTo]}`
 			)
 			// Tween
 			.attrTween('d', function (a: any) {


### PR DESCRIPTION
### Updates

Added aria-label field for pie and donut chart elements

### Demo screenshot or recording

Before
<img width="1082" alt="Image" src="https://github.com/user-attachments/assets/fb4f773e-05c6-46c1-a47f-49163445c2b2" />

After
<img width="1728" alt="Screenshot 2025-05-19 at 3 47 58 PM" src="https://github.com/user-attachments/assets/80f5c71d-3d9a-4f87-a02d-30ff26dc1510" />
