### PR TITLE
fix: address security vulnerabilities in dompurify, postcss, and nanoid

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
 	},
 	"packageManager": "yarn@4.9.2",
 	"resolutions": {
-		"postcss": "^8.5.10",
+		"postcss": "^8.5.19",
+		"nanoid": "^3.3.12",
 		"react-router": "^7.18.0"
 	},
 	"devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -81,7 +81,7 @@
 		"d3-cloud": "^1.2.7",
 		"d3-sankey": "^0.12.3",
 		"date-fns": "^4.1.0",
-		"dompurify": "^3.4.12",
+		"dompurify": "^3.4.14",
 		"html-to-image": "1.11.11",
 		"lodash-es": "^4.18.0",
 		"topojson-client": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -921,7 +921,7 @@ __metadata:
     d3-cloud: "npm:^1.2.7"
     d3-sankey: "npm:^0.12.3"
     date-fns: "npm:^4.1.0"
-    dompurify: "npm:^3.4.12"
+    dompurify: "npm:^3.4.14"
     downlevel-dts: "npm:^0.11.0"
     eslint: "npm:^9.32.0"
     html-to-image: "npm:1.11.11"
@@ -7643,15 +7643,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:^3.4.12":
-  version: 3.4.12
-  resolution: "dompurify@npm:3.4.12"
+"dompurify@npm:^3.4.14":
+  version: 3.4.14
+  resolution: "dompurify@npm:3.4.14"
   dependencies:
     "@types/trusted-types": "npm:^2.0.7"
   dependenciesMeta:
     "@types/trusted-types":
       optional: true
-  checksum: 10c0/127a13817353d4e20e75a991a9022a04c3af12af7479f68e2b8bee6dbc7330a96edfb8f4ebff96f4f0f24cd43e8dbba46214131f510c3aa87a843bd8b610d0ab
+  checksum: 10c0/feca07ece3805d1d4e33e847c11196888dcdc97b2afe0bb8a2fd11de4e62bfdc434c2403ee3fb3c7771e903325041d062febec6c5518796391fdc0419a90a873
   languageName: node
   linkType: hard
 
@@ -11791,12 +11791,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.11":
-  version: 3.3.11
-  resolution: "nanoid@npm:3.3.11"
+"nanoid@npm:^3.3.12":
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/40e7f70b3d15f725ca072dfc4f74e81fcf1fbb02e491cf58ac0c79093adc9b0a73b152bcde57df4b79cd097e13023d7504acb38404a4da7bc1cd8e887b82fe0b
+  checksum: 10c0/b994b4e396730f8be2520923284e2040d61eaee55cc6d4935ef6d38d34bafdc46133eda4d3faea5073bda545aa6079d82b886caeac5c731cf9ac18bcc1301425
   languageName: node
   linkType: hard
 
@@ -13206,14 +13206,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.5.10":
-  version: 8.5.14
-  resolution: "postcss@npm:8.5.14"
+"postcss@npm:^8.5.19":
+  version: 8.5.28
+  resolution: "postcss@npm:8.5.28"
   dependencies:
-    nanoid: "npm:^3.3.11"
+    nanoid: "npm:^3.3.18"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10c0/48138207cf5ef5581be1bfe2cb65ccfe0ac75e43888ba045afc8ed6043d7b56aeb3b9a9fe5b353ff554be943cd0cc15d826ccb991525159175971e5ee8ab0237
+  checksum: 10c0/9fe44215a6628d89c8a75184b92f5b2f77e16f9e5b13b39b9009bb7e8e6eccddf82c8854bae922db1f17ace6ef3445073fe38abff513caeb03e5285b1b55620a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Summary

Addresses the security vulnerabilities reported in issues #2132 and #2133.

### Changes

**`packages/core/package.json`**
- Bumped `dompurify` from `^3.4.12` → `^3.4.14` to address CVE-2026-75838 (XSS via IN_PLACE sanitization in DOMPurify < 3.4.13)

**`package.json` (root resolutions)**
- Bumped `postcss` resolution from `^8.5.10` → `^8.5.19` to address CVE-2026-73646 (source map path traversal, fixed in 8.5.18) and CVE-2026-69153 (unintended source-map file read, fixed in 8.5.19). Lockfile resolves to `8.5.28`.
- Added `nanoid` resolution `^3.3.12` to address CVE-2026-73086 (CSPRNG pool corruption), CVE-2026-67213 (infinite loop on size=0), and CVE-2026-67214 (infinite loop on negative size). Lockfile resolves to `3.3.18`.

### Vulnerabilities addressed

| CVE | Package | Severity | Fix |
|-----|---------|----------|-----|
| CVE-2026-75838 | `dompurify` | Medium (5.4) | Bumped direct dep to `^3.4.14` |
| CVE-2026-73646 | `postcss` (transitive via `styled-components`) | High (7.5) | Root resolution `^8.5.19` |
| CVE-2026-69153 | `postcss` (transitive via `styled-components`) | Medium (5.3) | Root resolution `^8.5.19` |
| CVE-2026-73086 | `nanoid` (transitive via `postcss`) | High (7.4) | Root resolution `^3.3.12` |
| CVE-2026-67214 | `nanoid` (transitive via `postcss`) | Medium (5.9) | Root resolution `^3.3.12` |
| CVE-2026-67213 | `nanoid` (transitive via `postcss`) | Medium (5.9) | Root resolution `^3.3.12` |

Closes #2132
Closes #2133