### PR TITLE
fix(ruler): remove tooltip lag for large data sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [Unreleased]
+
+### Fixed
+
+- **Ruler**: Removed tooltip lag on charts with more than 100 data points.
+
 ## 1.27.18 (2026-07-31)
 
 **Note:** Version bump only for package @carbon/charts-monorepo

--- a/packages/core/src/components/axes/ruler.spec.ts
+++ b/packages/core/src/components/axes/ruler.spec.ts
@@ -1,0 +1,162 @@
+import { select } from 'd3'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Ruler } from './ruler'
+import { CartesianOrientations, Events } from '@/interfaces/enums'
+import type { ChartModel } from '@/model/model'
+import type { Services } from '@/interfaces/services'
+
+const sampleData = [
+	{ group: 'A', date: 10, value: 1 },
+	{ group: 'B', date: 10, value: 2 },
+	{ group: 'A', date: 20, value: 3 },
+	{ group: 'B', date: 20, value: 4 }
+]
+
+describe('ruler', () => {
+	let svg: SVGSVGElement
+	let frame: FrameRequestCallback
+	let dispatchEvent: ReturnType<typeof vi.fn>
+	let getDomainValue: ReturnType<typeof vi.fn>
+	let ruler: Ruler
+	let data: typeof sampleData
+	let orientation: CartesianOrientations
+
+	beforeEach(() => {
+		data = sampleData
+		orientation = CartesianOrientations.VERTICAL
+		svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+		document.body.appendChild(svg)
+		dispatchEvent = vi.fn()
+		getDomainValue = vi.fn(d => d.date)
+		vi.stubGlobal(
+			'requestAnimationFrame',
+			vi.fn(callback => {
+				frame = callback
+				return 1
+			})
+		)
+		vi.stubGlobal('cancelAnimationFrame', vi.fn())
+
+		ruler = new Ruler(
+			{
+				getOptions: () => ({ ruler: { enabled: true }, style: { prefix: 'cc' } }),
+				getDisplayData: () => data
+			} as unknown as ChartModel,
+			{
+				domUtils: { getMainContainer: () => svg },
+				cartesianScales: {
+					getOrientation: () => orientation,
+					getRangeScale: () => ({ range: () => [100, 0] }),
+					getDomainValue,
+					getRangeIdentifier: () => 'value'
+				},
+				events: { dispatchEvent }
+			} as unknown as Services
+		)
+		ruler.render()
+
+		select(svg)
+			.selectAll('circle')
+			.data(data)
+			.enter()
+			.append('circle')
+			.attr('role', 'graphics-symbol')
+	})
+
+	afterEach(() => {
+		vi.unstubAllGlobals()
+		document.body.replaceChildren()
+	})
+
+	function move(x: number) {
+		ruler.backdrop.node().dispatchEvent(new MouseEvent('mousemove', { clientX: x }))
+	}
+
+	it('draws the latest point once per animation frame and reuses its indexes', () => {
+		move(10)
+		move(20)
+
+		expect(requestAnimationFrame).toHaveBeenCalledOnce()
+		expect(dispatchEvent).not.toHaveBeenCalled()
+		frame(0)
+
+		expect(dispatchEvent).toHaveBeenLastCalledWith(
+			Events.Tooltip.SHOW,
+			expect.objectContaining({ data: data.slice(2), mousePosition: [20, 0] })
+		)
+		expect(svg.querySelector('line.ruler-line').getAttribute('x1')).toBe('20')
+		expect(getDomainValue).toHaveBeenCalledTimes(8)
+
+		move(21)
+		frame(16)
+		expect(dispatchEvent).toHaveBeenLastCalledWith(Events.Tooltip.MOVE, {
+			mousePosition: [21, 0]
+		})
+		expect(getDomainValue).toHaveBeenCalledTimes(8)
+
+		move(10)
+		frame(32)
+		expect(dispatchEvent).toHaveBeenLastCalledWith(
+			Events.Tooltip.SHOW,
+			expect.objectContaining({ data: data.slice(0, 2) })
+		)
+		expect(dispatchEvent).not.toHaveBeenCalledWith(Events.Tooltip.HIDE)
+		expect(getDomainValue).toHaveBeenCalledTimes(8)
+
+		move(50)
+		frame(48)
+		move(60)
+		frame(64)
+		expect(
+			dispatchEvent.mock.calls.filter(([event]) => event === Events.Tooltip.HIDE)
+		).toHaveLength(1)
+
+		ruler.render()
+		move(20)
+		frame(80)
+		expect(getDomainValue).toHaveBeenCalledTimes(16)
+	})
+
+	it('cancels pending work and clears only the active symbols on exit', () => {
+		move(10)
+		frame(0)
+		move(20)
+		ruler.backdrop.node().dispatchEvent(new MouseEvent('mouseout'))
+
+		expect(cancelAnimationFrame).toHaveBeenCalledWith(1)
+		expect(dispatchEvent).toHaveBeenLastCalledWith(Events.Tooltip.HIDE)
+		expect(svg.querySelector('g.ruler').getAttribute('opacity')).toBe('0')
+	})
+
+	it('uses the range coordinate on horizontal charts', () => {
+		orientation = CartesianOrientations.HORIZONTAL
+		ruler.showRuler(new CustomEvent('mousemove'), [50, 20])
+
+		expect(svg.querySelector('line.ruler-line').getAttribute('y1')).toBe('20')
+	})
+
+	it('indexes a 1,000-reading, 9-series chart only once', () => {
+		data = Array.from({ length: 1000 }, (_value, date) =>
+			Array.from({ length: 9 }, (_level, level) => ({
+				group: `L${level + 1}`,
+				date,
+				value: date
+			}))
+		).flat()
+		select(svg).selectAll('[role=graphics-symbol]').remove()
+		select(svg)
+			.selectAll('circle')
+			.data(data)
+			.enter()
+			.append('circle')
+			.attr('role', 'graphics-symbol')
+
+		for (let date = 0; date < 1000; date++) {
+			move(date)
+			frame(date)
+		}
+
+		expect(getDomainValue).toHaveBeenCalledTimes(18_000)
+		expect(dispatchEvent).not.toHaveBeenCalledWith(Events.Tooltip.HIDE)
+	})
+})

