### PR TITLE
fix: upgrade lodash-es and dompurify

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -81,9 +81,9 @@
 		"d3-cloud": "^1.2.7",
 		"d3-sankey": "^0.12.3",
 		"date-fns": "^4.1.0",
-		"dompurify": "^3.2.6",
+		"dompurify": "^3.3.2",
 		"html-to-image": "1.11.11",
-		"lodash-es": "^4.17.23",
+		"lodash-es": "^4.18.0",
 		"topojson-client": "^3.1.0",
 		"tslib": "^2.8.1"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -921,12 +921,12 @@ __metadata:
     d3-cloud: "npm:^1.2.7"
     d3-sankey: "npm:^0.12.3"
     date-fns: "npm:^4.1.0"
-    dompurify: "npm:^3.2.6"
+    dompurify: "npm:^3.3.2"
     downlevel-dts: "npm:^0.11.0"
     eslint: "npm:^9.32.0"
     html-to-image: "npm:1.11.11"
     jsdom: "npm:^26.1.0"
-    lodash-es: "npm:^4.17.23"
+    lodash-es: "npm:^4.18.0"
     prettier: "npm:^3.6.2"
     publint: "npm:^0.3.12"
     resize-observer-polyfill: "npm:^1.5.1"
@@ -7631,7 +7631,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:*, dompurify@npm:^3.2.6":
+"dompurify@npm:*":
   version: 3.2.6
   resolution: "dompurify@npm:3.2.6"
   dependencies:
@@ -7640,6 +7640,18 @@ __metadata:
     "@types/trusted-types":
       optional: true
   checksum: 10c0/c8f8e5b0879a0d93c84a2e5e78649a47d0c057ed0f7850ca3d573d2cca64b84fb1ff85bd4b20980ade69c4e5b80ae73011340f1c2ff375c7ef98bb8268e1d13a
+  languageName: node
+  linkType: hard
+
+"dompurify@npm:^3.3.2":
+  version: 3.3.3
+  resolution: "dompurify@npm:3.3.3"
+  dependencies:
+    "@types/trusted-types": "npm:^2.0.7"
+  dependenciesMeta:
+    "@types/trusted-types":
+      optional: true
+  checksum: 10c0/097c14a21a3f6cb95beded9ecd255f7c3512c42767b048390c747b0fe35736f6a71e02320fc50a9ac2be645834b463e4760915d595d502a56452daf339d0ea9c
   languageName: node
   linkType: hard
 
@@ -11021,10 +11033,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash-es@npm:^4.17.23":
-  version: 4.17.23
-  resolution: "lodash-es@npm:4.17.23"
-  checksum: 10c0/3150fb6660c14c7a6b5f23bd11597d884b140c0e862a17fdb415aaa5ef7741523182904a6b7929f04e5f60a11edb5a79499eb448734381c99ffb3c4734beeddd
+"lodash-es@npm:^4.18.0":
+  version: 4.18.1
+  resolution: "lodash-es@npm:4.18.1"
+  checksum: 10c0/35d4dcf87ef07f8d090f409447575800108057e360b445f590d0d25d09e3d1e33a163d2fc100d4d072b0f901d5e2fc533cd7c4bfd8eeb38a06abec693823c8b8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #2071 

#### Updates

Updated Dependencies in **packages/core/package.json**

1. **lodash-es: ^4.17.23 → ^4.18.0** (installed: 4.18.1)

✅ Fixed CVE-2026-4800 (High, CVSS 8.1) - Code injection via _.template
✅ Fixed CVE-2026-2950 (Medium, CVSS 6.5) - Prototype pollution bypass
✅ Fixed Product Vulnerability Record [PVR0747759](https://ibm.service-now.com/nav_to.do?uri=%2Fsn_vul_product_records.do%3Fsys_id%3D5b5c82e33b488710d20cb49693e45ad4)

2. **dompurify: ^3.2.6 → ^3.3.2** (installed: 3.3.3)

✅ Fixed CVE-2026-0540 (Medium, CVSS 6.1) - XSS via rawtext element bypass
✅ Fixed CVE-2025-15599 (Medium, CVSS 6.1) - XSS via textarea bypass
✅ Fixed Product Vulnerability Record [PVR0747609](https://ibm.service-now.com/nav_to.do?uri=%2Fsn_vul_product_records.do%3Fsys_id%3D589bc6273b088710d20cb49693e45ab6)

> No updates needed for type definition packages as the current versions are already optimal:
> @types/lodash-es@^4.17.12 - Latest available, fully compatible with lodash-es 4.18.1
> @types/dompurify@^3.2.0 - Latest available, fully compatible with dompurify 3.3.3
