### PR TITLE
Updated public api, added exports for Legend/Roles enums and tools.

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Change Log
+## [Unreleased]
+
+Updated public api.
+- Exposed enums `LegendEvent` and `Roles`
+- Exposed helper functions from `/packages/core/src/tools.ts`.
+
+# Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -148,6 +148,7 @@ export {
 	LayoutAlignItems,
 	LayoutDirection,
 	LayoutGrowth,
+	LegendEvent,
 	LegendItemType,
 	LegendOrientations,
 	LegendPositions,
@@ -158,6 +159,7 @@ export {
 	Projection,
 	RadarEvent,
 	RenderTypes,
+	Roles,
 	ScaleTypes,
 	ScatterEvent,
 	Skeletons,
@@ -331,3 +333,24 @@ export {
 	Transitions,
 	Zoom
 } from './services'
+
+export {
+	debounceWithD3MousePosition,
+	mergeDefaultChartOptions,
+	getDimensions,
+	getTranslationValues,
+	getTransformOffsets,
+	formatWidthHeightValues,
+	capitalizeFirstLetter,
+	convertValueToPercentage,
+	truncateLabel,
+	updateLegendAdditionalItems,
+	arrayDifferences,
+	getDuplicateValues,
+	moveToFront,
+	flipDomainAndRangeBasedOnOrientation,
+	getProperty,
+	flipSVGCoordinatesBasedOnOrientation,
+	generateSVGPathString,
+	compareNumeric
+} from './tools'

--- a/packages/core/src/interfaces/index.ts
+++ b/packages/core/src/interfaces/index.ts
@@ -129,6 +129,7 @@ export {
 	Chart as ChartEvent,
 	Gauge as GaugeEvent,
 	Line as LineEvent,
+	Legend as LegendEvent,
 	Modal as ModalEvent,
 	Model as ModelEvent,
 	Pie as PieEvent,


### PR DESCRIPTION
### Updates
#### Core
- Exposed enums `LegendEvent` and `Roles`
- Exposed helper functions from `/packages/core/src/tools.ts`.


