### PR TITLE
Stop using deprecated Sass `darken()` function

### DIFF
--- a/packages/core/scss/_colors.scss
+++ b/packages/core/scss/_colors.scss
@@ -47,7 +47,7 @@ $color-map-light: map-merge(getThemeColors('light'), getGradientColors());
 .#{globals.$prefix}--chart-holder {
 	@each $token, $color in $color-map-light {
 		--cds-charts-#{$token}: #{$color};
-		--cds-charts-#{$token}-hovered: #{darken($color, 7%)};
+		--cds-charts-#{$token}-hovered: #{color.adjust($color, $lightness: -7%)};
 	}
 }
 
@@ -56,7 +56,7 @@ $color-map-dark: map-merge(getThemeColors('dark'), getGradientColors());
 .#{globals.$prefix}--chart-holder[data-carbon-theme='g100'] {
 	@each $token, $color in $color-map-dark {
 		--cds-charts-#{$token}: #{$color};
-		--cds-charts-#{$token}-hovered: #{darken($color, 7%)};
+		--cds-charts-#{$token}-hovered: #{color.adjust($color, $lightness: -7%)};
 	}
 }
 


### PR DESCRIPTION
During normal usage of `@carbon/charts` we see the following repeating warning:

```
▲ [WARNING] darken() is deprecated. Suggestions:

color.scale($color, $lightness: -28.56%)
color.adjust($color, $lightness: -7%)

More info: https://sass-lang.com/d/color-functions [plugin sass-plugin]

    /C:/.../node_modules/@carbon/charts/scss/_colors.scss:49:18:
      49 │ darken($color, 7%)
```

The URL goes [here](https://sass-lang.com/documentation/breaking-changes/color-functions/). This PR applies the suggested fix.