### PR TITLE
fix: tooltip not showing for truncated labels in single-series charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,32 +3,15 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## 1.27.19 (2026-09-08)
+## [Unreleased]
 
-**Note:** Version bump only for package @carbon/charts-monorepo
+### Fixed
+- **Legend**: Fixed tooltip not showing for truncated labels in single-series charts
 
-# Change Log
-
-All notable changes to this project will be documented in this file. See
-[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
-## 1.27.18 (2026-07-31)
-
-**Note:** Version bump only for package @carbon/charts-monorepo
-
-# Change Log
-
-All notable changes to this project will be documented in this file. See
-[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
-## 1.27.17 (2026-07-23)
-
-**Note:** Version bump only for package @carbon/charts-monorepo
-
-# Change Log
-
-All notable changes to this project will be documented in this file. See
-[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+### Changed
+- **Legend**: Added `.single-series` CSS class to legend container for single-series charts
+- **Legend**: Added `.has-truncated-label` CSS class to legend items with truncated text
+- **Legend**: Pointer cursor now shows only for truncated labels in single-series charts (tooltip indicator)
 
 ## 1.27.16 (2026-06-25)
 

--- a/packages/core/scss/components/_legend.scss
+++ b/packages/core/scss/components/_legend.scss
@@ -102,4 +102,9 @@ div.#{globals.$prefix}--#{globals.$charts-prefix}--legend {
 			}
 		}
 	}
+
+	// Single-series: pointer cursor only for truncated labels (tooltip indicator)
+	&.single-series div.legend-item.has-truncated-label:hover {
+		cursor: pointer;
+	}
 }

--- a/packages/core/src/components/essentials/legend.ts
+++ b/packages/core/src/components/essentials/legend.ts
@@ -62,7 +62,9 @@ export class Legend extends Component {
 		})
 
 		const legendClickable = getProperty(this.getOptions(), 'legend', 'clickable')
+		const isSingleSeries = dataGroups.length === 1
 		svg.classed('clickable', legendClickable && dataGroups.length > 1)
+		svg.classed('single-series', isSingleSeries)
 
 		const checkboxRadius = legendConfigs.checkbox.radius
 
