### PR TITLE
Security: fix vulnerabilities in react-router and dompurify

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
 	},
 	"packageManager": "yarn@4.9.2",
 	"resolutions": {
-		"postcss": "^8.5.10"
+		"postcss": "^8.5.10",
+		"react-router": "^7.18.0"
 	},
 	"devDependencies": {
 		"@commitlint/cli": "^19.8.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -81,7 +81,7 @@
 		"d3-cloud": "^1.2.7",
 		"d3-sankey": "^0.12.3",
 		"date-fns": "^4.1.0",
-		"dompurify": "^3.4.0",
+		"dompurify": "^3.4.12",
 		"html-to-image": "1.11.11",
 		"lodash-es": "^4.18.0",
 		"topojson-client": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -921,7 +921,7 @@ __metadata:
     d3-cloud: "npm:^1.2.7"
     d3-sankey: "npm:^0.12.3"
     date-fns: "npm:^4.1.0"
-    dompurify: "npm:^3.4.0"
+    dompurify: "npm:^3.4.12"
     downlevel-dts: "npm:^0.11.0"
     eslint: "npm:^9.32.0"
     html-to-image: "npm:1.11.11"
@@ -7643,15 +7643,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:^3.4.0":
-  version: 3.4.2
-  resolution: "dompurify@npm:3.4.2"
+"dompurify@npm:^3.4.12":
+  version: 3.4.12
+  resolution: "dompurify@npm:3.4.12"
   dependencies:
     "@types/trusted-types": "npm:^2.0.7"
   dependenciesMeta:
     "@types/trusted-types":
       optional: true
-  checksum: 10c0/23ab3ab079480a49e1426c4ee7279e393913fa7f2193c4142a5be54d4163dbdd969558675876c6b8bbcbf2ad5d1bc3e00bf902acf142fff12e50274a65ae95b3
+  checksum: 10c0/127a13817353d4e20e75a991a9022a04c3af12af7479f68e2b8bee6dbc7330a96edfb8f4ebff96f4f0f24cd43e8dbba46214131f510c3aa87a843bd8b610d0ab
   languageName: node
   linkType: hard
 
@@ -13506,20 +13506,20 @@ __metadata:
   linkType: hard
 
 "react-router-dom@npm:^7.12.0":
-  version: 7.14.0
-  resolution: "react-router-dom@npm:7.14.0"
+  version: 7.18.1
+  resolution: "react-router-dom@npm:7.18.1"
   dependencies:
-    react-router: "npm:7.14.0"
+    react-router: "npm:7.18.1"
   peerDependencies:
     react: ">=18"
     react-dom: ">=18"
-  checksum: 10c0/f7130c7083c2a8921aa59e9a9755ae4b79ef98b4df0ae84052ab0fd95b27612a7ebd2539b83d299b8073f8b5fc41595e8cc82bf748837d95d166f8ee19bf5f24
+  checksum: 10c0/5efb99f2f09cecf445788f3459a8f5ff952ed85061f2d40f8de25fdd6e2ce6aeea8e40e4bacad470ea42a45d0460feb6fb59c62f14d87720b43d5c96cd9b2cb6
   languageName: node
   linkType: hard
 
-"react-router@npm:7.14.0":
-  version: 7.14.0
-  resolution: "react-router@npm:7.14.0"
+"react-router@npm:^7.18.0":
+  version: 7.18.1
+  resolution: "react-router@npm:7.18.1"
   dependencies:
     cookie: "npm:^1.0.1"
     set-cookie-parser: "npm:^2.6.0"
@@ -13529,7 +13529,7 @@ __metadata:
   peerDependenciesMeta:
     react-dom:
       optional: true
-  checksum: 10c0/a496489973cd5e87dcc5c1c7312f4cc99463eb5e0a0f97b3f298467531b754a3227562a83e0c9019b9d2452fd0681d05882ee061af2e0cafb0818f857578b805
+  checksum: 10c0/1a559de58d656bad5565f2232e4f4fab7e9f5282dfaf95bc24f195a06e7e85b281077fe5c21ed3ff527e3d90d930447e0d0bb0f0713950d2a56ad0f0377a7d09
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Updates

Closes #2120 and #2121 

Resolves two Mend security issues by upgrading vulnerable transitive dependencies.

### Fix 1 : `dompurify` `3.4.0` -> `3.4.12` (closes #2120)

File changed : `packages/core/package.json` - bumped constraint from `3.4.0 `-> `3.4.12`

| CVE | Severity | CVSS | Fixed in |
|---|---|---|---|
| CVE-2026-49978 | Critical | 9.3 | 3.4.7 |
| CVE-2026-65898 | High | 7.2 | 3.4.11 |
| CVE-2026-66010 | Medium | 6.1 | 3.4.12 |
| CVE-2026-65902 | Medium | 6.1 | 3.4.7 |
| CVE-2026-65901 | Medium | 6.1 | 3.4.7 |
| CVE-2026-65900 | Medium | 6.1 | 3.4.8 |
| CVE-2026-65899 | Medium | 6.1 | 3.4.9 |
| CVE-2026-49459 | Medium | 6.1 | 3.4.6 |
| CVE-2026-49458 | Medium | 6.1 | 3.4.6 |

### Fix 2 : `react-router` `7.14.0` -> `7.18.1` (closes #2121)

File changed : `package.json` - added `react-router` to the root resolutions block

`react-router` is a transitive dependency pulled by `react-router-dom` in `packages/docs`. Rather than altering the direct `react-router-dom` range, a yarn  `resolutions` override is used to pin the transitive package to a safe version.

| CVE | Severity | CVSS | Fixed in |
|---|---|---|---|
| CVE-2026-42211 | High | 8.1 | 7.14.2 |
| CVE-2026-55685 | High | 7.5 | 7.18.0 |
| CVE-2026-42342 | High | 7.5 | 7.15.0 |
| CVE-2026-40181 | High | 7.5 | 7.14.1 |
| CVE-2026-53667 | Medium | 6.9 | 7.18.0 |
| CVE-2026-53666 | Medium | 6.1 | 7.18.0 |
| CVE-2026-53669 | Medium | 4.7 | 7.18.0 |
| CVE-2026-53663 | Low | 3.1 | 7.15.1 |
