### PR TITLE
fix(deps): bump lodash-es to resolve security vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4788,4 +4788,4 @@ Log starts here...
 
 ### Security
 
-- Invite users to upgrade in case of vulnerabilities.
+- Bumped `lodash-es` to latest version to resolve security vulnerability (Fixes #2065)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4788,4 +4788,4 @@ Log starts here...
 
 ### Security
 
-- Bumped `lodash-es` to latest version to resolve security vulnerability (Fixes #2065)
+- Invite users to upgrade in case of vulnerabilities.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -83,7 +83,7 @@
 		"date-fns": "^4.1.0",
 		"dompurify": "^3.2.6",
 		"html-to-image": "1.11.11",
-		"lodash-es": "^4.17.21",
+		"lodash-es": "^4.17.23",
 		"topojson-client": "^3.1.0",
 		"tslib": "^2.8.1"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -926,7 +926,7 @@ __metadata:
     eslint: "npm:^9.32.0"
     html-to-image: "npm:1.11.11"
     jsdom: "npm:^26.1.0"
-    lodash-es: "npm:^4.17.21"
+    lodash-es: "npm:^4.17.23"
     prettier: "npm:^3.6.2"
     publint: "npm:^0.3.12"
     resize-observer-polyfill: "npm:^1.5.1"
@@ -11021,10 +11021,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash-es@npm:^4.17.21":
-  version: 4.17.21
-  resolution: "lodash-es@npm:4.17.21"
-  checksum: 10c0/fb407355f7e6cd523a9383e76e6b455321f0f153a6c9625e21a8827d10c54c2a2341bd2ae8d034358b60e07325e1330c14c224ff582d04612a46a4f0479ff2f2
+"lodash-es@npm:^4.17.23":
+  version: 4.17.23
+  resolution: "lodash-es@npm:4.17.23"
+  checksum: 10c0/3150fb6660c14c7a6b5f23bd11597d884b140c0e862a17fdb415aaa5ef7741523182904a6b7929f04e5f60a11edb5a79499eb448734381c99ffb3c4734beeddd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #2065

### Updates

- Bumped `lodash-es` dependency to latest version to resolve security vulnerability reported in #2065