--- a/packages/core/src/components/axes/ruler.ts
+++ b/packages/core/src/components/axes/ruler.ts
@@ -1,9 +1,9 @@
-import { Selection, pointer } from 'd3'
-import { isEqual } from 'lodash-es'
-import { debounceWithD3MousePosition, getProperty } from '@/tools'
+import { bisectCenter, pointer, selectAll, type Selection } from 'd3'
+import { getProperty } from '@/tools'
 import { Component } from '@/components/component'
 import { DOMUtils } from '@/services/essentials/dom-utils'
 import { CartesianOrientations, Events, RenderTypes } from '@/interfaces/enums'
+import type { ChartTabularData } from '@/interfaces/model'
 
 export type GenericSvgSelection = Selection<SVGGraphicsElement, any, Element, any>
 
@@ -19,11 +19,14 @@ export class Ruler extends Component {
 	renderType = RenderTypes.SVG
 
 	backdrop: GenericSvgSelection
-	elementsToHighlight: GenericSvgSelection
-	pointsWithinLine: {
-		domainValue: number
-		originalData: any
-	}[]
+	elementsToHighlight?: GenericSvgSelection
+	private domainValues?: number[]
+	private pointsByDomain?: Map<number, ChartTabularData>
+	private elementsByDomain?: Map<number, SVGGraphicsElement[]>
+	private activeDomainValue?: number
+	private frame?: number
+	private rulerEvent: CustomEvent
+	private rulerPosition: [number, number]
 	isXGridEnabled = getProperty(this.getOptions(), 'grid', 'x', 'enabled')
 	isYGridEnabled = getProperty(this.getOptions(), 'grid', 'y', 'enabled')
 	// flag for checking whether ruler event listener is added or not
@@ -34,8 +37,16 @@ export class Ruler extends Component {
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	render(animate = false) {
 		const isRulerEnabled = getProperty(this.getOptions(), 'ruler', 'enabled')
-		const alwaysShowRulerTooltip = getProperty(this.getOptions(), 'tooltip', 'alwaysShowRulerTooltip')
+		const alwaysShowRulerTooltip = getProperty(
+			this.getOptions(),
+			'tooltip',
+			'alwaysShowRulerTooltip'
+		)
 		const shouldEnableRuler = isRulerEnabled || alwaysShowRulerTooltip
+		this.domainValues = undefined
+		this.pointsByDomain = undefined
+		this.elementsByDomain = undefined
+		this.activeDomainValue = undefined
 
 		this.drawBackdrop()
 
@@ -49,6 +60,10 @@ export class Ruler extends Component {
 	removeBackdropEventListeners() {
 		this.isEventListenerAdded = false
 		this.backdrop.on('mousemove mouseover mouseout', null)
+		if (this.frame !== undefined) {
+			cancelAnimationFrame(this.frame)
+			this.frame = undefined
+		}
 	}
 
 	formatTooltipData(tooltipData: any) {
@@ -60,143 +75,114 @@ export class Ruler extends Component {
 
 		const orientation: CartesianOrientations = this.services.cartesianScales.getOrientation()
 
-		const displayData = this.model.getDisplayData()
-
 		const rangeScale = this.services.cartesianScales.getRangeScale()
 		const [yScaleEnd, yScaleStart] = rangeScale.range()
 
 		const mouseCoordinate = orientation === CartesianOrientations.HORIZONTAL ? y : x
 		const ruler = DOMUtils.appendOrSelect(svg, 'g.ruler').attr('aria-label', 'ruler')
 		const rulerLine = DOMUtils.appendOrSelect(ruler, 'line.ruler-line')
-		const dataPointElements: GenericSvgSelection = svg.selectAll('[role=graphics-symbol]')
 
-		const pointsWithinLine = displayData
-			.map((d: any) => ({
-				domainValue: this.services.cartesianScales.getDomainValue(d) as number,
-				originalData: d
-			}))
-			.filter((d: any) => pointIsWithinThreshold(d.domainValue, mouseCoordinate))
+		if (!this.pointsByDomain) {
+			this.indexData()
+		}
 
-		if (
-			this.pointsWithinLine &&
-			pointsWithinLine.length === this.pointsWithinLine.length &&
-			pointsWithinLine.map((point: any) => point.domainValue).join() ===
-				this.pointsWithinLine.map(point => point.domainValue).join()
-		) {
-			this.pointsWithinLine = pointsWithinLine
+		const domainValue = this.domainValues[bisectCenter(this.domainValues, mouseCoordinate)]
+		if (domainValue === undefined || !pointIsWithinThreshold(domainValue, mouseCoordinate)) {
+			if (this.elementsToHighlight) this.hideRuler()
+			return
+		}
+
+		if (domainValue === this.activeDomainValue) {
 			return this.services.events.dispatchEvent(Events.Tooltip.MOVE, {
 				mousePosition: [x, y]
 			})
 		}
 
-		this.pointsWithinLine = pointsWithinLine
+		const dataPointsMatchingRulerLine = this.pointsByDomain.get(domainValue)
+		const tooltipData = dataPointsMatchingRulerLine.filter(d => {
+			const rangeIdentifier = this.services.cartesianScales.getRangeIdentifier(d)
+			const value = d[rangeIdentifier]
+			return value !== null && value !== undefined
+		})
 
-		/**
-		 * Find matches, reduce is used instead of filter
-		 * to only get elements which belong to the same axis coordinate
-		 */
-		const dataPointsMatchingRulerLine: {
-			domainValue: number
-			originalData: any
-		}[] = this.pointsWithinLine.reduce((accum, currentValue) => {
-			if (accum.length === 0) {
-				accum.push(currentValue)
-				return accum
-			}
+		if (!this.elementsByDomain) {
+			this.indexElements()
+		}
+		const elementsToHighlight = selectAll(
+			this.elementsByDomain.get(domainValue) ?? []
+		) as GenericSvgSelection
 
-			// store the first element of the accumulator array to compare it with current element being processed
-			const sampleAccumValue = accum[0].domainValue
+		this.elementsToHighlight?.dispatch('mouseout')
+		elementsToHighlight.dispatch('mouseover')
+		this.elementsToHighlight = elementsToHighlight
+		this.activeDomainValue = domainValue
 
-			const distanceToCurrentValue = Math.abs(mouseCoordinate - currentValue.domainValue)
-			const distanceToAccumValue = Math.abs(mouseCoordinate - sampleAccumValue)
+		this.services.events.dispatchEvent(Events.Tooltip.SHOW, {
+			event,
+			mousePosition: [x, y],
+			hoveredElement: rulerLine,
+			data: this.formatTooltipData(tooltipData)
+		})
 
-			if (distanceToCurrentValue > distanceToAccumValue) {
-				// if distance with current value is bigger than already existing value in the accumulator, skip current iteration
-				return accum
-			} else if (distanceToCurrentValue < distanceToAccumValue) {
-				// currentValue data point is closer to mouse inside the threshold area, so reinstantiate array
-				accum = [currentValue]
-			} else {
-				// currentValue is equal to already stored values, which means there's another match on the same coordinate
-				accum.push(currentValue)
-			}
+		ruler.attr('opacity', 1)
 
-			return accum
-		}, [])
-
-		// some data point match
-		if (dataPointsMatchingRulerLine.length > 0) {
-			const tooltipData = dataPointsMatchingRulerLine
-				.map((d: any) => d.originalData)
-				.filter((d: any) => {
-					const rangeIdentifier = this.services.cartesianScales.getRangeIdentifier(d)
-					const value = d[rangeIdentifier]
-					return value !== null && value !== undefined
-				})
-
-			// get elements on which we should trigger mouse events
-			const domainValuesMatchingRulerLine = dataPointsMatchingRulerLine.map(
-				(d: any) => d.domainValue
-			)
-			const elementsToHighlight = dataPointElements.filter((d: any) => {
-				const domainValue = this.services.cartesianScales.getDomainValue(d) as number
-				return domainValuesMatchingRulerLine.includes(domainValue)
-			})
-
-			/** if we pass from a trigger area to another one
-			 * mouseout on previous elements won't get dispatched
-			 * so we need to do it manually
-			 */
-			if (
-				this.elementsToHighlight &&
-				this.elementsToHighlight.size() > 0 &&
-				!isEqual(this.elementsToHighlight, elementsToHighlight)
-			) {
-				this.hideRuler()
-			}
-
-			elementsToHighlight.dispatch('mouseover')
-
-			// set current hovered elements
-			this.elementsToHighlight = elementsToHighlight
-
-			this.services.events.dispatchEvent(Events.Tooltip.SHOW, {
-				event,
-				mousePosition: [x, y],
-				hoveredElement: rulerLine,
-				data: this.formatTooltipData(tooltipData)
-			})
-
-			ruler.attr('opacity', 1)
-
-			// line snaps to matching point
-			const sampleMatch = dataPointsMatchingRulerLine[0]
-			if (orientation === 'horizontal') {
-				rulerLine
-					.attr('x1', yScaleStart)
-					.attr('x2', yScaleEnd)
-					.attr('y1', sampleMatch.domainValue)
-					.attr('y2', sampleMatch.domainValue)
-			} else {
-				rulerLine
-					.attr('y1', yScaleStart)
-					.attr('y2', yScaleEnd)
-					.attr('x1', sampleMatch.domainValue)
-					.attr('x2', sampleMatch.domainValue)
-			}
+		if (orientation === 'horizontal') {
+			rulerLine
+				.attr('x1', yScaleStart)
+				.attr('x2', yScaleEnd)
+				.attr('y1', domainValue)
+				.attr('y2', domainValue)
 		} else {
-			this.hideRuler()
+			rulerLine
+				.attr('y1', yScaleStart)
+				.attr('y2', yScaleEnd)
+				.attr('x1', domainValue)
+				.attr('x2', domainValue)
 		}
 	}
 
 	hideRuler() {
 		const svg = this.parent
 		const ruler = DOMUtils.appendOrSelect(svg, 'g.ruler')
-		const dataPointElements = svg.selectAll('[role=graphics-symbol]')
 
-		dataPointElements.dispatch('mouseout')
+		this.elementsToHighlight?.dispatch('mouseout')
+		this.elementsToHighlight = undefined
+		this.activeDomainValue = undefined
 		this.services.events.dispatchEvent(Events.Tooltip.HIDE)
 		ruler.attr('opacity', 0)
+	}
+
+	private indexData() {
+		const pointsByDomain = new Map<number, ChartTabularData>()
+		this.model.getDisplayData().forEach(originalData => {
+			const domainValue = this.services.cartesianScales.getDomainValue(originalData) as number
+			if (!Number.isFinite(domainValue)) return
+			const points = pointsByDomain.get(domainValue)
+			if (points) {
+				points.push(originalData)
+			} else {
+				pointsByDomain.set(domainValue, [originalData])
+			}
+		})
+
+		this.pointsByDomain = pointsByDomain
+		this.domainValues = [...pointsByDomain.keys()].sort((a, b) => a - b)
+	}
+
+	private indexElements() {
+		const elementsByDomain = new Map<number, SVGGraphicsElement[]>()
+		this.parent
+			.selectAll<SVGGraphicsElement, ChartTabularData[number]>('[role=graphics-symbol]')
+			.each((d, i, nodes) => {
+				const domainValue = this.services.cartesianScales.getDomainValue(d) as number
+				const elements = elementsByDomain.get(domainValue)
+				if (elements) {
+					elements.push(nodes[i])
+				} else {
+					elementsByDomain.set(domainValue, [nodes[i]])
+				}
+			})
+		this.elementsByDomain = elementsByDomain
 	}
 
 	/**
@@ -204,36 +190,24 @@ export class Ruler extends Component {
 	 */
 	addBackdropEventListeners() {
 		this.isEventListenerAdded = true
-
-		const self = this
-
-		const holder = this.services.domUtils.getHolder()
-
-		const displayData = this.model.getDisplayData()
-
-		let mouseMoveCallback = function (event: CustomEvent) {
-			const pos = pointer(event, self.parent.node())
-
-			self.showRuler(event, pos)
-		}
-
-		// Debounce mouseMoveCallback if there are more than 100 datapoints
-		if (displayData.length > 100) {
-			const debounceThreshold = (displayData.length % 50) * 12.5
-
-			mouseMoveCallback = debounceWithD3MousePosition(
-				function (event: CustomEvent) {
-					const { mousePosition } = this
-					self.showRuler(event, mousePosition)
-				},
-				debounceThreshold,
-				holder
-			)
-		}
-
 		this.backdrop
-			.on('mousemove mouseover', mouseMoveCallback)
-			.on('mouseout', this.hideRuler.bind(this))
+			.on('mousemove mouseover', (event: CustomEvent) => {
+				this.rulerEvent = event
+				this.rulerPosition = pointer(event, this.parent.node())
+				if (this.frame === undefined) {
+					this.frame = requestAnimationFrame(() => {
+						this.frame = undefined
+						this.showRuler(this.rulerEvent, this.rulerPosition)
+					})
+				}
+			})
+			.on('mouseout', () => {
+				if (this.frame !== undefined) {
+					cancelAnimationFrame(this.frame)
+					this.frame = undefined
+				}
+				this.hideRuler()
+			})
 	}
 
 	drawBackdrop() {


### PR DESCRIPTION
Fixes #1107

### Updates

- Remove the data-count debounce from the ruler.
- Index data and chart symbols once per render.
- Process the latest pointer position once per animation frame.
- Add ruler tests.

### Checks

- `yarn workspace @carbon/charts test --run src/components/axes/ruler.spec.ts`
- `yarn workspace @carbon/charts build`
- Changed-file ESLint: no errors
- 8,991 symbols, 50 moves: about 3.5 s to 64 ms