@@ -164,9 +166,7 @@ export class Legend extends Component {
 		// Remove old elements as needed.
 		legendItems.exit().on('mouseover', null).on('click', null).on('mouseout', null).remove()
 
-		if (legendClickable && addedLegendItems.size() > 1) {
-			this.addEventListeners()
-		}
+		this.addEventListeners()
 	}
 
 	sortDataGroups(dataGroups: any, legendOrder: any) {
@@ -342,17 +342,25 @@ export class Legend extends Component {
 		if (truncationType !== TruncationTypes.NONE) {
 			addedLegendItemsText.html(function (d: any) {
 				const _sanitizedLabel = sanitizeText(d.name)
-				if (
+				const isTruncated =
 					_sanitizedLabel.length > truncationThreshold &&
 					_sanitizedLabel.length !== truncationNumCharacter
-				) {
+
+				// Add class to parent legend-item to indicate truncation
+				select((this as any).parentNode).classed('has-truncated-label', isTruncated)
+
+				if (isTruncated) {
 					return truncateLabel(_sanitizedLabel, truncationType, truncationNumCharacter)
 				} else {
 					return _sanitizedLabel
 				}
 			})
 		} else {
-			addedLegendItemsText.html((d: any) => sanitizeText(d.name))
+			addedLegendItemsText.html(function (d: any) {
+				// Ensure no truncation class when truncation is disabled
+				select((this as any).parentNode).classed('has-truncated-label', false)
+				return sanitizeText(d.name)
+			})
 		}
 	}
 
@@ -362,6 +370,8 @@ export class Legend extends Component {
 		const options = this.getOptions()
 		const legendOptions = getProperty(options, 'legend')
 		const truncation = getProperty(legendOptions, 'truncation')
+		const dataGroups = this.model.getDataGroups()
+		const isSingleSeries = dataGroups.length === 1
 
 		svg
 			.selectAll('div.legend-item')
@@ -373,13 +383,14 @@ export class Legend extends Component {
 				const hoveredItem = select(this)
 				hoveredItem.select('div.checkbox').classed('hovered', true)
 
-				// Show tooltip if character length is greater than threshold & there is no truncation
+				// Show tooltip if character length is greater than threshold & there is truncation
 				const hoveredItemData = hoveredItem.datum() as any
-				if (
+				const isTruncated =
 					hoveredItemData.name.length > truncation.threshold &&
 					truncation.numCharacter < hoveredItemData.name.length &&
 					truncation.type !== TruncationTypes.NONE
-				) {
+
+				if (isTruncated) {
 					self.services.events.dispatchEvent(Events.Tooltip.SHOW, {
 						event,
 						hoveredElement: hoveredItem,
@@ -400,6 +411,11 @@ export class Legend extends Component {
 				}
 			})
 			.on('click', function () {
+				// Prevent toggling data visibility for single series charts
+				if (isSingleSeries) {
+					return
+				}
+
 				self.services.events.dispatchEvent(Events.Legend.ITEM_CLICK, {
 					clickedElement: select(this)
 				})
@@ -441,7 +457,10 @@ export class Legend extends Component {
 			.on('keydown', function (event: KeyboardEvent, d: any) {
 				if (event.key && event.key === ' ') {
 					event.preventDefault()
-					self.model.toggleDataLabel(d.name)
+					// Only allow toggling for multi-series charts
+					if (!isSingleSeries) {
+						self.model.toggleDataLabel(d.name)
+					}
 				} else if (event.key && event.key === 'Tab') {
 					// Unhiglight group
 					self.services.events.dispatchEvent(Events.Legend.ITEM_MOUSEOUT, {

--- a/packages/core/src/components/essentials/legend.ts
+++ b/packages/core/src/components/essentials/legend.ts
@@ -166,7 +166,11 @@ export class Legend extends Component {
 		// Remove old elements as needed.
 		legendItems.exit().on('mouseover', null).on('click', null).on('mouseout', null).remove()
 
-		this.addEventListeners()
+		if (legendClickable && dataGroups.length > 1) {
+			this.addEventListeners()
+		} else {
+			this.addTooltipListeners()
+		}
 	}
 
 	sortDataGroups(dataGroups: any, legendOrder: any) {
@@ -364,14 +368,12 @@ export class Legend extends Component {
 		}
 	}
 
-	addEventListeners() {
+	addTooltipListeners() {
 		const self = this
 		const svg = this.getComponentContainer()
 		const options = this.getOptions()
 		const legendOptions = getProperty(options, 'legend')
 		const truncation = getProperty(legendOptions, 'truncation')
-		const dataGroups = this.model.getDataGroups()
-		const isSingleSeries = dataGroups.length === 1
 
 		svg
 			.selectAll('div.legend-item')
@@ -410,21 +412,6 @@ export class Legend extends Component {
 					})
 				}
 			})
-			.on('click', function () {
-				// Prevent toggling data visibility for single series charts
-				if (isSingleSeries) {
-					return
-				}
-
-				self.services.events.dispatchEvent(Events.Legend.ITEM_CLICK, {
-					clickedElement: select(this)
-				})
-
-				const clickedItem = select(this)
-				const clickedItemData = clickedItem.datum() as any
-
-				self.model.toggleDataLabel(clickedItemData.name)
-			})
 			.on('mouseout', function () {
 				const hoveredItem = select(this)
 				hoveredItem.select('div.checkbox').classed('hovered', false)
@@ -451,16 +438,36 @@ export class Legend extends Component {
 				})
 			}
 		})
+	}
+
+	addEventListeners() {
+		const self = this
+		const svg = this.getComponentContainer()
+		const options = this.getOptions()
+		const legendOptions = getProperty(options, 'legend')
+		const truncation = getProperty(legendOptions, 'truncation')
+
+		this.addTooltipListeners()
+
+		svg
+			.selectAll('div.legend-item')
+			.on('click', function () {
+				self.services.events.dispatchEvent(Events.Legend.ITEM_CLICK, {
+					clickedElement: select(this)
+				})
+
+				const clickedItem = select(this)
+				const clickedItemData = clickedItem.datum() as any
+
+				self.model.toggleDataLabel(clickedItemData.name)
+			})
 
 		svg
 			.selectAll('div.legend-item div.checkbox')
 			.on('keydown', function (event: KeyboardEvent, d: any) {
 				if (event.key && event.key === ' ') {
 					event.preventDefault()
-					// Only allow toggling for multi-series charts
-					if (!isSingleSeries) {
-						self.model.toggleDataLabel(d.name)
-					}
+					self.model.toggleDataLabel(d.name)
 				} else if (event.key && event.key === 'Tab') {
 					// Unhiglight group
 					self.services.events.dispatchEvent(Events.Legend.ITEM_MOUSEOUT, {


### PR DESCRIPTION
Closes #2108 

### Updates

- Fixed tooltip not showing for truncated labels in single-series charts
- Fixed keyboard space bar allowing toggle of single-series charts (preventing empty chart state)
- Added `.single-series` CSS class to legend container
- Added `.has-truncated-label` CSS class to truncated legend items
- Pointer cursor now indicates tooltip availability for truncated labels

### Demo screenshot or recording
<img width="1640" height="954" alt="image" src="https://github.com/user-attachments/assets/da995107-6935-4334-a38f-7f4a1d6c7409" />
