### PR TITLE
feat(radar): add custom maxValue option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [Unreleased]
+
+### Features
+
+- **radar:** add custom `maxValue` option to allow setting a fixed maximum scale value instead of auto-calculated max from data
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 ## 1.27.6 (2026-04-16)
 
 **Note:** Version bump only for package @carbon/charts-monorepo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,9 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-<<<<<<< HEAD
-## [Unreleased]
-
-### Features
-
-- **radar:** add custom `maxValue` option to allow setting a fixed maximum scale value instead of auto-calculated max from data
-=======
 ## 1.27.4 (2026-04-20)
 
 **Note:** Version bump only for package @carbon/charts-monorepo
->>>>>>> main
 
 # Change Log
 

--- a/packages/core/src/components/graphs/radar.ts
+++ b/packages/core/src/components/graphs/radar.ts
@@ -87,10 +87,16 @@ export class Radar extends Component {
 			.range([0, 2 * Math.PI].map((a: number) => a - Math.PI / 2) as [Angle, Angle])
 
 		const centerPointMinValue = min(this.fullDataNormalized.map((d: any) => d[value]) as number[])
+		
+		// Get custom max value from options if provided, otherwise calculate from data
+		const customMaxValue = getProperty(options, 'radar', 'maxValue')
+		const calculatedMaxValue = max(this.fullDataNormalized.map((d: any) => d[value]) as number[])
+		const maxValue = customMaxValue !== undefined ? customMaxValue : calculatedMaxValue
+		
 		const yScale = scaleLinear()
 			.domain([
 				centerPointMinValue >= 0 ? 0 : centerPointMinValue,
-				max(this.fullDataNormalized.map((d: any) => d[value]) as number[])
+				maxValue
 			])
 			.range([minRange, radius])
 			.nice(yTicksNumber)

--- a/packages/core/src/components/graphs/radar.ts
+++ b/packages/core/src/components/graphs/radar.ts
@@ -87,17 +87,26 @@ export class Radar extends Component {
 			.range([0, 2 * Math.PI].map((a: number) => a - Math.PI / 2) as [Angle, Angle])
 
 		const centerPointMinValue = min(this.fullDataNormalized.map((d: any) => d[value]) as number[])
-		
+
 		// Get custom max value from options if provided, otherwise calculate from data
 		const customMaxValue = getProperty(options, 'radar', 'maxValue')
 		const calculatedMaxValue = max(this.fullDataNormalized.map((d: any) => d[value]) as number[])
-		const maxValue = customMaxValue !== undefined ? customMaxValue : calculatedMaxValue
-		
+
+		// Use the larger of customMaxValue or calculatedMaxValue to prevent data clipping
+		// If customMaxValue is less than data max, use the calculated max and log a warning
+		let maxValue = calculatedMaxValue
+		if (customMaxValue !== undefined) {
+			if (customMaxValue >= calculatedMaxValue) {
+				maxValue = customMaxValue
+			} else {
+				console.warn(
+					`Carbon Charts - Radar: Custom maxValue (${customMaxValue}) is less than the maximum data value (${calculatedMaxValue}). Using data maximum to prevent clipping.`
+				)
+			}
+		}
+
 		const yScale = scaleLinear()
-			.domain([
-				centerPointMinValue >= 0 ? 0 : centerPointMinValue,
-				maxValue
-			])
+			.domain([centerPointMinValue >= 0 ? 0 : centerPointMinValue, maxValue])
 			.range([minRange, radius])
 			.nice(yTicksNumber)
 		const yTicks = yScale.ticks(yTicksNumber)

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -724,7 +724,8 @@ const radarChart: RadarChartOptions = merge({}, chart, {
 			angle: 'key',
 			value: 'value'
 		},
-		alignment: Alignments.LEFT
+		alignment: Alignments.LEFT,
+		maxValue: undefined // Optional custom max value, undefined means auto-calculate from data
 	},
 	tooltip: {
 		gridline: {

--- a/packages/core/src/interfaces/charts.ts
+++ b/packages/core/src/interfaces/charts.ts
@@ -484,6 +484,11 @@ export interface RadarChartOptions extends BaseChartOptions {
 			value: string
 		}
 		alignment?: Alignments | string
+		/**
+		 * Optional custom maximum value for the radar chart scale.
+		 * If not provided, the maximum will be calculated from the data.
+		 */
+		maxValue?: number
 	}
 }
 

--- a/packages/core/src/interfaces/charts.ts
+++ b/packages/core/src/interfaces/charts.ts
@@ -487,6 +487,9 @@ export interface RadarChartOptions extends BaseChartOptions {
 		/**
 		 * Optional custom maximum value for the radar chart scale.
 		 * If not provided, the maximum will be calculated from the data.
+		 * Note: If the provided maxValue is less than the actual data maximum,
+		 * the actual data maximum will be used instead to prevent data clipping,
+		 * and a warning will be logged to the console.
 		 */
 		maxValue?: number
 	}

--- a/packages/docs/src/lib/radar/index.ts
+++ b/packages/docs/src/lib/radar/index.ts
@@ -62,6 +62,21 @@ const radarDenseOptions: RadarChartOptions = {
 	height: '400px'
 }
 
+const radarCustomMaxOptions: RadarChartOptions = {
+	title: 'Radar - Custom Max Score (100)',
+	radar: {
+		axes: {
+			angle: 'feature',
+			value: 'score'
+		},
+		maxValue: 100 // Custom maximum value instead of auto-calculated
+	},
+	data: {
+		groupMapsTo: 'product'
+	},
+	height: '400px'
+}
+
 const radarData: ChartTabularData = [
 	{ product: 'Product 1', feature: 'Price', score: 60 },
 	{ product: 'Product 1', feature: 'Usability', score: 92 },
@@ -73,6 +88,14 @@ const radarData: ChartTabularData = [
 	{ product: 'Product 2', feature: 'Availability', score: 78 },
 	{ product: 'Product 2', feature: 'Performance', score: 50 },
 	{ product: 'Product 2', feature: 'Quality', score: 30 }
+]
+
+const radarWithCustomMaxScore: ChartTabularData = [
+	{ product: 'Product 1', feature: 'Price', score: 50 },
+	{ product: 'Product 1', feature: 'Usability', score: 20 },
+	{ product: 'Product 1', feature: 'Availability', score: 5 },
+	{ product: 'Product 1', feature: 'Performance', score: 45 },
+	{ product: 'Product 1', feature: 'Quality', score: 60 }
 ]
 
 const radarWithMissingDataData: ChartTabularData = [
@@ -154,6 +177,11 @@ export const examples: Example[] = [
 	{
 		data: radarDenseData,
 		options: radarDenseOptions,
+		tags: ['test']
+	},
+	{
+		data: radarWithCustomMaxScore,
+		options: radarCustomMaxOptions,
 		tags: ['test']
 	}
 ]

--- a/packages/docs/src/searchIndex.ts
+++ b/packages/docs/src/searchIndex.ts
@@ -686,7 +686,13 @@ export default [
 		path: 'radar',
 		title: 'Radar Charts',
 		text: 'Radar Charts, also known as spider or Kiviat charts, are graphical representations of multivariate data on a two-dimensional plane. They feature a circular shape with multiple spokes extending from a central point, each representing a different variable or category. Data points are plotted along these spokes and connected to form a polygon, allowing for the comparison of multiple variables across different categories simultaneously. Radar charts are particularly useful for visualizing patterns, trends, and relationships in data with multiple dimensions. They are commonly employed in fields such as performance evaluation, market analysis, and sports analytics to assess strengths and weaknesses across various attributes or criteria. Radar charts offer a holistic view of complex data sets, enabling users to identify patterns and make informed decisions based on the relationships between different variables. Details on Radar Chart options can be found here.',
-		charts: ['Radar', 'Radar (centered)', 'Radar - Missing datapoints', 'Radar - Dense']
+		charts: [
+			'Radar',
+			'Radar (centered)',
+			'Radar - Missing datapoints',
+			'Radar - Dense',
+			'Radar - Custom Max Score (100)'
+		]
 	},
 	{
 		path: 'scatter',


### PR DESCRIPTION
### Updates

## Issue
https://github.com/carbon-design-system/carbon-charts/issues/2081

## Summary
Adds a custom `maxValue` option to radar charts, allowing users to set a fixed maximum scale value instead of using the auto-calculated maximum from data.

## Changes Made
- Added `maxValue?: number` option to `RadarChartOptions` interface
- Updated radar chart configuration with default `maxValue: undefined`
- Modified radar rendering logic to use custom max when provided
- Added demo example "Radar - Custom Max Score (100)"
- Updated CHANGELOG.md

## Motivation
This feature enables:
- Standardized comparisons across multiple radar charts
- Fixed scoring systems (e.g., 0-100 scale)
- Consistent visualization regardless of data range

## Usage Example
```typescript
const options = {
  radar: {
    axes: { angle: 'feature', value: 'score' },
    maxValue: 100  // Custom max score
  }
}
```
### Demo screenshot
<img width="881" height="481" alt="image" src="https://github.com/user-attachments/assets/a883907e-9b03-4841-8a06-31637fa04d87" />
