### PR TITLE
feat(core): add support for custom chartId and fix modal ARIA labeling

### DIFF
--- a/packages/core/src/components/essentials/modal.ts
+++ b/packages/core/src/components/essentials/modal.ts
@@ -104,7 +104,7 @@ export class Modal extends Component {
 		<div class="cds--modal-container">
 			<div class="cds--modal-header">
 
-				<p class="cds--modal-header__label cds--type-delta" id="modal-title">${title}</p>
+				<p class="cds--modal-header__label cds--type-delta" id="${id}__modal-title">${title}</p>
 
 				<p class="cds--modal-header__heading cds--type-beta" id="${id}__modal-description">${sanitizeText(
 					options.title

--- a/packages/core/src/interfaces/charts.ts
+++ b/packages/core/src/interfaces/charts.ts
@@ -34,6 +34,10 @@ import type {
  * Base chart options common to any chart
  */
 export interface BaseChartOptions {
+	/**
+	 * Optional custom chart ID
+	 */
+	chartId?: string
 	/*
 	 * aria-labels and other accessibility options
 	 */

--- a/packages/core/src/services/essentials/dom-utils.ts
+++ b/packages/core/src/services/essentials/dom-utils.ts
@@ -251,7 +251,15 @@ export class DOMUtils extends Service {
 	}
 
 	private initializeID() {
-		this.chartID = Math.floor((1 + Math.random()) * 0x1000000000000).toString(16)
+		// Check if user provided a custom chartId in options
+		const customId = this.model.getOptions().chartId
+		
+		if (customId) {
+			this.chartID = customId
+		} else {
+			// Generate random ID as fallback
+			this.chartID = Math.floor((1 + Math.random()) * 0x1000000000000).toString(16)
+		}
 	}
 
 	addMainContainer() {


### PR DESCRIPTION
### Related Issues
#2049 

### Description
- Added: chartId property in charts.ts
 → Enables developers to define a custom chart ID for accessibility, testing, and debugging.

- Updated: DOMUtils.initializeID() in dom-utils.ts
 → Uses user-defined chartId when available, otherwise generates a random fallback.

- Fixed: modal title ID mismatch in modal.ts
 → Updated from id="modal-title" to id="${chartId}__modal-title"
 → Resolves the ARIA validation error where aria-labelledby referenced a non-existent element.

### Validated:
Accessibility checks now pass (no ARIA ID reference violations)

Backward compatibility retained — no breaking changes

Tested with and without custom chartId defined

### Demo Screenshot or Recording

https://github.com/user-attachments/assets/a75c8522-5512-4d79-8481-e74d4789853a

