### PR TITLE
fix(toolbar): move control ARIA onto the button, resolving nested-interactive

### DIFF
--- a/packages/core/src/components/axes/toolbar.ts
+++ b/packages/core/src/components/axes/toolbar.ts
@@ -83,9 +83,6 @@ export class Toolbar extends Component {
 			enteringToolbarControls
 				.merge(toolbarControls as any)
 				.classed('disabled', (d: any) => d.shouldBeDisabled())
-				.attr('role', 'button')
-				.attr('aria-disabled', (d: any) => d.shouldBeDisabled())
-				.attr('aria-label', (d: any) => d.title)
 				.html((d: any) => {
 					return `
 			<button
@@ -93,7 +90,7 @@ export class Toolbar extends Component {
 				class="cds--overflow-menu__trigger cds--overflow-menu__trigger"
 				aria-haspopup="true" aria-expanded="false" id="${this.services.domUtils.generateElementIDString(
 					`control-${sanitizeText(d.id)}`
-				)}" aria-label="${sanitizeText(d.title)}">
+				)}" aria-disabled="${d.shouldBeDisabled()}" aria-label="${sanitizeText(d.title)}">
 				<svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" class="cds--overflow-menu__icon cds--overflow-menu__icon" viewBox="0 0 32 32" aria-hidden="true">
 					${sanitizeSVG(d.iconSVG.content)}
 				</svg>


### PR DESCRIPTION
Closes #2130 

### Updates

- Fixes the `nested-interactive` violation on chart toolbar controls
- Removes `role="button"`, `aria-label` and `aria-disabled` from the `.toolbar-control` wrapper `<div>`
- Adds `aria-disabled` onto the inner `<button>`

### Demo screenshot or recording
**Before change** (note the nested button roles in the accessibility tree):
<img width="1025" height="881" alt="Screenshot 2026-08-19 at 15 50 29" src="https://github.com/user-attachments/assets/a82debf0-6489-452a-9371-f547926a5338" />

**After change** (no visual change, mouse and keyboard interactivity as before):
<img width="1032" height="875" alt="Screenshot 2026-08-19 at 15 49 53" src="https://github.com/user-attachments/assets/831324a5-90b5-4b5b-8873-e7effd3116ba" />
